### PR TITLE
feat(agentic-v2): C2 booted a real guest under the jailer, and the seven attacks that judge it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,6 +183,11 @@ tasks/0822_saturday/*
 !tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md
 !tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
 !tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
+# The two stage-C artefacts, unedited. They are what the host wrote, and the
+# prose in the task document is a reading of them -- a reading nobody can check
+# if the thing being read is only on a VM that gets deallocated.
+!tasks/0822_saturday/c2_first_boot.json
+!tasks/0822_saturday/c3_attacks.json
 !tasks/0828_friday/
 tasks/0828_friday/*
 !tasks/0828_friday/TASK_PER_TASK_COST_RECEIPTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,13 @@ batch-runner/scripts/*
 # tests/test_run_agentic_stage_a_probe.py.
 !batch-runner/scripts/run_agentic_stage_a_probe.py
 
+# Stage C2's boot. Committed for the same reason as the probe above and one
+# more: it cannot run here at all. This box's kernel is 3.10 and will not boot a
+# Firecracker machine, so the only place this executes is the host stage B
+# measured, which reaches the repository by cloning it. A checkout is how it
+# gets there.
+!batch-runner/scripts/run_agentic_c2_first_boot.py
+
 
 # Experiment report HTML (skews GitHub language stats)
 batch-runner/results/*/report/report.html
@@ -507,3 +514,8 @@ data/gdpval-local/
 .history/
 tasks/*/render_probe/
 batch-runner/data/
+
+# Written afresh by infra/dev-host/deploy.sh on every deploy. The values it
+# carries belong in the dated artefact that cites them, not in a tracked file
+# that changes under the record pointing at it.
+infra/dev-host/last-deployment.json

--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,10 @@ batch-runner/scripts/*
 # gets there.
 !batch-runner/scripts/run_agentic_c2_first_boot.py
 
+# Stage C3's attacks. Same reason again: it needs a machine that boots, which
+# this box is not, so the host gets it by cloning the repository.
+!batch-runner/scripts/run_agentic_c3_attacks.py
+
 
 # Experiment report HTML (skews GitHub language stats)
 batch-runner/results/*/report/report.html

--- a/batch-runner/core/agentic_v2_containment_attacks.py
+++ b/batch-runner/core/agentic_v2_containment_attacks.py
@@ -102,12 +102,45 @@ echo "$outcome" | tail -3
 
 _ALLOCATE_PAST_THE_BOUND = r"""
 grep MemTotal /proc/meminfo
-mkdir -p /dev/shm 2>/dev/null
-mount -t tmpfs -o size={tmpfs_mib}m tmpfs /dev/shm 2>/dev/null || echo "tmpfs_mount=failed"
-outcome=$(dd if=/dev/zero of=/dev/shm/gdpval-balloon bs=1M count={overshoot} 2>&1; echo "rc=$?")
-rm -f /dev/shm/gdpval-balloon 2>/dev/null
-umount /dev/shm 2>/dev/null
-echo "$outcome" | tail -3
+
+# Two things about the shape of this attack, both learned from a run where the
+# bound held and the attack reported nothing, which reads as a failure.
+#
+# The allocation has to be charged to the process making it. tmpfs pages are
+# shmem and count against no process's RSS, so when the machine filled, the
+# kernel's OOM killer found nothing large to pick and took a bystander. And the
+# reporter cannot be a child: `rc=$?` inside a command substitution runs in a
+# fork, and that fork was the bystander it took. The attack destroyed its own
+# evidence.
+#
+# So: anonymous memory, touched a page at a time, which makes the allocator the
+# largest thing in the machine and the unambiguous target; and the report is
+# made by the top-level shell, which allocates nothing and is never picked.
+cat > /work/gdpval-allocate.py <<'PY'
+import sys
+
+step = 64 * 1024 * 1024
+target = {overshoot} * 1024 * 1024
+held = []
+allocated = 0
+while allocated < target:
+    # bytearray(n) is calloc, and calloc over a fresh mapping is a promise of
+    # zeroes rather than pages. Untouched it would allocate address space and
+    # never reach the bound at all.
+    block = bytearray(step)
+    for offset in range(0, step, 4096):
+        block[offset] = 1
+    held.append(block)
+    allocated += step
+    sys.stdout.write("allocated_mib=%d\n" % (allocated // (1024 * 1024)))
+    sys.stdout.flush()
+sys.stdout.write("ALLOCATED_ALL\n")
+PY
+python3 /work/gdpval-allocate.py &
+allocator=$!
+wait "$allocator"
+echo "rc=$?"
+rm -f /work/gdpval-allocate.py
 """
 
 _HANG_FOREVER = """
@@ -130,9 +163,7 @@ def guest_commands(policy: Mapping[str, Any] = REQUIRED_MICROVM_POLICY) -> dict[
         BOOT_WORKDIR: _FILL_THE_WORK_DISK.format(
             quota=quota, overshoot=quota * 2
         ),
-        BOOT_MEMORY: _ALLOCATE_PAST_THE_BOUND.format(
-            tmpfs_mib=memory * 2, overshoot=int(memory * 1.5)
-        ),
+        BOOT_MEMORY: _ALLOCATE_PAST_THE_BOUND.format(overshoot=int(memory * 1.5)),
         BOOT_WALL_CLOCK: _HANG_FOREVER,
     }
 
@@ -202,16 +233,27 @@ def _memory_bound(evidence: Mapping[str, Any]) -> tuple[bool, str]:
             f"the guest sees {total_kib // 1024} MiB, which is more than the "
             f"{allowed_mib} MiB the rule allows"
         )
-    if "rc=0" in output:
+    reached = _high_water_mib(output)
+    if reached is not None and reached > allowed_mib:
+        # Every one of those pages was written to, and a guest with no swap
+        # cannot reclaim anonymous memory it has touched. Getting past the
+        # number is the escape whatever the process's exit status ends up being.
+        return False, (
+            f"the guest held {reached} MiB of touched anonymous memory, past the "
+            f"{allowed_mib} MiB the rule allows"
+        )
+    if "rc=0" in output or "ALLOCATED_ALL" in output:
         return False, (
             f"an allocation of {int(allowed_mib * 1.5)} MiB succeeded inside a "
             f"machine bounded to {allowed_mib} MiB"
         )
     if "rc=" not in output:
         return False, "the allocation probe did not report, so it did not run"
+    got_to = f", having reached {reached} MiB" if reached is not None else ""
     return True, (
         f"the guest sees {total_kib // 1024} MiB against a {allowed_mib} MiB "
-        f"bound and the over-allocation failed: {_line_with(output, 'rc=')}"
+        f"bound and the over-allocation was stopped{got_to}: "
+        f"{_line_with(output, 'rc=')}"
     )
 
 
@@ -346,6 +388,22 @@ def _mem_total_kib(output: str) -> int | None:
         if part.isdigit():
             return int(part)
     return None
+
+
+def _high_water_mib(output: str) -> int | None:
+    """The most the allocator was holding, as it last reported it.
+
+    Printed as it goes rather than at the end, because the end is exactly what a
+    process the kernel decided to kill does not get to reach. It is also the
+    only number that says how far the guest got, as opposed to merely that
+    something stopped it.
+    """
+    marks = [
+        int(line.split("=", 1)[1])
+        for line in output.splitlines()
+        if line.startswith("allocated_mib=") and line.split("=", 1)[1].isdigit()
+    ]
+    return max(marks) if marks else None
 
 
 ATTACKS: tuple[dict[str, Any], ...] = (

--- a/batch-runner/core/agentic_v2_containment_attacks.py
+++ b/batch-runner/core/agentic_v2_containment_attacks.py
@@ -1,0 +1,463 @@
+"""The seven attacks, and what each one has to produce to count as stopped.
+
+Stage C1 turned the policy into arguments. C2 showed a guest boots under them.
+Neither shows that the arguments have the effect their names suggest, and the
+gap between those two things is the whole reason this stage exists: a rule that
+reads as enforced and is not is worse than a rule nobody wrote down, because the
+report says it is covered.
+
+**Absent evidence is never a pass.** Every verdict in this module starts at
+"not stopped" and has to be argued into "stopped" by something that was actually
+read back. A probe that did not run, a guest that died before it got there, a
+file that came back empty — all of those are failures of the attack, recorded as
+such. The alternative, treating silence as success, would turn a guest that
+crashed on boot into a clean sweep of all seven.
+
+**Two of the seven are not observed inside the guest, and cannot be.**
+``user: jailer-unprivileged`` is a statement about the Firecracker process on
+the host, not about the guest's own uid — inside the machine PID 1 is root and
+is supposed to be. ``credentials: none-inherited`` is the same: what matters is
+what the host-side process carries, in its environment *and* in its open
+descriptors. Both are read from ``/proc/<pid>`` while the machine is alive,
+which is why the runner needs a way to look at a machine mid-flight rather than
+only at what it left behind.
+
+**The attacks are grouped into separate boots on purpose.** Filling the work
+disk destroys the only channel the guest has to answer on; provoking the memory
+bound can take the guest down with it. Running those beside the quiet probes
+would let one attack's success erase another's evidence, and the erased one
+would read as "no evidence", which is a failure. So the destructive ones get
+their own machines.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping
+
+from core.agentic_v2_substrate import REQUIRED_MICROVM_POLICY
+
+BOOT_PROBES = "probes"
+BOOT_WORKDIR = "workdir-quota"
+BOOT_MEMORY = "memory"
+BOOT_WALL_CLOCK = "wall-clock"
+
+_MIB = 1024 * 1024
+
+
+class AttackRefused(RuntimeError):
+    """An attack could not be judged, which is not the same as it being stopped."""
+
+
+# --------------------------------------------------------------------------
+# what each attack runs inside the guest
+# --------------------------------------------------------------------------
+
+_QUIET_PROBES = r"""
+echo "== network =="
+cat /proc/net/dev 2>/dev/null | awk 'NR>2 {print $1}' | tr -d ':'
+python3 - <<'PY' 2>&1 || echo "connect_probe=no-python"
+import socket
+try:
+    socket.create_connection(("1.1.1.1", 443), 5).close()
+    print("connect_probe=CONNECTED")
+except OSError as failure:
+    print("connect_probe=refused:%s" % failure.__class__.__name__)
+PY
+
+echo "== rootfs =="
+grep ' / ' /proc/mounts
+if echo probe > /gdpval-root-write-probe 2>/dev/null; then
+  echo "rootfs_write=SUCCEEDED"
+  rm -f /gdpval-root-write-probe
+else
+  echo "rootfs_write=refused"
+fi
+
+echo "== memory bound =="
+grep MemTotal /proc/meminfo
+
+echo "== credentials =="
+echo "env_count=$(env | wc -l)"
+env | grep -Ei 'KEY|TOKEN|SECRET|PASSWORD|AZURE|OPENAI|ANTHROPIC|GITHUB' \
+  && echo "guest_env=CARRIES SOMETHING" || echo "guest_env=clean"
+echo "self_environ_bytes=$(wc -c < /proc/1/environ 2>/dev/null || echo unknown)"
+
+# Two of the seven are facts about the host-side process rather than about
+# anything in here, and they can only be read while it is alive. C2's guest
+# was gone 1.269 seconds after the jailer started it, which is not reliably
+# long enough for a watcher to land a /proc read. This holds the machine open
+# and weakens nothing: the deadline still applies, and a guest that hangs past
+# it is attack 3.
+echo "holding_open=8s"
+sleep 8
+"""
+
+_FILL_THE_WORK_DISK = r"""
+echo "quota_mib_configured={quota}"
+outcome=$(dd if=/dev/zero of=/work/gdpval-filler bs=1M count={overshoot} 2>&1; echo "rc=$?")
+rm -f /work/gdpval-filler
+sync
+echo "$outcome" | tail -3
+"""
+
+_ALLOCATE_PAST_THE_BOUND = r"""
+grep MemTotal /proc/meminfo
+mkdir -p /dev/shm 2>/dev/null
+mount -t tmpfs -o size={tmpfs_mib}m tmpfs /dev/shm 2>/dev/null || echo "tmpfs_mount=failed"
+outcome=$(dd if=/dev/zero of=/dev/shm/gdpval-balloon bs=1M count={overshoot} 2>&1; echo "rc=$?")
+rm -f /dev/shm/gdpval-balloon 2>/dev/null
+umount /dev/shm 2>/dev/null
+echo "$outcome" | tail -3
+"""
+
+_HANG_FOREVER = """
+echo 'about to hang on purpose'
+while true; do sleep 5; done
+"""
+
+
+def guest_commands(policy: Mapping[str, Any] = REQUIRED_MICROVM_POLICY) -> dict[str, str]:
+    """The script each boot runs, with the overshoot sized from the rule itself.
+
+    Taken from the policy rather than written as a number, so that raising a
+    bound cannot silently leave an attack probing below it — which would be an
+    attack that passes because it never reached the limit.
+    """
+    quota = int(policy["workdir_quota_mib"])
+    memory = int(policy["memory_mib"])
+    return {
+        BOOT_PROBES: _QUIET_PROBES,
+        BOOT_WORKDIR: _FILL_THE_WORK_DISK.format(
+            quota=quota, overshoot=quota * 2
+        ),
+        BOOT_MEMORY: _ALLOCATE_PAST_THE_BOUND.format(
+            tmpfs_mib=memory * 2, overshoot=int(memory * 1.5)
+        ),
+        BOOT_WALL_CLOCK: _HANG_FOREVER,
+    }
+
+
+# --------------------------------------------------------------------------
+# how each attack is judged
+# --------------------------------------------------------------------------
+
+
+def _stdout(evidence: Mapping[str, Any], boot: str) -> str | None:
+    boot_result = (evidence.get("boots") or {}).get(boot)
+    if not isinstance(boot_result, Mapping):
+        return None
+    return ((boot_result.get("results") or {}).get("/out/stdout")) or None
+
+
+def _network(evidence: Mapping[str, Any]) -> tuple[bool, str]:
+    output = _stdout(evidence, BOOT_PROBES)
+    if output is None:
+        return False, "the probe guest returned nothing, so nothing was observed"
+    if "connect_probe=CONNECTED" in output:
+        return False, "the guest opened a connection to 1.1.1.1:443"
+    interfaces = {
+        line.strip()
+        for line in output.splitlines()
+        if line.strip() and not line.startswith(("=", " "))
+        and line.strip() in {"lo", "eth0", "ens3", "tap0"}
+    }
+    beyond_loopback = interfaces - {"lo"}
+    if beyond_loopback:
+        return False, f"the guest has interfaces beyond loopback: {sorted(beyond_loopback)}"
+    if "connect_probe=" not in output:
+        return False, "the connection probe did not report, so it did not run"
+    return True, (
+        "no interface but loopback in /proc/net/dev and the connection attempt "
+        f"failed: {_line_with(output, 'connect_probe=')}"
+    )
+
+
+def _read_only_root(evidence: Mapping[str, Any]) -> tuple[bool, str]:
+    output = _stdout(evidence, BOOT_PROBES)
+    if output is None:
+        return False, "the probe guest returned nothing, so nothing was observed"
+    if "rootfs_write=SUCCEEDED" in output:
+        return False, "a write to / succeeded inside the guest"
+    if "rootfs_write=refused" not in output:
+        return False, "the write probe did not report, so it did not run"
+    mount_line = _line_with(output, " / ")
+    if mount_line and " ro," not in mount_line and not mount_line.endswith(" ro"):
+        # The mount table is the second half of the same rule. A guest that
+        # could not write because of a permission bit, on a root the kernel
+        # mounted read-write, is one remount away from writing.
+        return False, f"the write failed but / is not mounted read-only: {mount_line}"
+    return True, f"the write was refused and / is mounted read-only: {mount_line}"
+
+
+def _memory_bound(evidence: Mapping[str, Any]) -> tuple[bool, str]:
+    output = _stdout(evidence, BOOT_MEMORY)
+    if output is None:
+        return False, "the memory guest returned nothing, so nothing was observed"
+    total_kib = _mem_total_kib(output)
+    if total_kib is None:
+        return False, "MemTotal did not come back, so the bound was not observed"
+    allowed_mib = int(REQUIRED_MICROVM_POLICY["memory_mib"])
+    if total_kib // 1024 > allowed_mib:
+        return False, (
+            f"the guest sees {total_kib // 1024} MiB, which is more than the "
+            f"{allowed_mib} MiB the rule allows"
+        )
+    if "rc=0" in output:
+        return False, (
+            f"an allocation of {int(allowed_mib * 1.5)} MiB succeeded inside a "
+            f"machine bounded to {allowed_mib} MiB"
+        )
+    if "rc=" not in output:
+        return False, "the allocation probe did not report, so it did not run"
+    return True, (
+        f"the guest sees {total_kib // 1024} MiB against a {allowed_mib} MiB "
+        f"bound and the over-allocation failed: {_line_with(output, 'rc=')}"
+    )
+
+
+def _workdir_quota(evidence: Mapping[str, Any]) -> tuple[bool, str]:
+    output = _stdout(evidence, BOOT_WORKDIR)
+    if output is None:
+        return False, "the quota guest returned nothing, so nothing was observed"
+    if "rc=0" in output:
+        quota = REQUIRED_MICROVM_POLICY["workdir_quota_mib"]
+        return False, f"writing {int(quota) * 2} MiB into a {quota} MiB disk succeeded"
+    if "rc=" not in output:
+        return False, "the fill probe did not report, so it did not run"
+    return True, (
+        "the write past the quota failed: " + (_line_with(output, "rc=") or "")
+    )
+
+
+def _wall_clock(evidence: Mapping[str, Any]) -> tuple[bool, str]:
+    boot = (evidence.get("boots") or {}).get(BOOT_WALL_CLOCK)
+    if not isinstance(boot, Mapping):
+        return False, "the hanging guest was not run, so nothing was observed"
+    if not boot.get("stopped_by_the_deadline"):
+        return False, (
+            f"the guest that hangs on purpose ended as {boot.get('outcome')!r} "
+            "rather than being stopped by the deadline"
+        )
+    if not boot.get("teardown", {}).get("all_gone"):
+        return False, "the deadline fired but the machine's chroot survived it"
+    return True, (
+        f"the guest hung and was stopped after {boot.get('ran_for_seconds')}s "
+        f"against a {boot.get('deadline_seconds')}s bound, and its chroot is gone"
+    )
+
+
+def _unprivileged_host_process(evidence: Mapping[str, Any]) -> tuple[bool, str]:
+    """Read from the host, because the guest cannot see the thing being ruled on.
+
+    Inside the machine PID 1 is root and is meant to be. The rule is about the
+    Firecracker process the jailer left running on the host after it dropped
+    privilege, and a test that looked for an unprivileged uid inside the guest
+    would pass on a launcher that had never dropped anything.
+    """
+    watch = _host_watch(evidence)
+    if watch is None:
+        return False, "the host-side process was not looked at while it ran"
+    uid = watch.get("real_uid")
+    if uid is None:
+        return False, "the process's uid did not come back, so it was not observed"
+    if int(uid) == 0:
+        return False, "the Firecracker process is still running as root on the host"
+    expected = watch.get("expected_uid")
+    if expected is not None and int(uid) != int(expected):
+        return False, f"the process runs as uid {uid}, not the jail account's {expected}"
+    groups = watch.get("supplementary_groups") or []
+    if groups:
+        return False, f"the process carries supplementary groups {groups}"
+    return True, (
+        f"the host-side Firecracker process runs as uid {uid} with no "
+        "supplementary groups"
+    )
+
+
+def _no_credentials_inherited(evidence: Mapping[str, Any]) -> tuple[bool, str]:
+    """Both halves. The jailer covers them differently and only one is unconditional.
+
+    The environment is wiped whatever else is passed. The three standard
+    descriptors are redirected by ``--daemonize`` and by nothing else, so an
+    attack that checked the environment alone would pass on a launcher that had
+    quietly dropped that flag — which is exactly the regression this is for.
+    """
+    watch = _host_watch(evidence)
+    if watch is None:
+        return False, "the host-side process was not looked at while it ran"
+    if watch.get("environment_seen") is None:
+        return False, "the process's environment did not come back"
+    leaked = watch.get("canaries_in_environment") or []
+    if leaked:
+        return False, f"the process's environment carries {leaked}"
+    descriptors = watch.get("descriptors")
+    if descriptors is None:
+        return False, (
+            "the process's open descriptors did not come back, and the "
+            "environment alone is not the rule"
+        )
+    pointing_out = watch.get("descriptors_reaching_the_orchestrator") or []
+    if pointing_out:
+        return False, f"descriptors still reach the orchestrator: {pointing_out}"
+    standard = watch.get("standard_descriptors") or {}
+    not_closed = {
+        fd: target
+        for fd, target in standard.items()
+        if target is not None and target != "/dev/null"
+    }
+    if not_closed:
+        return False, (
+            f"the standard descriptors are not all /dev/null: {not_closed}. "
+            "--daemonize is the only thing that redirects them, and without it "
+            "the guest's console is whatever the orchestrator was writing to"
+        )
+    guest = _stdout(evidence, BOOT_PROBES)
+    if guest is None:
+        return False, "the guest half of the probe returned nothing"
+    if "guest_env=CARRIES SOMETHING" in guest:
+        return False, "the guest's own environment carries a credential-shaped name"
+    return True, (
+        f"the host process's environment holds {watch.get('environment_seen')} "
+        f"entries with none of the canaries, its {len(descriptors)} descriptors "
+        "reach nothing of the orchestrator's, all three standard ones are "
+        "/dev/null, and the guest's environment is clean"
+    )
+
+
+def _host_watch(evidence: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    for boot in (evidence.get("boots") or {}).values():
+        if isinstance(boot, Mapping) and isinstance(boot.get("watched"), Mapping):
+            return boot["watched"]
+    return None
+
+
+def _line_with(output: str, needle: str) -> str | None:
+    for line in output.splitlines():
+        if needle in line:
+            return line.strip()
+    return None
+
+
+def _mem_total_kib(output: str) -> int | None:
+    line = _line_with(output, "MemTotal")
+    if not line:
+        return None
+    for part in line.split():
+        if part.isdigit():
+            return int(part)
+    return None
+
+
+ATTACKS: tuple[dict[str, Any], ...] = (
+    {
+        "number": 1,
+        "id": "workdir-quota",
+        "rule": "workdir_quota_mib",
+        "boot": BOOT_WORKDIR,
+        "observed": "guest",
+        "what_it_tries": "write twice the quota into the ephemeral work disk",
+        "judge": _workdir_quota,
+    },
+    {
+        "number": 2,
+        "id": "memory",
+        "rule": "memory_mib",
+        "boot": BOOT_MEMORY,
+        "observed": "guest",
+        "what_it_tries": "allocate half again the memory bound inside the guest",
+        "judge": _memory_bound,
+    },
+    {
+        "number": 3,
+        "id": "wall-clock",
+        "rule": "wall_clock_seconds",
+        "boot": BOOT_WALL_CLOCK,
+        "observed": "host",
+        "what_it_tries": "never finish",
+        "judge": _wall_clock,
+    },
+    {
+        "number": 4,
+        "id": "network",
+        "rule": "network",
+        "boot": BOOT_PROBES,
+        "observed": "guest",
+        "what_it_tries": "find an interface and open a connection through it",
+        "judge": _network,
+    },
+    {
+        "number": 5,
+        "id": "read-only-root",
+        "rule": "rootfs",
+        "boot": BOOT_PROBES,
+        "observed": "guest",
+        "what_it_tries": "write a file into the root filesystem",
+        "judge": _read_only_root,
+    },
+    {
+        "number": 6,
+        "id": "privileged-user",
+        "rule": "user",
+        "boot": BOOT_PROBES,
+        "observed": "host",
+        "what_it_tries": (
+            "be a host-side process that kept root, which the guest cannot see "
+            "and so cannot be asked about"
+        ),
+        "judge": _unprivileged_host_process,
+    },
+    {
+        "number": 7,
+        "id": "inherited-credentials",
+        "rule": "credentials",
+        "boot": BOOT_PROBES,
+        "observed": "host and guest",
+        "what_it_tries": (
+            "reach a token the orchestrator holds, through the environment and "
+            "through an inherited descriptor"
+        ),
+        "judge": _no_credentials_inherited,
+    },
+)
+
+
+def judge_all(evidence: Mapping[str, Any]) -> dict[str, Any]:
+    """Turn what was collected into seven verdicts and one overall answer.
+
+    Seven passes is the condition. Six and a note is a failure, and so is seven
+    verdicts where one of them was reached without evidence — which is why each
+    verdict carries the sentence that argued it rather than only a boolean.
+    """
+    verdicts = []
+    for attack in ATTACKS:
+        judge: Callable[[Mapping[str, Any]], tuple[bool, str]] = attack["judge"]
+        try:
+            stopped, why = judge(evidence)
+        except Exception as failure:  # noqa: BLE001 - an unjudgeable attack failed
+            stopped, why = False, f"the attack could not be judged: {failure!r}"
+        verdicts.append(
+            {
+                "number": attack["number"],
+                "id": attack["id"],
+                "rule_it_enforced": attack["rule"],
+                "rule_value": REQUIRED_MICROVM_POLICY.get(attack["rule"]),
+                "observed": attack["observed"],
+                "what_it_tried": attack["what_it_tries"],
+                "stopped": bool(stopped),
+                "evidence": why,
+            }
+        )
+    stopped_count = sum(1 for verdict in verdicts if verdict["stopped"])
+    return {
+        "schema_version": "1.0",
+        "verdicts": verdicts,
+        "stopped": stopped_count,
+        "attempted": len(ATTACKS),
+        "all_seven_stopped": stopped_count == len(ATTACKS),
+        "escapes": [v["id"] for v in verdicts if not v["stopped"]],
+        "how_absent_evidence_is_treated": (
+            "as a failure of that attack. A probe that did not run and a rule "
+            "that did not hold leave the same silence, and calling silence a "
+            "pass would let a guest that never booted sweep all seven."
+        ),
+    }

--- a/batch-runner/core/agentic_v2_first_boot.py
+++ b/batch-runner/core/agentic_v2_first_boot.py
@@ -40,7 +40,11 @@ import time
 from pathlib import Path
 from typing import Any, Callable, Mapping
 
-from core.agentic_v2_guest_image import files_out_of_work_disk, sha256_file
+from core.agentic_v2_guest_image import (
+    GUEST_INIT_PATH,
+    files_out_of_work_disk,
+    sha256_file,
+)
 from core.agentic_v2_substrate import canonical_sha256
 
 WORK_DISK_INPUT = "/in/command.sh"
@@ -290,7 +294,10 @@ def unjailed_image_check(
     config = {
         "boot-source": {
             "kernel_image_path": Path(kernel).as_posix(),
-            "boot_args": "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda ro",
+            "boot_args": (
+                "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda ro "
+                f"init={GUEST_INIT_PATH}"
+            ),
         },
         "drives": [
             {

--- a/batch-runner/core/agentic_v2_first_boot.py
+++ b/batch-runner/core/agentic_v2_first_boot.py
@@ -1,0 +1,334 @@
+"""Start what C1 wrote down, once, and take the result back off the work disk.
+
+C1 turns :data:`REQUIRED_MICROVM_POLICY` into a document and starts nothing.
+That was deliberate — the mapping can be checked anywhere, including on a
+machine that cannot boot a virtual machine at all, and this box runs kernel 3.10
+and cannot. This module is the other half, and it runs only where stage B
+measured: it takes that document and does exactly what it says.
+
+**It adds no argument of its own.** Everything it runs comes out of the plan:
+``jailer.argv``, ``firecracker.config``, ``place_in_jail``, and the three
+host-side facts under ``host_side``. If a rule is to be applied differently, the
+change belongs in C1's builder where the refusals are, not here. That is why
+:func:`first_boot` refuses a plan whose ``plan_sha256`` does not match its
+contents — a plan edited between being built and being run is a set of arguments
+nobody checked.
+
+**Where the result comes from, and why there is only one place.** The policy
+forbids a network, and the launcher pins ``vsock`` absent for the same reason.
+``--daemonize`` points Firecracker's standard descriptors at ``/dev/null``, so
+there is no console either. The work disk is the whole channel: the command goes
+in at ``/in/command.sh`` and the answer comes back at ``/out/…``. It is read
+with ``debugfs``, which walks the image without mounting it — no loop device, no
+privilege, and the host kernel's ext4 driver never sees a filesystem the guest
+was writing.
+
+**What this is not.** Booting a guest and getting one command's output back is
+not ``exec_run``, is not a model call, and is not a task. Nothing here changes
+``foundation_only`` or ``production_activation``, and nothing here is wired into
+the product path. That is stage D, and it gets its own change.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import signal
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from core.agentic_v2_guest_image import files_out_of_work_disk, sha256_file
+from core.agentic_v2_substrate import canonical_sha256
+
+WORK_DISK_INPUT = "/in/command.sh"
+WORK_DISK_RESULTS = (
+    "/out/stdout",
+    "/out/stderr",
+    "/out/exit_status",
+    "/out/guest_kernel",
+    "/out/guest_uid",
+    "/out/init_reached_the_end",
+)
+
+POLL_SECONDS = 0.25
+PID_FILE_GRACE_SECONDS = 20.0
+"""How long the launcher waits for the jailer to write the PID file.
+
+Not the same thing as the deadline. ``--daemonize`` makes the jailer fork and
+return immediately, so the absence of a PID file for a moment is normal and its
+absence after this long means the machine never started — which is a different
+outcome from a machine that started and overran, and the artefact says which.
+"""
+
+
+class BootRefused(RuntimeError):
+    """The plan was not run, and the reason is not a boot failure."""
+
+
+def _run(argv: list[str], timeout: float = 300.0) -> subprocess.CompletedProcess:
+    return subprocess.run(  # noqa: S603
+        argv, check=False, capture_output=True, text=True, timeout=timeout
+    )
+
+
+def _still_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def place_the_images(
+    plan: Mapping[str, Any],
+    *,
+    kernel: str | Path,
+    rootfs: str | Path,
+    work_disk: str | Path,
+    uid: int,
+    gid: int,
+) -> dict[str, Any]:
+    """Put each image where ``place_in_jail`` says, with the mode it says.
+
+    The jailer will create this directory itself if it is absent; it is created
+    here because the images have to be inside it before the machine starts and
+    there is no later moment to put them there.
+
+    Ownership follows the plan's ``writable_by_the_jailed_user`` rather than a
+    convention: the two images the guest must not change are ``0444`` and owned
+    by root, and only the work disk is writable by the account the jailer drops
+    to. A rootfs the jailed user can write to would make ``rootfs: read-only``
+    true only for as long as the guest chose to respect it.
+    """
+    chroot_dir = Path(plan["host_side"]["chroot_dir"])
+    chroot_dir.mkdir(parents=True, exist_ok=True)
+    sources = {"/vmlinux": Path(kernel), "/rootfs.ext4": Path(rootfs)}
+    placed = []
+    for item in plan["place_in_jail"]:
+        target = chroot_dir / item["in_jail"].lstrip("/")
+        if item["in_jail"] == "/vmconfig.json":
+            target.write_text(
+                json.dumps(plan["firecracker"]["config"], indent=2), encoding="utf-8"
+            )
+        elif item["how"] == "create-empty":
+            shutil.copy2(work_disk, target)
+        else:
+            shutil.copy2(sources[item["in_jail"]], target)
+        writable = bool(item["writable_by_the_jailed_user"])
+        os.chmod(target, 0o644 if writable else 0o444)
+        os.chown(target, uid if writable else 0, gid if writable else 0)
+        placed.append(
+            {
+                "in_jail": item["in_jail"],
+                "sha256": sha256_file(target),
+                "bytes": target.stat().st_size,
+                "mode": oct(target.stat().st_mode & 0o777),
+                "owned_by_the_jailed_user": writable,
+            }
+        )
+    os.chmod(chroot_dir, 0o755)
+    return {"chroot_dir": chroot_dir.as_posix(), "placed": placed}
+
+
+def first_boot(
+    plan: Mapping[str, Any],
+    *,
+    jailer_binary: str = "jailer",
+    kernel: str | Path,
+    rootfs: str | Path,
+    work_disk: str | Path,
+    uid: int,
+    gid: int,
+    now: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict[str, Any]:
+    """Run one plan through to a result, or to a recorded reason it produced none.
+
+    Returns rather than raises for every outcome that is about the machine —
+    a guest that would not boot, one that overran its deadline, one that booted
+    and wrote nothing. Those are findings. It raises only when the plan itself
+    is unusable, which is not a finding about a machine.
+    """
+    if plan.get("starts_nothing") is not True:
+        raise BootRefused("this is not a launch plan from the C1 builder")
+    stated = plan.get("plan_sha256")
+    recomputed = canonical_sha256({k: v for k, v in plan.items() if k != "plan_sha256"})
+    if stated != recomputed:
+        raise BootRefused(
+            "the plan's contents do not hash to its own plan_sha256, so it was "
+            "changed after it was built and these are arguments nobody checked"
+        )
+
+    host_side = plan["host_side"]
+    pid_file = Path(host_side["pid_file"])
+    deadline_seconds = float(host_side["deadline_seconds"])
+    placement = place_the_images(
+        plan, kernel=kernel, rootfs=rootfs, work_disk=work_disk, uid=uid, gid=gid
+    )
+    chroot_dir = Path(placement["chroot_dir"])
+
+    started_at = now()
+    launch = _run([jailer_binary, *plan["jailer"]["argv"]], timeout=120.0)
+
+    pid: int | None = None
+    while now() - started_at < PID_FILE_GRACE_SECONDS:
+        if pid_file.exists():
+            try:
+                pid = int(pid_file.read_text().strip())
+            except ValueError:
+                pid = None
+            if pid:
+                break
+        sleep(POLL_SECONDS)
+
+    outcome = "booted"
+    stopped_by_the_deadline = False
+    if pid is None:
+        outcome = "never_started"
+    else:
+        while _still_running(pid):
+            if now() - started_at >= deadline_seconds:
+                stopped_by_the_deadline = True
+                outcome = "stopped_by_the_deadline"
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    stopped_by_the_deadline = False
+                    outcome = "booted"
+                break
+            sleep(POLL_SECONDS)
+    ran_for = round(now() - started_at, 3)
+
+    disk_in_jail = chroot_dir / "work.ext4"
+    results: dict[str, str | None] = {}
+    if disk_in_jail.exists():
+        results = files_out_of_work_disk(disk_in_jail, WORK_DISK_RESULTS)
+        shutil.copy2(disk_in_jail, str(work_disk) + ".returned")
+
+    exit_status = None
+    raw_status = (results.get("/out/exit_status") or "").strip()
+    if raw_status.isdigit():
+        exit_status = int(raw_status)
+    if outcome == "booted" and exit_status is None:
+        outcome = "booted_but_wrote_nothing"
+
+    destroyed = _destroy(host_side.get("destroy_after_the_run", []))
+
+    return {
+        "schema_version": "1.0",
+        "outcome": outcome,
+        "vm_id": plan["vm_id"],
+        "plan_sha256": plan["plan_sha256"],
+        "policy_sha256": plan["policy_sha256"],
+        "jailer": {
+            "argv": list(plan["jailer"]["argv"]),
+            "returncode": launch.returncode,
+            "stderr": launch.stderr[-4000:],
+        },
+        "pid_file": {
+            "path": pid_file.as_posix(),
+            "appeared": pid is not None,
+            "pid_recorded": pid is not None,
+        },
+        "ran_for_seconds": ran_for,
+        "deadline_seconds": deadline_seconds,
+        "stopped_by_the_deadline": stopped_by_the_deadline,
+        "command_exit_status": exit_status,
+        "results": results,
+        "placement": placement,
+        "teardown": destroyed,
+        "channel": (
+            "the work disk only: no network by policy, vsock pinned absent, and "
+            "--daemonize sends the console to /dev/null"
+        ),
+    }
+
+
+def _destroy(paths: list[str]) -> dict[str, Any]:
+    """Remove what the plan said to remove, and say whether it is gone.
+
+    Reported rather than assumed. A chroot that survives holds the work disk,
+    which holds whatever the guest wrote, and "destroyed after the run" is part
+    of ``workdir: ephemeral-quota`` rather than tidiness.
+    """
+    gone = {}
+    for path in paths:
+        shutil.rmtree(path, ignore_errors=True)
+        gone[path] = not Path(path).exists()
+    return {"removed": gone, "all_gone": all(gone.values()) if gone else False}
+
+
+def unjailed_image_check(
+    *,
+    firecracker_binary: str,
+    kernel: str | Path,
+    rootfs: str | Path,
+    work_disk: str | Path,
+    workdir: str | Path,
+    seconds: float = 90.0,
+) -> dict[str, Any]:
+    """Boot the same two images with the console attached, outside the jail.
+
+    **This is not the contained run and does not count towards C2's exit
+    condition.** It exists because a jailed boot is nearly silent: with no
+    console and no network, a guest that panics on its second instruction leaves
+    exactly the evidence a guest that booted and wrote nothing leaves. Running
+    the images once with the console readable separates "the images are wrong"
+    from "the jail is wrong", which is the difference between a fixable result
+    and a shrug.
+
+    It applies none of the containment. Every field it returns is labelled with
+    that, and a caller that treats it as the boundary is reading it wrong.
+    """
+    workdir = Path(workdir)
+    workdir.mkdir(parents=True, exist_ok=True)
+    config = {
+        "boot-source": {
+            "kernel_image_path": Path(kernel).as_posix(),
+            "boot_args": "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda ro",
+        },
+        "drives": [
+            {
+                "drive_id": "rootfs",
+                "path_on_host": Path(rootfs).as_posix(),
+                "is_root_device": True,
+                "is_read_only": True,
+            },
+            {
+                "drive_id": "work",
+                "path_on_host": Path(work_disk).as_posix(),
+                "is_root_device": False,
+                "is_read_only": False,
+            },
+        ],
+        "machine-config": {"vcpu_count": 1, "mem_size_mib": 1024},
+        "network-interfaces": [],
+    }
+    config_path = workdir / "unjailed-vmconfig.json"
+    config_path.write_text(json.dumps(config, indent=2), encoding="utf-8")
+    timed_out = False
+    try:
+        finished = _run(
+            [firecracker_binary, "--config-file", config_path.as_posix(), "--no-api"],
+            timeout=seconds,
+        )
+        console, returncode = finished.stdout, finished.returncode
+    except subprocess.TimeoutExpired as expired:
+        timed_out = True
+        console = (expired.stdout or b"").decode("utf-8", "replace") if isinstance(
+            expired.stdout, bytes
+        ) else (expired.stdout or "")
+        returncode = None
+    return {
+        "this_is_not_the_contained_run": True,
+        "what_it_proves": "only that these two images boot; no rule was applied",
+        "applied_containment": False,
+        "timed_out": timed_out,
+        "returncode": returncode,
+        "console_tail": console[-6000:],
+    }

--- a/batch-runner/core/agentic_v2_guest_image.py
+++ b/batch-runner/core/agentic_v2_guest_image.py
@@ -1,0 +1,494 @@
+"""The two images a guest boots from, and where each of them came from.
+
+A Firecracker machine needs a ``vmlinux`` and a root filesystem. Neither is an
+OCI image, so ``security/agentic-v2-supply-chain-policy.json`` — which is
+written for OCI images, asks for ``oci_layout`` as evidence and names a
+``dockerfile`` among its provenance subjects — does not reach either of them as
+written. That is a statement about the shape of the artefacts, not about the
+strength of the policy.
+
+The answer that keeps the chain intact is to build the root filesystem *from*
+the image the policy already governs, so that what boots is what was signed,
+scanned and attested rather than a second filesystem assembled beside it. That
+is what :func:`pull_image_by_digest` and :func:`unpack_layers` do: every blob is
+checked against the digest that named it before a single byte of it is used,
+and the layers are applied in the order the manifest lists them.
+
+**The kernel has no such parent, and this module says so rather than implying
+otherwise.** It comes from Firecracker's own CI bucket, pinned to
+:data:`PINNED_GUEST_KERNEL`. Three things about that source are recorded in the
+data itself, because each of them is the kind of fact that quietly disappears
+when only a hash is written down:
+
+*Upstream publishes no checksum and no signature for these files.* The
+getting-started guide's verification step prints filenames. The bucket's ETag
+for this object is a multipart tag and is not a hash of the content. So the
+digest this module enforces is one **we** computed on download. It proves the
+file did not change between that download and this boot. It does not mean
+anybody vouched for it, and :func:`fetch_pinned_kernel` returns
+``vouched_for_by_upstream: False`` so that no caller can print a hash beside the
+word "verified" and leave a reader to assume a signature was checked.
+
+*The bucket listing that would find this key is fetched over plain ``http``.*
+So the key is pinned here in full rather than discovered, which also stops
+``sort -V | tail -1`` from changing the guest kernel underneath the containment
+tests without anything saying so.
+
+*Its validated support window has already lapsed.* Firecracker's
+``docs/kernel-policy.md`` at v1.13.1 validates two guest kernels; 6.1's minimum
+end-of-support date is 2026-09-02. The other, 5.10, expired in 2024. This is
+recorded as lapsed rather than pinned in silence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tarfile
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+A_MEBIBYTE = 1024 * 1024
+
+PINNED_GUEST_KERNEL: dict[str, Any] = {
+    "url": (
+        "https://s3.amazonaws.com/spec.ccfc.min/"
+        "firecracker-ci/v1.13/x86_64/vmlinux-6.1.141"
+    ),
+    "bucket": "spec.ccfc.min",
+    "key": "firecracker-ci/v1.13/x86_64/vmlinux-6.1.141",
+    "version": "6.1.141",
+    "size_bytes": 41865904,
+    "published": "2025-08-12",
+    "validated_by": "firecracker docs/kernel-policy.md at tag v1.13.1",
+    "minimum_end_of_support": "2026-09-02",
+    "support_window_has_lapsed": True,
+    "upstream_publishes_a_checksum": False,
+    "upstream_publishes_a_signature": False,
+}
+"""One exact object, not the discovery upstream's guide performs.
+
+``size_bytes`` is checked on download. It is a shape check and nothing more —
+a wrong file of the right length would pass it — which is why the digest is
+what gets recorded and enforced afterwards.
+"""
+
+GUEST_INIT_PATH = "/gdpval-init"
+
+GUEST_INIT = """#!/bin/sh
+# PID 1 in the guest. There is no console: the launcher passes --daemonize,
+# which points Firecracker's standard descriptors at /dev/null, so everything
+# this script has to say it says on the work disk.
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+export PATH
+mount -t proc proc /proc 2>/dev/null
+mount -t sysfs sys /sys 2>/dev/null
+mount -t devtmpfs dev /dev 2>/dev/null
+mkdir -p /work
+mount -t ext4 /dev/vdb /work
+mkdir -p /work/out
+uname -r > /work/out/guest_kernel 2>/dev/null
+id -u > /work/out/guest_uid 2>/dev/null
+sh /work/in/command.sh > /work/out/stdout 2> /work/out/stderr
+echo $? > /work/out/exit_status
+echo done > /work/out/init_reached_the_end
+sync
+umount /work 2>/dev/null
+sync
+# Reset through the i8042 controller, which is what boot_args' reboot=k selects
+# and what makes Firecracker exit rather than sit on a halted guest.
+reboot -f 2>/dev/null
+echo b > /proc/sysrq-trigger 2>/dev/null
+while true; do sleep 1; done
+"""
+"""The one file added to the image's own layers, recorded in full in the artefact.
+
+It is deliberately dull. Anything clever here would be a second thing to
+distrust when a boot produces nothing, and a boot producing nothing is the
+failure mode this stage has to be able to tell apart from a boot that worked.
+"""
+
+_MANIFEST_TYPES = (
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+)
+
+_INDEX_TYPES = frozenset(
+    {
+        "application/vnd.oci.image.index.v1+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+    }
+)
+
+
+class ImageRefused(RuntimeError):
+    """An image or kernel was not what its digest said it would be."""
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: str | Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _http_get(url: str, headers: Mapping[str, str] | None = None) -> bytes:
+    request = urllib.request.Request(url, headers=dict(headers or {}))
+    with urllib.request.urlopen(request, timeout=300) as response:  # noqa: S310
+        return response.read()
+
+
+def fetch_pinned_kernel(
+    destination: str | Path,
+    *,
+    fetch: Callable[[str, Mapping[str, str] | None], bytes] = _http_get,
+    pinned: Mapping[str, Any] = PINNED_GUEST_KERNEL,
+) -> dict[str, Any]:
+    """Download the one pinned kernel and describe it, disclaimers included.
+
+    Returns the digest it computed rather than comparing against one, because on
+    a first download there is nothing to compare against — that is the whole
+    content of ``upstream_publishes_a_checksum: False``. A caller that has a
+    previous digest should compare, and :func:`require_same_kernel` is how.
+    """
+    destination = Path(destination)
+    body = fetch(str(pinned["url"]), None)
+    if len(body) != pinned["size_bytes"]:
+        raise ImageRefused(
+            f"the pinned kernel object is {pinned['size_bytes']} bytes and "
+            f"{len(body)} arrived; the key names one exact object and this is "
+            "not it"
+        )
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(body)
+    return {
+        "path": destination.as_posix(),
+        "sha256": hashlib.sha256(body).hexdigest(),
+        "size_bytes": len(body),
+        "source": {k: v for k, v in pinned.items() if k != "url"},
+        "url": pinned["url"],
+        "vouched_for_by_upstream": False,
+        "what_the_digest_means": (
+            "computed here on download, not published by upstream. It shows the "
+            "file did not change between that download and this boot. It is not "
+            "a signature and nothing upstream attests to it."
+        ),
+    }
+
+
+def require_same_kernel(reading: Mapping[str, Any], expected_sha256: str) -> None:
+    if reading["sha256"] != expected_sha256:
+        raise ImageRefused(
+            "the pinned kernel key now returns a different file: expected "
+            f"{expected_sha256}, got {reading['sha256']}. The key is a moving "
+            "target upstream and this is what pinning it is for"
+        )
+
+
+def anonymous_pull_token(
+    repository: str,
+    *,
+    registry: str = "ghcr.io",
+    fetch: Callable[[str, Mapping[str, str] | None], bytes] = _http_get,
+) -> str:
+    """A read-only token for a public repository. Issues no credential.
+
+    ``ghcr.io/v2/`` answers 401 to an unauthenticated request even for public
+    content, which reads like a permission problem and is not one: the registry
+    is asking for a token it will hand out to anybody. Nothing here is stored,
+    and nothing here belongs to an account.
+    """
+    url = (
+        f"https://{registry}/token"
+        f"?scope=repository:{repository}:pull&service={registry}"
+    )
+    return str(json.loads(fetch(url, None))["token"])
+
+
+def pull_image_by_digest(
+    repository: str,
+    digest: str,
+    destination: str | Path,
+    *,
+    registry: str = "ghcr.io",
+    platform: str = "linux/amd64",
+    token: str | None = None,
+    fetch: Callable[[str, Mapping[str, str] | None], bytes] = _http_get,
+) -> dict[str, Any]:
+    """Fetch one image by digest and lay it out, checking every blob it takes.
+
+    The digest may name a multi-architecture index, which is what
+    ``parent.lock.json`` pins. An index digest is exact, but it does not say
+    which of its children was used, so the child's digest is returned separately
+    and belongs in the artefact beside it.
+    """
+    destination = Path(destination)
+    (destination / "blobs" / "sha256").mkdir(parents=True, exist_ok=True)
+    if token is None:
+        token = anonymous_pull_token(repository, registry=registry, fetch=fetch)
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": ",".join(_MANIFEST_TYPES),
+    }
+
+    def _manifest(reference: str) -> tuple[dict[str, Any], bytes]:
+        body = fetch(
+            f"https://{registry}/v2/{repository}/manifests/{reference}", headers
+        )
+        if reference.startswith("sha256:") and _sha256_bytes(body) != reference:
+            raise ImageRefused(
+                f"the registry returned a manifest whose content is not "
+                f"{reference}; a digest that does not match is the one thing "
+                "pinning by digest is supposed to make impossible"
+            )
+        return json.loads(body), body
+
+    index_digest = None
+    manifest, raw = _manifest(digest)
+    if manifest.get("mediaType") in _INDEX_TYPES:
+        index_digest = digest
+        wanted_os, _, wanted_arch = platform.partition("/")
+        children = [
+            child
+            for child in manifest.get("manifests", [])
+            if (child.get("platform") or {}).get("architecture") == wanted_arch
+            and (child.get("platform") or {}).get("os") == wanted_os
+        ]
+        if len(children) != 1:
+            raise ImageRefused(
+                f"the index names {len(children)} manifests for {platform}; "
+                "one is needed and picking among several is a choice this "
+                "should not be making silently"
+            )
+        digest = str(children[0]["digest"])
+        manifest, raw = _manifest(digest)
+
+    layers = []
+    for layer in manifest.get("layers", []):
+        blob_digest = str(layer["digest"])
+        body = fetch(
+            f"https://{registry}/v2/{repository}/blobs/{blob_digest}", headers
+        )
+        if _sha256_bytes(body) != blob_digest:
+            raise ImageRefused(
+                f"layer {blob_digest} does not hash to its own name; nothing "
+                "from this image is used"
+            )
+        path = destination / "blobs" / "sha256" / blob_digest.split(":", 1)[1]
+        path.write_bytes(body)
+        layers.append(
+            {
+                "digest": blob_digest,
+                "media_type": str(layer.get("mediaType", "")),
+                "size_bytes": len(body),
+                "path": path.as_posix(),
+            }
+        )
+    if not layers:
+        raise ImageRefused("the manifest lists no layers, so there is no rootfs")
+
+    return {
+        "repository": f"{registry}/{repository}",
+        "pinned_digest": index_digest or digest,
+        "pinned_digest_is_an_index": index_digest is not None,
+        "manifest_digest": digest,
+        "platform": platform,
+        "layers": layers,
+        "layer_count": len(layers),
+        "credential_used": "none — anonymous pull token for a public repository",
+    }
+
+
+def _remove(path: Path) -> None:
+    """Delete a path whatever it is, without following a symlink to a directory."""
+    if path.is_symlink() or path.is_file():
+        path.unlink(missing_ok=True)
+    elif path.is_dir():
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def unpack_layers(
+    layers: Sequence[Mapping[str, Any]], into: str | Path
+) -> dict[str, Any]:
+    """Apply verified layers in order, honouring whiteouts, refusing escapes.
+
+    A layer entry named ``.wh.<name>`` deletes ``<name>`` from what earlier
+    layers put there, and ``.wh..wh..opq`` empties the directory it sits in.
+    Skipping either would leave files in the guest that the image says are not
+    in it — including, in the worst case, a file a later layer replaced for a
+    reason.
+
+    Members whose names climb out of the destination are refused rather than
+    filtered, because a layer that contains one is not an image this should be
+    unpacking at all.
+    """
+    into = Path(into)
+    into.mkdir(parents=True, exist_ok=True)
+    applied: list[str] = []
+    whiteouts = 0
+    entries = 0
+    for layer in layers:
+        with tarfile.open(layer["path"], "r:*") as archive:
+            for member in archive:
+                name = member.name.lstrip("./")
+                if not name or name == ".." or name.startswith("../") or "/../" in name:
+                    raise ImageRefused(
+                        f"layer {layer['digest']} contains {member.name!r}, "
+                        "which points outside the filesystem it describes"
+                    )
+                if os.path.isabs(name):
+                    raise ImageRefused(
+                        f"layer {layer['digest']} contains the absolute path "
+                        f"{member.name!r}"
+                    )
+                base = os.path.basename(name)
+                if base == ".wh..wh..opq":
+                    directory = into / os.path.dirname(name)
+                    if directory.is_dir() and not directory.is_symlink():
+                        for child in directory.iterdir():
+                            _remove(child)
+                    whiteouts += 1
+                    continue
+                if base.startswith(".wh."):
+                    _remove(into / os.path.dirname(name) / base[len(".wh.") :])
+                    whiteouts += 1
+                    continue
+                target = into / name
+                if member.isdir() and target.is_dir() and not target.is_symlink():
+                    pass
+                elif target.is_symlink() or target.exists():
+                    _remove(target)
+                archive.extract(member, into, set_attrs=True)
+                entries += 1
+        applied.append(layer["digest"])
+    return {
+        "root": into.as_posix(),
+        "layers_applied_in_order": applied,
+        "entries_written": entries,
+        "whiteouts_honoured": whiteouts,
+    }
+
+
+def add_guest_init(root: str | Path, *, text: str = GUEST_INIT) -> dict[str, Any]:
+    """The one file that is not the image's, written where the artefact says."""
+    path = Path(root) / GUEST_INIT_PATH.lstrip("/")
+    path.write_text(text, encoding="utf-8")
+    path.chmod(0o755)
+    return {
+        "path": GUEST_INIT_PATH,
+        "sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+        "bytes": len(text.encode("utf-8")),
+        "text": text,
+        "why": (
+            "the rootfs is read-only and the image has no init that would run "
+            "one command and stop, so exactly one file is added and its whole "
+            "text is recorded here rather than described"
+        ),
+    }
+
+
+def _directory_bytes(root: Path) -> int:
+    total = 0
+    for path in root.rglob("*"):
+        if path.is_file() and not path.is_symlink():
+            total += path.stat().st_size
+    return total
+
+
+def ext4_image_arguments(
+    image: str | Path, *, size_mib: int, populate_from: str | Path | None
+) -> list[str]:
+    """``mke2fs`` arguments, built where a test can read them.
+
+    ``-d`` populates the image from a directory without mounting anything, so no
+    loop device is attached and no mount is performed. ``-F`` is needed because
+    the target is a regular file rather than a block device.
+    """
+    argv = ["mke2fs", "-q", "-F", "-t", "ext4", "-b", "4096"]
+    if populate_from is not None:
+        argv += ["-d", Path(populate_from).as_posix()]
+    argv += [Path(image).as_posix(), f"{size_mib * 256}"]
+    return argv
+
+
+def build_ext4(
+    image: str | Path,
+    *,
+    size_mib: int,
+    populate_from: str | Path | None = None,
+    run: Callable[[Sequence[str]], Any] = None,  # type: ignore[assignment]
+) -> dict[str, Any]:
+    image = Path(image)
+    image.parent.mkdir(parents=True, exist_ok=True)
+    argv = ext4_image_arguments(image, size_mib=size_mib, populate_from=populate_from)
+    runner = run or (
+        lambda command: subprocess.run(  # noqa: S603
+            list(command), check=True, capture_output=True, text=True, timeout=1800
+        )
+    )
+    runner(argv)
+    return {
+        "path": image.as_posix(),
+        "size_mib": size_mib,
+        "sha256": sha256_file(image) if image.exists() else None,
+        "argv": argv,
+        "populated_from": (
+            Path(populate_from).as_posix() if populate_from is not None else None
+        ),
+    }
+
+
+def rootfs_size_mib(root: str | Path, *, headroom: float = 1.35, floor: int = 512) -> int:
+    """How large the rootfs image has to be, with room for ext4's own overhead.
+
+    Sized from what is actually there rather than from a constant, because the
+    image this builds from is pinned by digest but is not the same size forever,
+    and an image one block too small fails at ``mke2fs`` in a way that reads
+    like a broken layer.
+    """
+    used_mib = _directory_bytes(Path(root)) // A_MEBIBYTE
+    return max(floor, int(used_mib * headroom) + 128)
+
+
+def read_file_out_of_ext4(
+    image: str | Path,
+    inside: str,
+    *,
+    run: Callable[[Sequence[str]], Any] = None,  # type: ignore[assignment]
+) -> str | None:
+    """Take one file out of an ext4 image without mounting it.
+
+    ``debugfs`` walks the filesystem structures directly. That matters twice
+    over: mounting would need privilege the jailed account does not have, and it
+    would also mean trusting the guest's filesystem to the host kernel's ext4
+    driver, which is a larger attack surface than reading it with a userspace
+    tool.
+    """
+    runner = run or (
+        lambda command: subprocess.run(  # noqa: S603
+            list(command), check=False, capture_output=True, text=True, timeout=300
+        )
+    )
+    result = runner(["debugfs", "-R", f"cat {inside}", Path(image).as_posix()])
+    output = getattr(result, "stdout", "") or ""
+    stderr = getattr(result, "stderr", "") or ""
+    if "File not found" in stderr or getattr(result, "returncode", 0) not in (0, None):
+        return None
+    return output
+
+
+def files_out_of_work_disk(
+    image: str | Path, names: Iterable[str], **kwargs: Any
+) -> dict[str, str | None]:
+    return {name: read_file_out_of_ext4(image, name, **kwargs) for name in names}

--- a/batch-runner/core/agentic_v2_guest_image.py
+++ b/batch-runner/core/agentic_v2_guest_image.py
@@ -126,6 +126,24 @@ _INDEX_TYPES = frozenset(
     }
 )
 
+_EXTRACTION_FILTER: dict[str, str] = (
+    {"filter": "tar"} if hasattr(tarfile, "data_filter") else {}
+)
+"""CPython's own extraction filter, where the running interpreter has one.
+
+``tar`` rather than ``data``: ``data`` refuses device nodes and absolute
+symbolic-link targets, and a root filesystem legitimately contains both, so it
+would reject images this is meant to boot. ``tar`` blocks what is dangerous —
+absolute paths, traversal, and a destination that escapes *after* symbolic links
+are followed — and that last one is the same defence :func:`_refuse_symlinked_parents`
+implements, kept as well because the filter is absent on older interpreters.
+
+Presence is detected through :data:`tarfile.data_filter` rather than a version
+comparison: the ``filter`` parameter arrived in 3.12 and was backported into
+security releases of four earlier branches, so the version number does not
+answer the question and the attribute does.
+"""
+
 
 class ImageRefused(RuntimeError):
     """An image or kernel was not what its digest said it would be."""
@@ -318,6 +336,55 @@ def _remove(path: Path) -> None:
         shutil.rmtree(path, ignore_errors=True)
 
 
+def _inside_the_root(name: str, digest: str) -> str | None:
+    """Where a tar member lands under the root, or ``None`` for the root itself.
+
+    The first version of this stripped ``"./"`` off the front with
+    :meth:`str.lstrip`, which was wrong in both directions and refused the real
+    image on its first entry. ``lstrip`` takes a *set of characters*, so it ate
+    every leading dot and slash: ``"."`` — the root entry every OCI layer starts
+    with — became the empty string and was refused as an escape, while
+    ``"../x"`` became ``"x"`` and ``"/etc/shadow"`` became ``"etc/shadow"``, so
+    the two members the check exists to stop were the two it let through.
+
+    :func:`os.path.normpath` is the right tool: it collapses the traversal
+    first, so what is compared against ``".."`` is where the member actually
+    lands rather than how it spelled itself.
+    """
+    if name.startswith("/") or os.path.isabs(name):
+        raise ImageRefused(
+            f"layer {digest} contains the absolute path {name!r}"
+        )
+    landing = os.path.normpath(name)
+    if landing in (".", ""):
+        return None
+    if landing == ".." or landing.startswith(".." + os.sep):
+        raise ImageRefused(
+            f"layer {digest} contains {name!r}, which points outside the "
+            "filesystem it describes"
+        )
+    return landing
+
+
+def _refuse_symlinked_parents(into: Path, landing: str, digest: str) -> None:
+    """Refuse a member whose parent directory is a symbolic link.
+
+    An image can name ``etc`` as a link to ``/`` and then write ``etc/passwd``.
+    Neither member escapes on its own reading, and the second one lands on the
+    host's own file. Checking the parents at the moment of extraction catches it
+    because the link has to exist by then for the trick to work.
+    """
+    current = into
+    for part in Path(landing).parent.parts:
+        current = current / part
+        if current.is_symlink():
+            raise ImageRefused(
+                f"layer {digest} writes through {current.as_posix()}, which an "
+                "earlier entry made a symbolic link, so the write leaves the "
+                "filesystem being assembled"
+            )
+
+
 def unpack_layers(
     layers: Sequence[Mapping[str, Any]], into: str | Path
 ) -> dict[str, Any]:
@@ -336,48 +403,92 @@ def unpack_layers(
     into = Path(into)
     into.mkdir(parents=True, exist_ok=True)
     applied: list[str] = []
+    directory_modes: dict[Path, int] = {}
     whiteouts = 0
     entries = 0
     for layer in layers:
+        digest = str(layer["digest"])
         with tarfile.open(layer["path"], "r:*") as archive:
             for member in archive:
-                name = member.name.lstrip("./")
-                if not name or name == ".." or name.startswith("../") or "/../" in name:
-                    raise ImageRefused(
-                        f"layer {layer['digest']} contains {member.name!r}, "
-                        "which points outside the filesystem it describes"
-                    )
-                if os.path.isabs(name):
-                    raise ImageRefused(
-                        f"layer {layer['digest']} contains the absolute path "
-                        f"{member.name!r}"
-                    )
-                base = os.path.basename(name)
+                landing = _inside_the_root(member.name, digest)
+                if landing is None:
+                    continue
+                if member.islnk():
+                    _inside_the_root(member.linkname, digest)
+                base = os.path.basename(landing)
                 if base == ".wh..wh..opq":
-                    directory = into / os.path.dirname(name)
+                    directory = into / os.path.dirname(landing)
                     if directory.is_dir() and not directory.is_symlink():
                         for child in directory.iterdir():
                             _remove(child)
                     whiteouts += 1
                     continue
                 if base.startswith(".wh."):
-                    _remove(into / os.path.dirname(name) / base[len(".wh.") :])
+                    _remove(into / os.path.dirname(landing) / base[len(".wh.") :])
                     whiteouts += 1
                     continue
-                target = into / name
+                _refuse_symlinked_parents(into, landing, digest)
+                target = into / landing
                 if member.isdir() and target.is_dir() and not target.is_symlink():
                     pass
                 elif target.is_symlink() or target.exists():
                     _remove(target)
-                archive.extract(member, into, set_attrs=True)
+                try:
+                    archive.extract(member, into, set_attrs=True, **_EXTRACTION_FILTER)
+                except tarfile.TarError as refused:
+                    # Covers the filter's own refusals, which subclass this, and
+                    # a corrupt archive. Both mean the same thing here: what
+                    # came back is not the filesystem the manifest described.
+                    raise ImageRefused(
+                        f"layer {digest} would not extract {member.name!r}: {refused}"
+                    ) from refused
+                if member.isdir() and not target.is_symlink():
+                    _hold_open_until_the_end(target, directory_modes)
                 entries += 1
-        applied.append(layer["digest"])
+        applied.append(digest)
+    restored = _restore_directory_modes(directory_modes)
     return {
         "root": into.as_posix(),
         "layers_applied_in_order": applied,
         "entries_written": entries,
         "whiteouts_honoured": whiteouts,
+        "directory_modes_restored": restored,
+        "extraction_filter": _EXTRACTION_FILTER.get("filter", "none available"),
+        "what_the_filter_changed": (
+            "the tar filter clears setuid, setgid and sticky bits. Nothing in "
+            "this guest depends on them: it boots one process as root and has "
+            "no second user to escalate from. Recorded because it means the "
+            "unpacked tree is not byte-for-byte the image's own permissions."
+        ),
     }
+
+
+def _hold_open_until_the_end(directory: Path, remember: dict[Path, int]) -> None:
+    """Give a freshly-extracted directory the bits needed to descend into it.
+
+    A layer can name a directory ``0o750`` or narrower, and later entries in the
+    same layer land underneath it. Extracting members one at a time — which is
+    what the whiteout and escape checks above require — means that mode is in
+    place before its children arrive, and the extraction of the next child then
+    fails on a permission error that reads like a corrupt archive.
+
+    :meth:`tarfile.TarFile.extractall` solves this by applying directory modes
+    only after everything is written. This does the same thing, split in two so
+    the recorded mode is the one the image asked for rather than the one that
+    made the unpack possible.
+    """
+    mode = directory.stat().st_mode & 0o7777
+    remember.setdefault(directory, mode)
+    if mode & 0o700 != 0o700:
+        directory.chmod(mode | 0o700)
+
+
+def _restore_directory_modes(remembered: Mapping[Path, int]) -> int:
+    """Put the image's own directory modes back, deepest first."""
+    for directory in sorted(remembered, key=lambda path: len(path.parts), reverse=True):
+        if directory.is_dir() and not directory.is_symlink():
+            directory.chmod(remembered[directory])
+    return len(remembered)
 
 
 def add_guest_init(root: str | Path, *, text: str = GUEST_INIT) -> dict[str, Any]:

--- a/batch-runner/core/agentic_v2_microvm_launch.py
+++ b/batch-runner/core/agentic_v2_microvm_launch.py
@@ -76,6 +76,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Mapping
 
+from core.agentic_v2_guest_image import GUEST_INIT_PATH
 from core.agentic_v2_microvm import inspect_microvm_readiness
 from core.agentic_v2_substrate import REQUIRED_MICROVM_POLICY, canonical_sha256
 
@@ -505,9 +506,20 @@ def _firecracker_configuration(
             # kernel. Only one of the two is Firecracker's; a guest told to
             # mount a read-only drive read-write fails at boot in a way that
             # reads as a broken image rather than as an enforced rule.
+            #
+            # ``init=`` is named rather than left to the kernel's search. With
+            # it absent the kernel tries /sbin/init, /etc/init, /bin/init and
+            # then falls back to /bin/sh — and an image built from a language
+            # runtime has no init but does have a shell, so the guest would
+            # come up on an interactive shell attached to a console that
+            # ``--daemonize`` has already sent to /dev/null. That is a machine
+            # that boots, runs nothing, writes nothing and sits there until the
+            # deadline stops it, which is the hardest of all the failures here
+            # to tell apart from a broken image.
             "boot_args": (
                 "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda"
                 + (" ro" if read_only else "")
+                + f" init={GUEST_INIT_PATH}"
             ),
         },
         "drives": [

--- a/batch-runner/scripts/run_agentic_c2_first_boot.py
+++ b/batch-runner/scripts/run_agentic_c2_first_boot.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""C2: boot one guest under the jailer on the machine stage B measured.
+
+Runs **on the execution host** and nowhere else. This box runs kernel 3.10 and
+cannot boot a Firecracker machine at all, so C1's mapping is tested here and
+this is tested only there, and the two are not allowed to be confused.
+
+What it does, in the order it does it, because each step can fail differently:
+
+1.  read the host — cgroup hierarchy version above all, since the jailer
+    defaults to v1 and Ubuntu 24.04 runs v2, and a memory bound written to the
+    wrong file reads as enforced and is not;
+2.  make sure there is an account to jail to that cannot become root;
+3.  fetch the pinned guest kernel, recording that upstream vouches for nothing;
+4.  pull the parent image by digest, check every blob against its own name,
+    unpack the layers in order, add exactly one file, build an ext4 from it;
+5.  build the work disk with the command on it;
+6.  ask C1's builder for the arguments — this script writes none of its own;
+7.  boot the images once *without* the jail, console attached, purely to tell a
+    broken image apart from a broken jail. Recorded as not the contained run;
+8.  boot under the jailer, wait, read the result off the work disk, destroy the
+    chroot;
+9.  write one artefact with all of it, including every disclaimer.
+
+It changes no flag and opens no gate. ``foundation_only`` and
+``production_activation`` are untouched, and ``exec_run`` stays shut.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pwd
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.agentic_v2_first_boot import (  # noqa: E402
+    WORK_DISK_INPUT,
+    first_boot,
+    unjailed_image_check,
+)
+from core.agentic_v2_guest_image import (  # noqa: E402
+    PINNED_GUEST_KERNEL,
+    add_guest_init,
+    build_ext4,
+    fetch_pinned_kernel,
+    pull_image_by_digest,
+    rootfs_size_mib,
+    unpack_layers,
+)
+from core.agentic_v2_microvm_launch import build_launch_plan  # noqa: E402
+from core.agentic_v2_substrate import REQUIRED_MICROVM_POLICY  # noqa: E402
+
+JAIL_ACCOUNT = "gdpvaljail"
+
+
+def now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def read_the_host() -> dict[str, Any]:
+    """The readings the plan depends on, taken rather than assumed."""
+    unified = Path("/sys/fs/cgroup/cgroup.controllers").exists()
+    kvm = Path("/dev/kvm")
+    return {
+        "read_at": now(),
+        "cgroup_version": 2 if unified else 1,
+        "cgroup_evidence": (
+            "/sys/fs/cgroup/cgroup.controllers exists"
+            if unified
+            else "no /sys/fs/cgroup/cgroup.controllers, so the v1 hierarchy"
+        ),
+        "kernel_release": os.uname().release,
+        "processors": os.cpu_count(),
+        "kvm_present": kvm.exists(),
+        "firecracker": shutil.which("firecracker"),
+        "jailer": shutil.which("jailer"),
+        "firecracker_version": _version("firecracker"),
+        "jailer_version": _version("jailer"),
+    }
+
+
+def _version(binary: str) -> str | None:
+    path = shutil.which(binary)
+    if not path:
+        return None
+    result = subprocess.run(  # noqa: S603
+        [path, "--version"], check=False, capture_output=True, text=True, timeout=60
+    )
+    return (result.stdout or result.stderr).strip().splitlines()[0] if result else None
+
+
+def account_to_jail_to(name: str = JAIL_ACCOUNT) -> dict[str, Any]:
+    """An account with no shell, no password and no group but its own.
+
+    uid 1000 on this host is in ``sudo``. Jailing to it would leave the
+    host-side process one command away from root if it ever got out, and the
+    ``user: jailer-unprivileged`` rule would still have read as met. So a
+    dedicated account is used, and if it turns out to have gained a group this
+    refuses rather than jailing to it anyway.
+    """
+    try:
+        entry = pwd.getpwnam(name)
+    except KeyError:
+        subprocess.run(  # noqa: S603
+            [
+                "useradd",
+                "--system",
+                "--no-create-home",
+                "--shell",
+                "/usr/sbin/nologin",
+                name,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        entry = pwd.getpwnam(name)
+    groups = subprocess.run(  # noqa: S603
+        ["id", "-Gn", name], check=False, capture_output=True, text=True, timeout=60
+    ).stdout.split()
+    extra = sorted(set(groups) - {name})
+    if extra:
+        raise SystemExit(
+            f"the jail account {name} is in {extra}, which is not the "
+            "unprivileged account the user rule asks for"
+        )
+    if entry.pw_uid <= 0 or entry.pw_gid <= 0:
+        raise SystemExit(f"{name} resolves to uid {entry.pw_uid}, which is not an account")
+    return {
+        "name": name,
+        "uid": entry.pw_uid,
+        "gid": entry.pw_gid,
+        "shell": entry.pw_shell,
+        "groups_beyond_its_own": extra,
+    }
+
+
+def build_guest_images(
+    workdir: Path, repository: str, digest: str, command: str
+) -> dict[str, Any]:
+    kernel = fetch_pinned_kernel(workdir / "vmlinux")
+    image = pull_image_by_digest(repository, digest, workdir / "oci")
+    unpacked = unpack_layers(image["layers"], workdir / "root")
+    init = add_guest_init(workdir / "root")
+    size = rootfs_size_mib(workdir / "root")
+    rootfs = build_ext4(workdir / "rootfs.ext4", size_mib=size, populate_from=workdir / "root")
+
+    staging = workdir / "work-in"
+    (staging / "in").mkdir(parents=True, exist_ok=True)
+    (staging / "out").mkdir(parents=True, exist_ok=True)
+    (staging / WORK_DISK_INPUT.lstrip("/")).write_text(command, encoding="utf-8")
+    work = build_ext4(
+        workdir / "work.ext4",
+        size_mib=int(REQUIRED_MICROVM_POLICY["workdir_quota_mib"]),
+        populate_from=staging,
+    )
+    return {
+        "kernel": kernel,
+        "image": image,
+        "unpacked": unpacked,
+        "guest_init": init,
+        "rootfs": rootfs,
+        "work_disk": work,
+        "command": command,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workdir", default="/var/tmp/gdpval-c2")
+    parser.add_argument(
+        "--repository", default="hyeonsangjeon/gdpval-sandbox"
+    )
+    parser.add_argument(
+        "--digest",
+        default=(
+            "sha256:ee6ef798631d3c3aeaed28658c640e6f5d021677449852bf2e1f18be5"
+            "bd24edb"
+        ),
+        help="the digest parent.lock.json pins; a multi-architecture index",
+    )
+    parser.add_argument("--vcpu-count", type=int, default=1)
+    parser.add_argument("--artefact", default="/var/tmp/gdpval-c2/c2-first-boot.json")
+    parser.add_argument(
+        "--command",
+        default=(
+            "set -eu\n"
+            "echo 'this ran inside the guest'\n"
+            "python3 -c \"print('python answered', 2 + 2)\" 2>/dev/null || "
+            "echo 'no python3 in the image'\n"
+            "id -u\n"
+            "mount | grep ' / ' || true\n"
+            "( echo write-to-root > /root-write-probe.txt && "
+            "echo 'ROOTFS WAS WRITABLE' ) 2>/dev/null || "
+            "echo 'rootfs refused a write, as the rule says it must'\n"
+        ),
+    )
+    parser.add_argument("--skip-unjailed-check", action="store_true")
+    parser.add_argument("--also-fire-the-deadline", action="store_true")
+    parser.add_argument("--deadline-test-seconds", type=int, default=45)
+    args = parser.parse_args()
+
+    started = time.time()
+    workdir = Path(args.workdir)
+    workdir.mkdir(parents=True, exist_ok=True)
+    host = read_the_host()
+    artefact: dict[str, Any] = {
+        "schema_version": "1.0",
+        "stage": "C2",
+        "started_at": now(),
+        "host": host,
+        "what_this_is_not": (
+            "not exec_run, not a model call, not a task. No flag was changed "
+            "and nothing here is wired into the product path."
+        ),
+    }
+
+    try:
+        if not host["kvm_present"] or not host["jailer"]:
+            artefact["outcome"] = "host_cannot_boot"
+            artefact["reason"] = (
+                "no /dev/kvm or no jailer on this machine, so there is nothing "
+                "to run the plan on"
+            )
+            return _write(artefact, args.artefact, started)
+
+        account = account_to_jail_to()
+        artefact["jail_account"] = account
+
+        images = build_guest_images(
+            workdir, args.repository, args.digest, args.command
+        )
+        artefact["images"] = images
+
+        plan = build_launch_plan(
+            vm_id="c2-first-boot",
+            firecracker_binary=host["firecracker"],
+            kernel_path=images["kernel"]["path"],
+            rootfs_path=images["rootfs"]["path"],
+            work_disk_path=images["work_disk"]["path"],
+            uid=account["uid"],
+            gid=account["gid"],
+            vcpu_count=args.vcpu_count,
+            cgroup_version=host["cgroup_version"],
+        )
+        artefact["plan"] = plan
+
+        if not args.skip_unjailed_check:
+            with tempfile.TemporaryDirectory(prefix="c2-unjailed-") as scratch:
+                probe_disk = Path(scratch) / "work.ext4"
+                shutil.copy2(images["work_disk"]["path"], probe_disk)
+                artefact["unjailed_image_check"] = unjailed_image_check(
+                    firecracker_binary=host["firecracker"],
+                    kernel=images["kernel"]["path"],
+                    rootfs=images["rootfs"]["path"],
+                    work_disk=probe_disk,
+                    workdir=scratch,
+                )
+
+        artefact["boot"] = first_boot(
+            plan,
+            jailer_binary=host["jailer"],
+            kernel=images["kernel"]["path"],
+            rootfs=images["rootfs"]["path"],
+            work_disk=images["work_disk"]["path"],
+            uid=account["uid"],
+            gid=account["gid"],
+        )
+        artefact["outcome"] = artefact["boot"]["outcome"]
+
+        if args.also_fire_the_deadline and artefact["outcome"] == "booted":
+            artefact["deadline_test"] = _fire_the_deadline(
+                workdir, host, account, args
+            )
+    except Exception as failure:  # noqa: BLE001 - the reason is the artefact
+        artefact["outcome"] = "refused"
+        artefact["reason"] = f"{type(failure).__name__}: {failure}"
+    return _write(artefact, args.artefact, started)
+
+
+def _fire_the_deadline(
+    workdir: Path, host: dict[str, Any], account: dict[str, Any], args: Any
+) -> dict[str, Any]:
+    """Make ``wall_clock_seconds`` actually fire, without touching the policy.
+
+    The real bound is 1,200 seconds, and waiting twenty minutes to watch a
+    deadline work is not a test anybody runs twice. So a *different* policy is
+    handed to the same builder — which is a supported argument, and which still
+    refuses a policy with a rule missing, added or out of reach — carrying a
+    short bound and a command that would never return. The builder is
+    unchanged, :data:`REQUIRED_MICROVM_POLICY` is unchanged, and what is being
+    checked is the launcher's ability to stop a machine that overruns.
+
+    A deadline nobody has watched fire is a deadline nobody has tested, and this
+    one is the only thing standing between a wedged guest and a host that waits
+    forever.
+    """
+    seconds = int(args.deadline_test_seconds)
+    policy = dict(REQUIRED_MICROVM_POLICY) | {"wall_clock_seconds": seconds}
+    scratch = workdir / "deadline"
+    staging = scratch / "work-in"
+    (staging / "in").mkdir(parents=True, exist_ok=True)
+    (staging / "out").mkdir(parents=True, exist_ok=True)
+    (staging / WORK_DISK_INPUT.lstrip("/")).write_text(
+        "echo 'about to hang on purpose'\nwhile true; do sleep 5; done\n",
+        encoding="utf-8",
+    )
+    disk = build_ext4(
+        scratch / "work.ext4",
+        size_mib=int(policy["workdir_quota_mib"]),
+        populate_from=staging,
+    )
+    plan = build_launch_plan(
+        vm_id="c2-deadline",
+        firecracker_binary=host["firecracker"],
+        kernel_path=(workdir / "vmlinux").as_posix(),
+        rootfs_path=(workdir / "rootfs.ext4").as_posix(),
+        work_disk_path=disk["path"],
+        uid=account["uid"],
+        gid=account["gid"],
+        vcpu_count=args.vcpu_count,
+        cgroup_version=host["cgroup_version"],
+        policy=policy,
+    )
+    result = first_boot(
+        plan,
+        jailer_binary=host["jailer"],
+        kernel=(workdir / "vmlinux").as_posix(),
+        rootfs=(workdir / "rootfs.ext4").as_posix(),
+        work_disk=disk["path"],
+        uid=account["uid"],
+        gid=account["gid"],
+    )
+    return {
+        "why": (
+            "the real bound is 1200s; this run hands the same builder a "
+            f"different policy with {seconds}s so the stop can be watched"
+        ),
+        "policy_used_is_not_the_required_one": True,
+        "wall_clock_seconds": seconds,
+        "outcome": result["outcome"],
+        "stopped_by_the_deadline": result["stopped_by_the_deadline"],
+        "ran_for_seconds": result["ran_for_seconds"],
+        "chroot_destroyed": result["teardown"]["all_gone"],
+    }
+
+
+def _write(artefact: dict[str, Any], path: str, started: float) -> int:
+    artefact["finished_at"] = now()
+    artefact["elapsed_seconds"] = round(time.time() - started, 1)
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(json.dumps(artefact, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps({"outcome": artefact["outcome"], "artefact": path}))
+    return 0 if artefact["outcome"] == "booted" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/batch-runner/scripts/run_agentic_c3_attacks.py
+++ b/batch-runner/scripts/run_agentic_c3_attacks.py
@@ -1,0 +1,351 @@
+"""Run the seven attacks against a machine the C2 plan built, and judge them.
+
+Nothing here is new containment. Every rule being attacked is one C1 already
+turned into an argument and C2 already booted under; this script's whole job is
+to try to get past each of them and to read back something that says whether it
+got past.
+
+**It builds no new images.** The kernel and rootfs come from the C2 workdir, and
+their hashes are compared against what C2 recorded before anything boots. An
+attack run against a *different* guest than the one whose boot was recorded would
+be seven verdicts about an unidentified machine, and rebuilding an 8.7 GiB rootfs
+to get the same bytes is a slower way of being less sure.
+
+**Two of the seven are read from the host while the guest is alive.** The uid the
+jailer dropped to and the credentials the Firecracker process carries are facts
+about a host process, not about anything the guest can see — inside the machine
+PID 1 is root and is meant to be. So the probe boot holds itself open for a few
+seconds and a watcher reads ``/proc/<pid>`` while it does. The watcher runs
+beside :func:`first_boot` rather than inside it, because ``first_boot`` adds no
+argument of its own and this would be one.
+
+Usage on the host, as root, with C2's workdir already populated::
+
+    python3 scripts/run_agentic_c3_attacks.py \\
+        --images-from /var/tmp/gdpval-c2 \\
+        --workdir /var/tmp/gdpval-c3 \\
+        --artefact /var/tmp/gdpval-c3/c3-attacks.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.agentic_v2_containment_attacks import (  # noqa: E402
+    BOOT_MEMORY,
+    BOOT_PROBES,
+    BOOT_WALL_CLOCK,
+    BOOT_WORKDIR,
+    guest_commands,
+    judge_all,
+)
+from core.agentic_v2_first_boot import WORK_DISK_INPUT, first_boot  # noqa: E402
+from core.agentic_v2_guest_image import build_ext4, sha256_file  # noqa: E402
+from core.agentic_v2_microvm_launch import build_launch_plan  # noqa: E402
+from core.agentic_v2_substrate import REQUIRED_MICROVM_POLICY  # noqa: E402
+
+from run_agentic_c2_first_boot import (  # noqa: E402
+    account_to_jail_to,
+    now,
+    read_the_host,
+)
+
+CANARY_VARIABLE = "GDPVAL_C3_CANARY_TOKEN"
+CANARY_VALUE = "if-this-reaches-the-guest-the-rule-did-not-hold"
+
+
+class Watcher(threading.Thread):
+    """Read ``/proc/<pid>`` once, while the machine it belongs to is still alive.
+
+    Polls for the PID file the plan names rather than being handed a pid,
+    because the launcher owns the process and this thread is deliberately not
+    part of it. If the machine comes and goes before a single read lands, the
+    watcher reports nothing — and nothing is a failed attack, not a passed one.
+    """
+
+    def __init__(self, pid_file: Path, canary_path: Path, expected_uid: int):
+        super().__init__(daemon=True)
+        self.pid_file = pid_file
+        self.canary_path = canary_path.resolve().as_posix()
+        self.expected_uid = expected_uid
+        self.seen: dict[str, Any] | None = None
+        self.stop = threading.Event()
+
+    def run(self) -> None:
+        while not self.stop.is_set():
+            try:
+                pid = int(self.pid_file.read_text().strip())
+            except (OSError, ValueError):
+                time.sleep(0.02)
+                continue
+            reading = self._read(pid)
+            if reading is not None:
+                self.seen = reading
+                return
+            time.sleep(0.02)
+
+    def _read(self, pid: int) -> dict[str, Any] | None:
+        proc = Path("/proc") / str(pid)
+        try:
+            status = (proc / "status").read_text()
+            raw_environment = (proc / "environ").read_bytes()
+        except OSError:
+            return None
+
+        real_uid = None
+        groups: list[int] = []
+        for line in status.splitlines():
+            if line.startswith("Uid:"):
+                real_uid = int(line.split()[1])
+            elif line.startswith("Groups:"):
+                groups = [int(g) for g in line.split()[1:]]
+
+        entries = [e for e in raw_environment.decode("utf-8", "replace").split("\0") if e]
+        canaries = [
+            entry.split("=", 1)[0]
+            for entry in entries
+            if CANARY_VARIABLE in entry or CANARY_VALUE in entry
+        ]
+
+        descriptors: dict[str, str] = {}
+        try:
+            for handle in sorted((proc / "fd").iterdir(), key=lambda p: int(p.name)):
+                try:
+                    descriptors[handle.name] = os.readlink(handle)
+                except OSError:
+                    descriptors[handle.name] = "unreadable"
+        except OSError:
+            return None
+
+        return {
+            "pid": pid,
+            "real_uid": real_uid,
+            "expected_uid": self.expected_uid,
+            "supplementary_groups": [g for g in groups if g != 0],
+            "environment_seen": len(entries),
+            "environment_names": sorted(entry.split("=", 1)[0] for entry in entries),
+            "canaries_in_environment": canaries,
+            "descriptors": descriptors,
+            "descriptors_reaching_the_orchestrator": [
+                f"{fd} -> {target}"
+                for fd, target in descriptors.items()
+                if target == self.canary_path or "c3-canary" in target
+            ],
+            "standard_descriptors": {
+                fd: descriptors.get(fd) for fd in ("0", "1", "2")
+            },
+            "read_at": now(),
+        }
+
+
+def _work_disk(workdir: Path, name: str, command: str, size_mib: int) -> dict[str, Any]:
+    staging = workdir / f"work-in-{name}"
+    (staging / "in").mkdir(parents=True, exist_ok=True)
+    (staging / "out").mkdir(parents=True, exist_ok=True)
+    (staging / WORK_DISK_INPUT.lstrip("/")).write_text(command, encoding="utf-8")
+    return build_ext4(
+        workdir / f"work-{name}.ext4", size_mib=size_mib, populate_from=staging
+    )
+
+
+def _one_attack_boot(
+    *,
+    name: str,
+    command: str,
+    workdir: Path,
+    host: dict[str, Any],
+    account: dict[str, Any],
+    kernel: Path,
+    rootfs: Path,
+    policy: dict[str, Any],
+    canary_path: Path,
+    watch: bool,
+) -> dict[str, Any]:
+    disk = _work_disk(
+        workdir, name, command, int(policy["workdir_quota_mib"])
+    )
+    plan = build_launch_plan(
+        vm_id=f"c3-{name}",
+        firecracker_binary=host["firecracker"],
+        kernel_path=kernel,
+        rootfs_path=rootfs,
+        work_disk_path=disk["path"],
+        uid=account["uid"],
+        gid=account["gid"],
+        vcpu_count=1,
+        cgroup_version=host["cgroup_version"],
+        policy=policy,
+    )
+
+    watcher = None
+    if watch:
+        watcher = Watcher(
+            Path(plan["host_side"]["pid_file"]), canary_path, account["uid"]
+        )
+        watcher.start()
+
+    result = first_boot(
+        plan,
+        jailer_binary=host["jailer"],
+        kernel=kernel,
+        rootfs=rootfs,
+        work_disk=disk["path"],
+        uid=account["uid"],
+        gid=account["gid"],
+    )
+    if watcher is not None:
+        watcher.stop.set()
+        watcher.join(timeout=2.0)
+        result["watched"] = watcher.seen
+        if watcher.seen is None:
+            result["watched_failed_because"] = (
+                "no /proc read landed while the machine was alive; the attacks "
+                "that depend on it are recorded as not stopped"
+            )
+    result["work_disk"] = disk
+    result["policy_used"] = policy
+    result["policy_is_the_required_one"] = policy == dict(REQUIRED_MICROVM_POLICY)
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workdir", default="/var/tmp/gdpval-c3")
+    parser.add_argument("--images-from", default="/var/tmp/gdpval-c2")
+    parser.add_argument(
+        "--c2-artefact", default="/var/tmp/gdpval-c2/c2-first-boot.json"
+    )
+    parser.add_argument("--artefact", default="/var/tmp/gdpval-c3/c3-attacks.json")
+    parser.add_argument(
+        "--wall-clock-seconds",
+        type=int,
+        default=45,
+        help=(
+            "the bound the hanging guest is run against. The real rule is 1200s; "
+            "attack 3 uses a shorter one so the stop can be watched, and the "
+            "artefact records that the policy was not the required one"
+        ),
+    )
+    args = parser.parse_args()
+
+    started = time.time()
+    workdir = Path(args.workdir)
+    workdir.mkdir(parents=True, exist_ok=True)
+    images_from = Path(args.images_from)
+    kernel = images_from / "vmlinux"
+    rootfs = images_from / "rootfs.ext4"
+
+    host = read_the_host()
+    artefact: dict[str, Any] = {
+        "schema_version": "1.0",
+        "stage": "C3",
+        "started_at": now(),
+        "host": host,
+        "what_this_is_not": (
+            "not exec_run, not a model call, not a task. No flag was changed, no "
+            "rule was relaxed, and nothing here is wired into the product path."
+        ),
+    }
+
+    try:
+        for image in (kernel, rootfs):
+            if not image.exists():
+                artefact["outcome"] = "images_not_present"
+                artefact["reason"] = f"{image} is not there; run C2 first"
+                return _write(artefact, args.artefact, started)
+
+        same = {"kernel_sha256": sha256_file(kernel), "rootfs_sha256": sha256_file(rootfs)}
+        try:
+            c2 = json.loads(Path(args.c2_artefact).read_text())
+            recorded = {
+                "kernel_sha256": c2["images"]["kernel"]["sha256"],
+                "rootfs_sha256": c2["images"]["rootfs"]["sha256"],
+            }
+            same["matches_the_guest_c2_booted"] = same != {} and all(
+                same[k] == recorded[k] for k in recorded
+            )
+            same["c2_recorded"] = recorded
+        except (OSError, KeyError, ValueError) as unreadable:
+            same["matches_the_guest_c2_booted"] = None
+            same["c2_could_not_be_read"] = repr(unreadable)
+        artefact["images"] = same
+
+        if same.get("matches_the_guest_c2_booted") is False:
+            artefact["outcome"] = "different_guest"
+            artefact["reason"] = (
+                "the images here are not the ones C2 booted, so seven verdicts "
+                "would be about a machine whose boot nobody recorded"
+            )
+            return _write(artefact, args.artefact, started)
+
+        account = account_to_jail_to()
+        artefact["jail_account"] = account
+
+        canary_path = workdir / "c3-canary-token.txt"
+        canary_path.write_text(CANARY_VALUE, encoding="utf-8")
+        os.environ[CANARY_VARIABLE] = CANARY_VALUE
+        held_open = canary_path.open("rb")
+
+        required = dict(REQUIRED_MICROVM_POLICY)
+        shortened = required | {"wall_clock_seconds": int(args.wall_clock_seconds)}
+        commands = guest_commands(required)
+        groups = [
+            (BOOT_PROBES, commands[BOOT_PROBES], required, True),
+            (BOOT_WORKDIR, commands[BOOT_WORKDIR], required, False),
+            (BOOT_MEMORY, commands[BOOT_MEMORY], required, False),
+            (BOOT_WALL_CLOCK, commands[BOOT_WALL_CLOCK], shortened, False),
+        ]
+
+        boots: dict[str, Any] = {}
+        for name, command, policy, watch in groups:
+            boots[name] = _one_attack_boot(
+                name=name,
+                command=command,
+                workdir=workdir,
+                host=host,
+                account=account,
+                kernel=kernel,
+                rootfs=rootfs,
+                policy=policy,
+                canary_path=canary_path,
+                watch=watch,
+            )
+            boots[name]["command"] = command
+        held_open.close()
+        artefact["boots"] = boots
+
+        artefact["judgement"] = judge_all(artefact)
+        artefact["outcome"] = (
+            "all_seven_stopped"
+            if artefact["judgement"]["all_seven_stopped"]
+            else "escaped"
+        )
+    except Exception as failure:  # noqa: BLE001 - the artefact records the failure
+        artefact["outcome"] = "error"
+        artefact["error"] = repr(failure)
+    return _write(artefact, args.artefact, started)
+
+
+def _write(artefact: dict[str, Any], path: str, started: float) -> int:
+    artefact["finished_at"] = now()
+    artefact["elapsed_seconds"] = round(time.time() - started, 1)
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(artefact, indent=1, sort_keys=True), encoding="utf-8")
+    print(f"artefact={target}")
+    print(json.dumps(artefact.get("judgement", {"outcome": artefact["outcome"]}), indent=1))
+    return 0 if artefact["outcome"] == "all_seven_stopped" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/batch-runner/tests/test_agentic_v2_containment_attacks.py
+++ b/batch-runner/tests/test_agentic_v2_containment_attacks.py
@@ -102,10 +102,12 @@ def _clean_sweep(**overrides):
                 "outcome": "booted",
                 "results": {
                     "/out/stdout": (
-                        "MemTotal:        4014520 kB\n"
-                        "dd: error writing '/dev/shm/gdpval-balloon': Cannot "
-                        "allocate memory\nrc=1\n"
-                    )
+                        "MemTotal:        4036852 kB\n"
+                        "allocated_mib=64\n"
+                        "allocated_mib=3840\n"
+                        "rc=137\n"
+                    ),
+                    "/out/stderr": "Killed\n",
                 },
             },
             BOOT_WALL_CLOCK: {
@@ -311,6 +313,62 @@ def test_an_allocation_past_the_bound_that_succeeded_is_an_escape():
         )
     )
     assert _verdict(judgement, "memory")["stopped"] is False
+
+
+def test_an_allocator_that_reported_holding_it_all_is_an_escape():
+    """``rc`` comes from the shell, and the shell is not what did the allocating.
+
+    A machine that let the guest hold every requested byte and then returned a
+    non-zero status — a tidy-up that failed, a signal on the way out — would pass
+    on the exit status alone, while the bound it was meant to enforce did not
+    hold.
+    """
+    judgement = judge_all(
+        _clean_sweep(
+            **{
+                BOOT_MEMORY: {
+                    "results": {
+                        "/out/stdout": (
+                            "MemTotal: 4014520 kB\nallocated_mib=6144\n"
+                            "ALLOCATED_ALL\nrc=1\n"
+                        )
+                    }
+                }
+            }
+        )
+    )
+    assert _verdict(judgement, "memory")["stopped"] is False
+
+
+def test_holding_more_than_the_bound_is_an_escape_however_the_guest_ended():
+    """The high-water mark is the rule; the exit status is only how it ended.
+
+    Every page counted there was written to, and a guest with no swap cannot give
+    touched anonymous memory back — so a number past the bound is memory the
+    machine actually handed over.
+    """
+    judgement = judge_all(
+        _clean_sweep(
+            **{
+                BOOT_MEMORY: {
+                    "results": {
+                        "/out/stdout": (
+                            "MemTotal: 4014520 kB\nallocated_mib=5120\nrc=137\n"
+                        )
+                    }
+                }
+            }
+        )
+    )
+    verdict = _verdict(judgement, "memory")
+    assert verdict["stopped"] is False
+    assert "5120" in verdict["evidence"]
+
+
+def test_the_verdict_says_how_far_the_allocation_got():
+    """"Something stopped it" and "it stopped 102 MiB short" are different findings."""
+    judgement = judge_all(_clean_sweep())
+    assert "3840 MiB" in _verdict(judgement, "memory")["evidence"]
 
 
 def test_a_hanging_guest_that_finished_on_its_own_did_not_test_the_deadline():
@@ -527,8 +585,46 @@ def test_the_overshoot_is_taken_from_the_rule_and_not_written_as_a_number():
     commands = guest_commands(raised)
 
     assert "count=2048" in commands[BOOT_WORKDIR]
-    assert "count=12288" in commands[BOOT_MEMORY]
+    assert "12288 * 1024 * 1024" in commands[BOOT_MEMORY]
     assert "quota_mib_configured=1024" in commands[BOOT_WORKDIR]
+
+
+def test_the_memory_attack_reports_from_a_shell_that_allocates_nothing():
+    """The regression from the first C3 run, where the reporter was the casualty.
+
+    ``rc=$?`` inside a command substitution runs in a fork. When the machine
+    filled, that fork was what the kernel took, so the attack came back with no
+    exit status at all — judged, correctly, as an attack that never ran, while
+    the bound had in fact held. The report has to be made by a process that is
+    never a candidate.
+    """
+    allocate = guest_commands()[BOOT_MEMORY]
+
+    assert "$(dd" not in allocate, "the reporter is inside a fork again"
+    assert "wait \"$allocator\"" in allocate
+    assert allocate.index('wait "$allocator"') < allocate.index('echo "rc=$?"')
+
+
+def test_the_memory_attack_allocates_memory_that_is_charged_to_it():
+    """tmpfs is shmem, and shmem belongs to no process the OOM killer can weigh.
+
+    The first run filled a tmpfs, the kernel found nothing large to pick, and it
+    picked a bystander. Anonymous memory that has been written to is charged to
+    the allocator, which is the only way this attack points the kernel at itself.
+    """
+    allocate = guest_commands()[BOOT_MEMORY]
+    runs = "\n".join(
+        line for line in allocate.splitlines() if not line.lstrip().startswith("#")
+    )
+
+    assert "tmpfs" not in runs
+    assert "/dev/shm" not in runs
+    assert "block[offset] = 1" in runs, "untouched pages are address space"
+
+
+def test_the_memory_attack_reports_as_it_goes_and_not_only_at_the_end():
+    """A process the kernel kills does not reach its last line."""
+    assert "allocated_mib=" in guest_commands()[BOOT_MEMORY]
 
 
 def test_the_quota_attack_removes_its_filler_before_the_guest_ends():

--- a/batch-runner/tests/test_agentic_v2_containment_attacks.py
+++ b/batch-runner/tests/test_agentic_v2_containment_attacks.py
@@ -1,0 +1,555 @@
+"""Judging the seven attacks, and the one way of judging them that would be a lie.
+
+The attacks themselves need a machine. The judging does not, and it is where the
+mistake would be: a verdict function that reads a missing observation as "nothing
+went wrong" turns a guest that never booted into a clean sweep. Most of this file
+is that one property, applied to each attack in turn, because it has to hold for
+all seven and not merely for the ones easiest to write.
+
+The second thing held here is that two attacks cannot be answered from inside the
+guest. ``user`` and ``credentials`` are facts about the host-side Firecracker
+process; inside the machine PID 1 is root and is supposed to be. A judge that
+accepted the guest's own uid would pass on a launcher that never dropped
+privilege at all, which is the failure the rule exists to prevent.
+
+Nothing here boots anything. This box runs kernel 3.10 and cannot.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.agentic_v2_containment_attacks import (
+    ATTACKS,
+    BOOT_MEMORY,
+    BOOT_PROBES,
+    BOOT_WALL_CLOCK,
+    BOOT_WORKDIR,
+    guest_commands,
+    judge_all,
+)
+from core.agentic_v2_substrate import REQUIRED_MICROVM_POLICY
+
+
+def _probe_output(**overrides: str) -> str:
+    lines = {
+        "interfaces": "lo",
+        "connect": "connect_probe=refused:OSError",
+        "mounts": "/dev/vda / ext4 ro,relatime 0 0",
+        "write": "rootfs_write=refused",
+        "memory": "MemTotal:        4014520 kB",
+        "env": "guest_env=clean",
+    }
+    lines.update(overrides)
+    return "\n".join(
+        [
+            "== network ==",
+            lines["interfaces"],
+            lines["connect"],
+            "== rootfs ==",
+            lines["mounts"],
+            lines["write"],
+            "== memory bound ==",
+            lines["memory"],
+            "== credentials ==",
+            "env_count=0",
+            lines["env"],
+            "",
+        ]
+    )
+
+
+def _watched(**overrides):
+    seen = {
+        "pid": 4242,
+        "real_uid": 999,
+        "expected_uid": 999,
+        "supplementary_groups": [],
+        "environment_seen": 3,
+        "canaries_in_environment": [],
+        "descriptors": {"0": "/dev/null", "1": "/dev/null", "2": "/dev/null"},
+        "descriptors_reaching_the_orchestrator": [],
+        "standard_descriptors": {
+            "0": "/dev/null",
+            "1": "/dev/null",
+            "2": "/dev/null",
+        },
+    }
+    seen.update(overrides)
+    return seen
+
+
+def _clean_sweep(**overrides):
+    """Evidence in which all seven rules held, before any override breaks one."""
+    evidence = {
+        "boots": {
+            BOOT_PROBES: {
+                "outcome": "booted",
+                "results": {"/out/stdout": _probe_output()},
+                "watched": _watched(),
+            },
+            BOOT_WORKDIR: {
+                "outcome": "booted",
+                "results": {
+                    "/out/stdout": (
+                        "quota_mib_configured=256\n"
+                        "dd: error writing '/work/gdpval-filler': No space left "
+                        "on device\nrc=1\n"
+                    )
+                },
+            },
+            BOOT_MEMORY: {
+                "outcome": "booted",
+                "results": {
+                    "/out/stdout": (
+                        "MemTotal:        4014520 kB\n"
+                        "dd: error writing '/dev/shm/gdpval-balloon': Cannot "
+                        "allocate memory\nrc=1\n"
+                    )
+                },
+            },
+            BOOT_WALL_CLOCK: {
+                "outcome": "stopped_by_the_deadline",
+                "stopped_by_the_deadline": True,
+                "ran_for_seconds": 45.04,
+                "deadline_seconds": 45,
+                "teardown": {"all_gone": True},
+            },
+        }
+    }
+    for boot, patch in overrides.items():
+        evidence["boots"][boot] = patch
+    return evidence
+
+
+def _verdict(judgement, attack_id):
+    return next(v for v in judgement["verdicts"] if v["id"] == attack_id)
+
+
+# --------------------------------------------------------------------------
+# the property the whole file exists for
+# --------------------------------------------------------------------------
+
+
+def test_nothing_at_all_stops_nothing_at_all():
+    """A run that produced no evidence is seven failures, not seven passes.
+
+    This is the shape of the mistake worth guarding: a guest that panicked on
+    boot leaves the same silence as a guest that was contained, and the only
+    thing separating them is which way the judge resolves an absence.
+    """
+    judgement = judge_all({})
+
+    assert judgement["stopped"] == 0
+    assert judgement["all_seven_stopped"] is False
+    assert len(judgement["escapes"]) == 7
+    for verdict in judgement["verdicts"]:
+        assert verdict["stopped"] is False
+        assert verdict["evidence"], "a verdict with no sentence behind it"
+
+
+@pytest.mark.parametrize("attack", ATTACKS, ids=lambda a: a["id"])
+def test_each_attack_fails_when_its_own_boot_produced_nothing(attack):
+    """Dropping one boot must fail that boot's attacks and no others.
+
+    Checked per attack rather than in aggregate, because a judge that reads the
+    wrong boot's output would still show seven verdicts and would still fail
+    when everything is missing — it would only be wrong in the case that matters.
+    """
+    evidence = _clean_sweep()
+    del evidence["boots"][attack["boot"]]
+
+    judgement = judge_all(evidence)
+    assert _verdict(judgement, attack["id"])["stopped"] is False
+
+
+def test_a_probe_that_did_not_report_is_not_a_probe_that_passed():
+    """An empty stdout from a machine that booted is still no observation.
+
+    The distinction matters because ``outcome: booted`` looks like success and
+    the attacks are judged on what came back, not on whether the machine ran.
+    """
+    judgement = judge_all(
+        _clean_sweep(
+            **{BOOT_PROBES: {"outcome": "booted", "results": {"/out/stdout": ""}}}
+        )
+    )
+
+    assert _verdict(judgement, "network")["stopped"] is False
+    assert _verdict(judgement, "read-only-root")["stopped"] is False
+
+
+def test_the_evidence_that_holds_says_all_seven_stopped():
+    judgement = judge_all(_clean_sweep())
+
+    assert judgement["all_seven_stopped"] is True
+    assert judgement["stopped"] == 7
+    assert judgement["escapes"] == []
+
+
+# --------------------------------------------------------------------------
+# each rule, broken one at a time
+# --------------------------------------------------------------------------
+
+
+def test_a_connection_that_opened_is_an_escape():
+    judgement = judge_all(
+        _clean_sweep(
+            **{
+                BOOT_PROBES: {
+                    "results": {
+                        "/out/stdout": _probe_output(connect="connect_probe=CONNECTED")
+                    },
+                    "watched": _watched(),
+                }
+            }
+        )
+    )
+    assert _verdict(judgement, "network")["stopped"] is False
+
+
+def test_an_interface_beyond_loopback_is_an_escape_even_with_no_connection():
+    """``network: none`` is about the device, not about whether it was used.
+
+    A guest handed a tap device that happened to reach nothing today is one
+    routing change away from reaching everything, and the rule says the device
+    is not there.
+    """
+    judgement = judge_all(
+        _clean_sweep(
+            **{
+                BOOT_PROBES: {
+                    "results": {"/out/stdout": _probe_output(interfaces="lo\neth0")},
+                    "watched": _watched(),
+                }
+            }
+        )
+    )
+    assert _verdict(judgement, "network")["stopped"] is False
+
+
+def test_a_root_that_refused_a_write_but_is_mounted_read_write_is_an_escape():
+    """The refusal alone is a permission bit, and a permission bit is not the rule.
+
+    A root the kernel mounted read-write is one ``mount -o remount,rw`` from
+    being writable, and the guest is root inside its own machine.
+    """
+    judgement = judge_all(
+        _clean_sweep(
+            **{
+                BOOT_PROBES: {
+                    "results": {
+                        "/out/stdout": _probe_output(
+                            mounts="/dev/vda / ext4 rw,relatime 0 0"
+                        )
+                    },
+                    "watched": _watched(),
+                }
+            }
+        )
+    )
+    assert _verdict(judgement, "read-only-root")["stopped"] is False
+
+
+def test_a_write_that_succeeded_on_the_root_is_an_escape():
+    judgement = judge_all(
+        _clean_sweep(
+            **{
+                BOOT_PROBES: {
+                    "results": {
+                        "/out/stdout": _probe_output(write="rootfs_write=SUCCEEDED")
+                    },
+                    "watched": _watched(),
+                }
+            }
+        )
+    )
+    assert _verdict(judgement, "read-only-root")["stopped"] is False
+
+
+def test_a_fill_past_the_quota_that_succeeded_is_an_escape():
+    judgement = judge_all(
+        _clean_sweep(
+            **{
+                BOOT_WORKDIR: {
+                    "results": {"/out/stdout": "quota_mib_configured=256\nrc=0\n"}
+                }
+            }
+        )
+    )
+    assert _verdict(judgement, "workdir-quota")["stopped"] is False
+
+
+def test_a_guest_that_sees_more_memory_than_the_rule_allows_is_an_escape():
+    """Read before the allocation, because the allocation can fail for other reasons.
+
+    A ``dd`` that failed on a machine which can see 32 GiB says nothing about
+    ``memory_mib``; what says something is the total the guest was given.
+    """
+    judgement = judge_all(
+        _clean_sweep(
+            **{
+                BOOT_MEMORY: {
+                    "results": {
+                        "/out/stdout": "MemTotal:       32000000 kB\nrc=1\n"
+                    }
+                }
+            }
+        )
+    )
+    assert _verdict(judgement, "memory")["stopped"] is False
+
+
+def test_an_allocation_past_the_bound_that_succeeded_is_an_escape():
+    judgement = judge_all(
+        _clean_sweep(
+            **{
+                BOOT_MEMORY: {
+                    "results": {"/out/stdout": "MemTotal: 4014520 kB\nrc=0\n"}
+                }
+            }
+        )
+    )
+    assert _verdict(judgement, "memory")["stopped"] is False
+
+
+def test_a_hanging_guest_that_finished_on_its_own_did_not_test_the_deadline():
+    judgement = judge_all(
+        _clean_sweep(
+            **{
+                BOOT_WALL_CLOCK: {
+                    "outcome": "booted",
+                    "stopped_by_the_deadline": False,
+                    "teardown": {"all_gone": True},
+                }
+            }
+        )
+    )
+    assert _verdict(judgement, "wall-clock")["stopped"] is False
+
+
+def test_a_deadline_that_fired_and_left_the_chroot_behind_is_not_a_stop():
+    """The work disk lives in that chroot, and it holds whatever the guest wrote."""
+    judgement = judge_all(
+        _clean_sweep(
+            **{
+                BOOT_WALL_CLOCK: {
+                    "outcome": "stopped_by_the_deadline",
+                    "stopped_by_the_deadline": True,
+                    "ran_for_seconds": 45.0,
+                    "teardown": {"all_gone": False},
+                }
+            }
+        )
+    )
+    assert _verdict(judgement, "wall-clock")["stopped"] is False
+
+
+# --------------------------------------------------------------------------
+# the two that the guest cannot answer
+# --------------------------------------------------------------------------
+
+
+def test_a_firecracker_process_still_running_as_root_is_an_escape():
+    judgement = judge_all(
+        _clean_sweep(
+            **{
+                BOOT_PROBES: {
+                    "results": {"/out/stdout": _probe_output()},
+                    "watched": _watched(real_uid=0),
+                }
+            }
+        )
+    )
+    verdict = _verdict(judgement, "privileged-user")
+    assert verdict["stopped"] is False
+    assert "root" in verdict["evidence"]
+
+
+def test_a_guest_running_as_root_inside_its_own_machine_is_not_the_rule():
+    """PID 1 is uid 0 in every one of these guests, including the ones that pass.
+
+    If the judge looked at the guest's uid this would fail, and the rule would
+    be untestable — which is the point of reading it from the host instead.
+    """
+    guest_says_root = _probe_output()
+    judgement = judge_all(
+        _clean_sweep(
+            **{
+                BOOT_PROBES: {
+                    "results": {"/out/stdout": guest_says_root},
+                    "watched": _watched(real_uid=999),
+                }
+            }
+        )
+    )
+    assert _verdict(judgement, "privileged-user")["stopped"] is True
+
+
+def test_supplementary_groups_on_the_jailed_process_are_an_escape():
+    judgement = judge_all(
+        _clean_sweep(
+            **{
+                BOOT_PROBES: {
+                    "results": {"/out/stdout": _probe_output()},
+                    "watched": _watched(supplementary_groups=[27]),
+                }
+            }
+        )
+    )
+    assert _verdict(judgement, "privileged-user")["stopped"] is False
+
+
+def test_a_canary_in_the_processs_environment_is_an_escape():
+    judgement = judge_all(
+        _clean_sweep(
+            **{
+                BOOT_PROBES: {
+                    "results": {"/out/stdout": _probe_output()},
+                    "watched": _watched(
+                        canaries_in_environment=["GDPVAL_C3_CANARY_TOKEN"]
+                    ),
+                }
+            }
+        )
+    )
+    assert _verdict(judgement, "inherited-credentials")["stopped"] is False
+
+
+def test_a_clean_environment_with_the_console_still_attached_is_an_escape():
+    """The half that a dropped ``--daemonize`` would silently reopen.
+
+    The jailer wipes the environment whatever else is passed to it, so an
+    attack that checked only the environment would pass on a launcher that had
+    lost the flag — and with the flag gone the guest's console is whatever the
+    orchestrator was writing to.
+    """
+    attached = {"0": "/dev/null", "1": "/var/log/orchestrator.log", "2": "/dev/null"}
+    judgement = judge_all(
+        _clean_sweep(
+            **{
+                BOOT_PROBES: {
+                    "results": {"/out/stdout": _probe_output()},
+                    "watched": _watched(
+                        standard_descriptors=attached, descriptors=attached
+                    ),
+                }
+            }
+        )
+    )
+    verdict = _verdict(judgement, "inherited-credentials")
+    assert verdict["stopped"] is False
+    assert "daemonize" in verdict["evidence"]
+
+
+def test_a_descriptor_reaching_the_orchestrator_is_an_escape():
+    judgement = judge_all(
+        _clean_sweep(
+            **{
+                BOOT_PROBES: {
+                    "results": {"/out/stdout": _probe_output()},
+                    "watched": _watched(
+                        descriptors_reaching_the_orchestrator=[
+                            "9 -> /var/tmp/gdpval-c3/c3-canary-token.txt"
+                        ]
+                    ),
+                }
+            }
+        )
+    )
+    assert _verdict(judgement, "inherited-credentials")["stopped"] is False
+
+
+def test_the_environment_alone_is_not_enough_to_pass_the_credential_rule():
+    judgement = judge_all(
+        _clean_sweep(
+            **{
+                BOOT_PROBES: {
+                    "results": {"/out/stdout": _probe_output()},
+                    "watched": _watched(descriptors=None, standard_descriptors=None),
+                }
+            }
+        )
+    )
+    verdict = _verdict(judgement, "inherited-credentials")
+    assert verdict["stopped"] is False
+    assert "environment alone is not the rule" in verdict["evidence"]
+
+
+def test_a_credential_shaped_name_inside_the_guest_is_an_escape():
+    judgement = judge_all(
+        _clean_sweep(
+            **{
+                BOOT_PROBES: {
+                    "results": {
+                        "/out/stdout": _probe_output(
+                            env="AZURE_OPENAI_API_KEY=sk-x\nguest_env=CARRIES SOMETHING"
+                        )
+                    },
+                    "watched": _watched(),
+                }
+            }
+        )
+    )
+    assert _verdict(judgement, "inherited-credentials")["stopped"] is False
+
+
+# --------------------------------------------------------------------------
+# the attacks themselves, and what they are sized against
+# --------------------------------------------------------------------------
+
+
+def test_every_verdict_names_the_rule_it_enforced_and_that_rules_value():
+    """"Stopped" without a rule beside it is an assertion rather than a finding."""
+    judgement = judge_all(_clean_sweep())
+
+    for verdict in judgement["verdicts"]:
+        assert verdict["rule_it_enforced"] in REQUIRED_MICROVM_POLICY
+        assert verdict["rule_value"] == REQUIRED_MICROVM_POLICY[verdict["rule_it_enforced"]]
+
+
+def test_the_seven_attacks_cover_seven_different_rules():
+    rules = [attack["rule"] for attack in ATTACKS]
+    assert len(ATTACKS) == 7
+    assert len(set(rules)) == 7
+
+
+def test_the_overshoot_is_taken_from_the_rule_and_not_written_as_a_number():
+    """A raised bound must not leave an attack probing below it.
+
+    An attack that stops short of the limit passes without the limit ever being
+    reached, and it passes more comfortably the more the bound is raised.
+    """
+    raised = dict(REQUIRED_MICROVM_POLICY) | {
+        "workdir_quota_mib": 1024,
+        "memory_mib": 8192,
+    }
+    commands = guest_commands(raised)
+
+    assert "count=2048" in commands[BOOT_WORKDIR]
+    assert "count=12288" in commands[BOOT_MEMORY]
+    assert "quota_mib_configured=1024" in commands[BOOT_WORKDIR]
+
+
+def test_the_quota_attack_removes_its_filler_before_the_guest_ends():
+    """The work disk is the only channel, and this attack's job is to fill it.
+
+    A guest that finishes with the disk full cannot write the answer, and the
+    absent answer would be judged a failure — which would be right, and would
+    also be the attack destroying its own evidence rather than the rule holding.
+    """
+    fill = guest_commands()[BOOT_WORKDIR]
+    assert "rm -f /work/gdpval-filler" in fill
+    assert fill.index("rm -f /work/gdpval-filler") < fill.rindex("echo")
+
+
+def test_the_probe_boot_holds_itself_open_long_enough_to_be_watched():
+    """C2's guest was gone in 1.269 seconds. Two of the attacks need it alive."""
+    probes = guest_commands()[BOOT_PROBES]
+    assert "sleep 8" in probes
+
+
+def test_the_probe_boot_does_not_reach_for_anything_the_policy_closed():
+    probes = guest_commands()[BOOT_PROBES]
+    for word in ("vsock", "curl", "wget", "ssh", "nc "):
+        assert word not in probes

--- a/batch-runner/tests/test_agentic_v2_first_boot.py
+++ b/batch-runner/tests/test_agentic_v2_first_boot.py
@@ -1,0 +1,438 @@
+"""Running the plan C1 wrote, and the four different ways it can produce nothing.
+
+The launcher's whole job is to add nothing. Every argument it runs comes out of
+the plan, and the plan has already refused anything the policy does not permit —
+so the interesting tests here are not "does it start a machine" but "does it
+start *only* what it was handed", and "when no result comes back, does it say
+which of the several reasons it was".
+
+That last one matters more than it looks. With no network, no vsock and a
+console pointed at ``/dev/null``, a guest that panicked on its second
+instruction and a guest that ran happily and wrote nothing leave the host
+exactly the same evidence: an empty work disk. Collapsing those into one
+"failed" would make the next step guesswork, so the outcomes are separate and
+each is reached by a different observation.
+
+Nothing here boots anything. This box runs kernel 3.10 and cannot.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from core.agentic_v2_first_boot import (
+    WORK_DISK_RESULTS,
+    BootRefused,
+    first_boot,
+    place_the_images,
+    unjailed_image_check,
+)
+from core.agentic_v2_microvm_launch import build_launch_plan
+
+
+@pytest.fixture
+def plan(tmp_path, monkeypatch):
+    """A real plan from the real builder, over files that exist."""
+    for name in ("firecracker", "vmlinux", "rootfs.ext4", "work.ext4"):
+        path = tmp_path / name
+        path.write_bytes(b"not really an image, but a readable file")
+        path.chmod(0o755)
+    monkeypatch.setattr(os, "chown", lambda *a, **k: None)
+    return build_launch_plan(
+        vm_id="test-boot",
+        firecracker_binary=tmp_path / "firecracker",
+        kernel_path=tmp_path / "vmlinux",
+        rootfs_path=tmp_path / "rootfs.ext4",
+        work_disk_path=tmp_path / "work.ext4",
+        uid=997,
+        gid=997,
+        vcpu_count=1,
+        cgroup_version=2,
+        chroot_base=tmp_path / "jail",
+    )
+
+
+class _Clock:
+    def __init__(self):
+        self.t = 0.0
+
+    def now(self) -> float:
+        return self.t
+
+    def sleep(self, seconds: float) -> None:
+        self.t += seconds
+
+
+def _boot(plan, tmp_path, monkeypatch, *, jailer, running, results):
+    """Run :func:`first_boot` with the host replaced and the clock in hand."""
+    clock = _Clock()
+    monkeypatch.setattr("core.agentic_v2_first_boot._run", jailer)
+    monkeypatch.setattr("core.agentic_v2_first_boot._still_running", running)
+    monkeypatch.setattr(
+        "core.agentic_v2_first_boot.files_out_of_work_disk",
+        lambda image, names, **kw: dict(results),
+    )
+    return first_boot(
+        plan,
+        jailer_binary="jailer",
+        kernel=tmp_path / "vmlinux",
+        rootfs=tmp_path / "rootfs.ext4",
+        work_disk=tmp_path / "work.ext4",
+        uid=997,
+        gid=997,
+        now=clock.now,
+        sleep=clock.sleep,
+    )
+
+
+def _writes_the_pid_file(plan, pid=4242):
+    def jailer(argv, timeout=300.0):
+        Path(plan["host_side"]["pid_file"]).write_text(f"{pid}\n")
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    return jailer
+
+
+def _finished(*, exit_status="0"):
+    results = {name: None for name in WORK_DISK_RESULTS}
+    results["/out/stdout"] = "this ran inside the guest\n"
+    results["/out/exit_status"] = exit_status
+    results["/out/init_reached_the_end"] = "done\n"
+    return results
+
+
+# --------------------------------------------------------------------------
+# the plan is the only source of arguments
+# --------------------------------------------------------------------------
+
+
+def test_something_that_is_not_a_plan_from_the_builder_is_not_run(tmp_path):
+    with pytest.raises(BootRefused, match="not a launch plan"):
+        first_boot(
+            {"jailer": {"argv": ["--id", "anything"]}},
+            kernel="k",
+            rootfs="r",
+            work_disk="w",
+            uid=1,
+            gid=1,
+        )
+
+
+def test_a_plan_edited_after_it_was_built_is_refused(plan):
+    """Its hash is over its own contents, so an edit anywhere shows up here.
+
+    The refusals live in the builder. A plan changed between being built and
+    being run has been round the refusals rather than through them, and the
+    arguments in it are ones nobody checked.
+    """
+    tampered = dict(plan)
+    tampered["jailer"] = dict(plan["jailer"])
+    tampered["jailer"]["argv"] = [
+        arg for arg in plan["jailer"]["argv"] if arg != "--new-pid-ns"
+    ]
+
+    with pytest.raises(BootRefused, match="changed after it was built"):
+        first_boot(tampered, kernel="k", rootfs="r", work_disk="w", uid=1, gid=1)
+
+
+def test_the_launcher_passes_the_plans_arguments_and_adds_none(
+    plan, tmp_path, monkeypatch
+):
+    """The one structural guarantee this module makes about itself.
+
+    If a rule has to be applied differently, the change belongs in the builder
+    where the refusals are. An argument appearing here instead would be one the
+    policy never saw, and it would be invisible in the plan the artefact records.
+    """
+    seen: list[list[str]] = []
+
+    def jailer(argv, timeout=300.0):
+        seen.append(list(argv))
+        Path(plan["host_side"]["pid_file"]).write_text("4242\n")
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    _boot(
+        plan,
+        tmp_path,
+        monkeypatch,
+        jailer=jailer,
+        running=lambda pid: False,
+        results=_finished(),
+    )
+
+    assert seen == [["jailer", *plan["jailer"]["argv"]]]
+
+
+# --------------------------------------------------------------------------
+# the images go where the plan says, with the modes the plan implies
+# --------------------------------------------------------------------------
+
+
+def test_only_the_work_disk_is_writable_by_the_account_the_jailer_drops_to(
+    plan, tmp_path, monkeypatch
+):
+    """``rootfs: read-only`` would otherwise hold only while the guest agreed.
+
+    Firecracker's ``is_read_only`` and the kernel's ``ro`` both describe what
+    the guest is told. The file mode is the part that does not depend on the
+    guest, and it is the reason the two images the guest must not change are
+    owned by root and the one it must change is not.
+    """
+    owners: dict[str, tuple[int, int]] = {}
+    monkeypatch.setattr(
+        os, "chown", lambda path, uid, gid: owners.__setitem__(str(path), (uid, gid))
+    )
+
+    placement = place_the_images(
+        plan,
+        kernel=tmp_path / "vmlinux",
+        rootfs=tmp_path / "rootfs.ext4",
+        work_disk=tmp_path / "work.ext4",
+        uid=997,
+        gid=997,
+    )
+
+    by_path = {item["in_jail"]: item for item in placement["placed"]}
+    assert by_path["/vmlinux"]["mode"] == "0o444"
+    assert by_path["/rootfs.ext4"]["mode"] == "0o444"
+    assert by_path["/work.ext4"]["mode"] == "0o644"
+    assert by_path["/work.ext4"]["owned_by_the_jailed_user"] is True
+    assert by_path["/rootfs.ext4"]["owned_by_the_jailed_user"] is False
+
+    chroot = placement["chroot_dir"]
+    assert owners[f"{chroot}/rootfs.ext4"] == (0, 0)
+    assert owners[f"{chroot}/work.ext4"] == (997, 997)
+
+
+def test_the_configuration_placed_in_the_jail_is_the_plans_own(
+    plan, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(os, "chown", lambda *a, **k: None)
+    placement = place_the_images(
+        plan,
+        kernel=tmp_path / "vmlinux",
+        rootfs=tmp_path / "rootfs.ext4",
+        work_disk=tmp_path / "work.ext4",
+        uid=997,
+        gid=997,
+    )
+    written = json.loads(
+        (Path(placement["chroot_dir"]) / "vmconfig.json").read_text()
+    )
+    assert written == plan["firecracker"]["config"]
+    assert written["network-interfaces"] == []
+    assert "init=" in written["boot-source"]["boot_args"]
+
+
+# --------------------------------------------------------------------------
+# four ways to produce no result, told apart
+# --------------------------------------------------------------------------
+
+
+def test_a_machine_that_ran_and_answered_is_recorded_with_its_exit_status(
+    plan, tmp_path, monkeypatch
+):
+    result = _boot(
+        plan,
+        tmp_path,
+        monkeypatch,
+        jailer=_writes_the_pid_file(plan),
+        running=lambda pid: False,
+        results=_finished(exit_status="0"),
+    )
+
+    assert result["outcome"] == "booted"
+    assert result["command_exit_status"] == 0
+    assert result["results"]["/out/stdout"] == "this ran inside the guest\n"
+    assert result["stopped_by_the_deadline"] is False
+
+
+def test_a_command_that_failed_inside_a_working_guest_is_still_a_boot(
+    plan, tmp_path, monkeypatch
+):
+    """The command's exit status is not the machine's outcome.
+
+    Conflating them is how an environment defect gets recorded as a model
+    failure later, which is the distinction the whole stage is being built to
+    keep.
+    """
+    result = _boot(
+        plan,
+        tmp_path,
+        monkeypatch,
+        jailer=_writes_the_pid_file(plan),
+        running=lambda pid: False,
+        results=_finished(exit_status="17"),
+    )
+
+    assert result["outcome"] == "booted"
+    assert result["command_exit_status"] == 17
+
+
+def test_a_jailer_that_never_wrote_a_pid_file_never_started(
+    plan, tmp_path, monkeypatch
+):
+    def jailer(argv, timeout=300.0):
+        return subprocess.CompletedProcess(argv, 1, "", "jailer: mknod failed\n")
+
+    result = _boot(
+        plan,
+        tmp_path,
+        monkeypatch,
+        jailer=jailer,
+        running=lambda pid: False,
+        results={name: None for name in WORK_DISK_RESULTS},
+    )
+
+    assert result["outcome"] == "never_started"
+    assert result["pid_file"]["appeared"] is False
+    assert "mknod failed" in result["jailer"]["stderr"]
+
+
+def test_a_guest_that_booted_and_wrote_nothing_is_its_own_outcome(
+    plan, tmp_path, monkeypatch
+):
+    """Distinct from a machine that never started, and it has to be.
+
+    One means the jail is wrong; the other means the image is. They are fixed in
+    different places and the host gives the same silence for both, which is what
+    the separate unjailed check exists to break.
+    """
+    result = _boot(
+        plan,
+        tmp_path,
+        monkeypatch,
+        jailer=_writes_the_pid_file(plan),
+        running=lambda pid: False,
+        results={name: None for name in WORK_DISK_RESULTS},
+    )
+
+    assert result["outcome"] == "booted_but_wrote_nothing"
+    assert result["pid_file"]["appeared"] is True
+    assert result["command_exit_status"] is None
+
+
+def test_a_machine_that_overruns_is_killed_and_says_so(plan, tmp_path, monkeypatch):
+    """The deadline is the only thing between a wedged guest and a host that waits.
+
+    ``wall_clock_seconds`` is 1,200 in the policy and the fake clock reaches it
+    without anybody waiting twenty minutes. What is being checked is that the
+    launcher stops the machine and records *why* it stopped, rather than
+    returning the same empty result a quiet guest returns.
+    """
+    killed: list[int] = []
+    monkeypatch.setattr(
+        os, "kill", lambda pid, signal_number: killed.append(pid)
+    )
+
+    result = _boot(
+        plan,
+        tmp_path,
+        monkeypatch,
+        jailer=_writes_the_pid_file(plan),
+        running=lambda pid: True,
+        results={name: None for name in WORK_DISK_RESULTS},
+    )
+
+    assert result["outcome"] == "stopped_by_the_deadline"
+    assert result["stopped_by_the_deadline"] is True
+    assert killed == [4242]
+    assert result["ran_for_seconds"] >= result["deadline_seconds"]
+
+
+# --------------------------------------------------------------------------
+# what is left behind, and the check that is not the boundary
+# --------------------------------------------------------------------------
+
+
+def test_the_chroot_is_destroyed_and_the_result_says_whether_it_worked(
+    plan, tmp_path, monkeypatch
+):
+    """Part of ``workdir: ephemeral-quota`` rather than tidiness.
+
+    A chroot that survives holds the work disk, which holds whatever the guest
+    wrote — so "removed" is reported per path instead of assumed from the fact
+    that a removal was attempted.
+    """
+    result = _boot(
+        plan,
+        tmp_path,
+        monkeypatch,
+        jailer=_writes_the_pid_file(plan),
+        running=lambda pid: False,
+        results=_finished(),
+    )
+
+    assert result["teardown"]["all_gone"] is True
+    assert not Path(plan["host_side"]["chroot_dir"]).exists()
+    assert Path(str(tmp_path / "work.ext4") + ".returned").exists(), (
+        "the work disk is the only channel, so it comes back before the jail goes"
+    )
+
+
+def test_the_result_names_the_single_channel_it_read_from(plan, tmp_path, monkeypatch):
+    result = _boot(
+        plan,
+        tmp_path,
+        monkeypatch,
+        jailer=_writes_the_pid_file(plan),
+        running=lambda pid: False,
+        results=_finished(),
+    )
+    assert "work disk" in result["channel"]
+    assert "/dev/null" in result["channel"]
+
+
+def test_the_unjailed_check_says_it_is_not_the_contained_run(tmp_path, monkeypatch):
+    """It applies none of the containment, and every field it returns says so.
+
+    It exists only to tell a broken image from a broken jail. A caller that
+    reads it as evidence of isolation is reading it wrong, and the wording is
+    the only thing that stops that, so the wording is tested.
+    """
+    monkeypatch.setattr(
+        "core.agentic_v2_first_boot._run",
+        lambda argv, timeout=300.0: subprocess.CompletedProcess(
+            argv, 0, "Guest-boot-time = 41 ms\n", ""
+        ),
+    )
+
+    check = unjailed_image_check(
+        firecracker_binary="firecracker",
+        kernel=tmp_path / "vmlinux",
+        rootfs=tmp_path / "rootfs.ext4",
+        work_disk=tmp_path / "work.ext4",
+        workdir=tmp_path / "scratch",
+    )
+
+    assert check["this_is_not_the_contained_run"] is True
+    assert check["applied_containment"] is False
+    assert "no rule was applied" in check["what_it_proves"]
+    assert "Guest-boot-time" in check["console_tail"]
+
+
+def test_the_unjailed_check_survives_a_guest_that_never_exits(tmp_path, monkeypatch):
+    """A hung guest here is a normal outcome and must not take the run with it."""
+
+    def hangs(argv, timeout=300.0):
+        raise subprocess.TimeoutExpired(argv, timeout, output=b"[    0.0] Linux\n")
+
+    monkeypatch.setattr("core.agentic_v2_first_boot._run", hangs)
+
+    check = unjailed_image_check(
+        firecracker_binary="firecracker",
+        kernel=tmp_path / "vmlinux",
+        rootfs=tmp_path / "rootfs.ext4",
+        work_disk=tmp_path / "work.ext4",
+        workdir=tmp_path / "scratch",
+        seconds=1.0,
+    )
+
+    assert check["timed_out"] is True
+    assert check["returncode"] is None
+    assert "Linux" in check["console_tail"]

--- a/batch-runner/tests/test_agentic_v2_guest_image.py
+++ b/batch-runner/tests/test_agentic_v2_guest_image.py
@@ -1,0 +1,369 @@
+"""What the two guest images have to be before anything boots from them.
+
+The tests here are mostly refusals. That is the shape of the module: a rootfs
+assembled from an image whose layers were not checked, or a kernel that is not
+the object the pin names, is not a weaker version of the containment — it is a
+guest whose contents nobody knows, and every rule underneath it is then a rule
+about something unidentified.
+
+The disclaimers get tests of their own, which is unusual and deliberate. A hash
+printed next to the word "verified" reads as a signature check to anybody who
+does not already know that Firecracker's CI bucket publishes neither a checksum
+nor a signature. The sentence that says otherwise is load-bearing, so it is held
+in place the same way a limit would be.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from core.agentic_v2_guest_image import (
+    GUEST_INIT,
+    GUEST_INIT_PATH,
+    PINNED_GUEST_KERNEL,
+    ImageRefused,
+    add_guest_init,
+    anonymous_pull_token,
+    ext4_image_arguments,
+    fetch_pinned_kernel,
+    pull_image_by_digest,
+    require_same_kernel,
+    rootfs_size_mib,
+    unpack_layers,
+)
+
+
+def _digest(body: bytes) -> str:
+    return "sha256:" + hashlib.sha256(body).hexdigest()
+
+
+def _layer(entries: dict[str, bytes | None], tmp_path: Path, name: str) -> dict:
+    """A gzip-free tar layer. ``None`` as a value means a directory."""
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w") as archive:
+        for member_name, content in entries.items():
+            info = tarfile.TarInfo(member_name)
+            if content is None:
+                info.type = tarfile.DIRTYPE
+                archive.addfile(info)
+            else:
+                info.size = len(content)
+                archive.addfile(info, io.BytesIO(content))
+    path = tmp_path / name
+    path.write_bytes(buffer.getvalue())
+    return {"digest": _digest(buffer.getvalue()), "path": path.as_posix()}
+
+
+class _Registry:
+    """Enough of a registry to answer by digest, and to be told to lie."""
+
+    def __init__(self, *, manifests: dict[str, bytes], blobs: dict[str, bytes]):
+        self.manifests = manifests
+        self.blobs = blobs
+        self.asked_for: list[str] = []
+
+    def __call__(self, url: str, headers=None) -> bytes:
+        self.asked_for.append(url)
+        if "/token" in url:
+            return json.dumps({"token": "anonymous-and-not-a-credential"}).encode()
+        reference = url.rsplit("/", 1)[1]
+        if "/manifests/" in url:
+            return self.manifests[reference]
+        return self.blobs[reference]
+
+
+def _index(child_digest: str, *, architecture: str = "amd64") -> bytes:
+    return json.dumps(
+        {
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.index.v1+json",
+            "manifests": [
+                {
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "digest": child_digest,
+                    "platform": {"architecture": architecture, "os": "linux"},
+                }
+            ],
+        }
+    ).encode()
+
+
+def _manifest(layers: list[dict]) -> bytes:
+    return json.dumps(
+        {
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "layers": [
+                {
+                    "digest": layer["digest"],
+                    "mediaType": "application/vnd.oci.image.layer.v1.tar",
+                    "size": Path(layer["path"]).stat().st_size,
+                }
+                for layer in layers
+            ],
+        }
+    ).encode()
+
+
+# --------------------------------------------------------------------------
+# the kernel, and the three things about it that are easy to lose
+# --------------------------------------------------------------------------
+
+
+def test_the_pinned_kernel_is_one_exact_key_and_not_a_search():
+    assert PINNED_GUEST_KERNEL["key"].endswith("vmlinux-6.1.141")
+    assert PINNED_GUEST_KERNEL["url"].startswith("https://")
+    assert PINNED_GUEST_KERNEL["key"] in PINNED_GUEST_KERNEL["url"]
+
+
+def test_the_kernel_reading_refuses_to_claim_upstream_vouched_for_it(tmp_path):
+    body = b"k" * PINNED_GUEST_KERNEL["size_bytes"]
+    reading = fetch_pinned_kernel(tmp_path / "vmlinux", fetch=lambda url, h: body)
+
+    assert reading["vouched_for_by_upstream"] is False
+    assert reading["sha256"] == hashlib.sha256(body).hexdigest()
+    explanation = reading["what_the_digest_means"]
+    assert "not a signature" in explanation
+    assert "computed here" in explanation
+    assert reading["source"]["upstream_publishes_a_signature"] is False
+    assert reading["source"]["upstream_publishes_a_checksum"] is False
+
+
+def test_the_lapsed_support_window_travels_with_the_pin(tmp_path):
+    """Recorded as lapsed rather than pinned in silence.
+
+    Firecracker's kernel policy at v1.13.1 validates two guest kernels and both
+    of their minimum end-of-support dates are in the past. Using one anyway is a
+    decision; using one without saying so is an omission, and this is the field
+    that makes it the first.
+    """
+    reading = fetch_pinned_kernel(
+        tmp_path / "vmlinux",
+        fetch=lambda url, h: b"k" * PINNED_GUEST_KERNEL["size_bytes"],
+    )
+    assert reading["source"]["support_window_has_lapsed"] is True
+    assert reading["source"]["minimum_end_of_support"] == "2026-09-02"
+
+
+def test_a_kernel_of_the_wrong_length_is_not_the_object_the_key_names(tmp_path):
+    with pytest.raises(ImageRefused, match="one exact object"):
+        fetch_pinned_kernel(tmp_path / "vmlinux", fetch=lambda url, h: b"short")
+
+
+def test_a_kernel_that_changed_under_its_key_is_refused(tmp_path):
+    reading = fetch_pinned_kernel(
+        tmp_path / "vmlinux",
+        fetch=lambda url, h: b"k" * PINNED_GUEST_KERNEL["size_bytes"],
+    )
+    require_same_kernel(reading, reading["sha256"])
+    with pytest.raises(ImageRefused, match="moving target"):
+        require_same_kernel(reading, "0" * 64)
+
+
+# --------------------------------------------------------------------------
+# the image, where every blob is checked against the name it arrived under
+# --------------------------------------------------------------------------
+
+
+def test_an_index_digest_is_exact_but_the_artefact_still_names_the_child(tmp_path):
+    """An index digest does not say which of its children was unpacked.
+
+    ``parent.lock.json`` pins the index. That is a reproducible pin, so the
+    temptation is to record only it — but a reader of the artefact wants to know
+    which architecture booted, and the index digest cannot tell them.
+    """
+    layer = _layer({"etc/hostname": b"guest\n"}, tmp_path, "layer0.tar")
+    manifest = _manifest([layer])
+    index = _index(_digest(manifest))
+    registry = _Registry(
+        manifests={_digest(index): index, _digest(manifest): manifest},
+        blobs={layer["digest"]: Path(layer["path"]).read_bytes()},
+    )
+
+    pulled = pull_image_by_digest(
+        "owner/image", _digest(index), tmp_path / "oci", fetch=registry
+    )
+
+    assert pulled["pinned_digest"] == _digest(index)
+    assert pulled["pinned_digest_is_an_index"] is True
+    assert pulled["manifest_digest"] == _digest(manifest)
+    assert pulled["manifest_digest"] != pulled["pinned_digest"]
+    assert pulled["layer_count"] == 1
+
+
+def test_a_manifest_that_does_not_hash_to_its_own_name_is_refused(tmp_path):
+    layer = _layer({"a": b"a"}, tmp_path, "layer0.tar")
+    manifest = _manifest([layer])
+    registry = _Registry(
+        manifests={"sha256:" + "1" * 64: manifest},
+        blobs={layer["digest"]: Path(layer["path"]).read_bytes()},
+    )
+    with pytest.raises(ImageRefused, match="pinning by digest"):
+        pull_image_by_digest(
+            "owner/image", "sha256:" + "1" * 64, tmp_path / "oci", fetch=registry
+        )
+
+
+def test_a_layer_that_does_not_hash_to_its_own_name_is_refused(tmp_path):
+    layer = _layer({"a": b"a"}, tmp_path, "layer0.tar")
+    manifest = _manifest([layer])
+    registry = _Registry(
+        manifests={_digest(manifest): manifest},
+        blobs={layer["digest"]: b"something else entirely"},
+    )
+    with pytest.raises(ImageRefused, match="nothing from this image is used"):
+        pull_image_by_digest(
+            "owner/image", _digest(manifest), tmp_path / "oci", fetch=registry
+        )
+
+
+def test_an_index_with_no_manifest_for_the_platform_is_refused(tmp_path):
+    layer = _layer({"a": b"a"}, tmp_path, "layer0.tar")
+    manifest = _manifest([layer])
+    index = _index(_digest(manifest), architecture="arm64")
+    registry = _Registry(
+        manifests={_digest(index): index, _digest(manifest): manifest},
+        blobs={layer["digest"]: Path(layer["path"]).read_bytes()},
+    )
+    with pytest.raises(ImageRefused, match="names 0 manifests"):
+        pull_image_by_digest(
+            "owner/image", _digest(index), tmp_path / "oci", fetch=registry
+        )
+
+
+def test_a_manifest_with_no_layers_has_no_rootfs_in_it(tmp_path):
+    manifest = _manifest([])
+    registry = _Registry(manifests={_digest(manifest): manifest}, blobs={})
+    with pytest.raises(ImageRefused, match="no layers"):
+        pull_image_by_digest(
+            "owner/image", _digest(manifest), tmp_path / "oci", fetch=registry
+        )
+
+
+def test_the_pull_token_is_anonymous_and_is_not_a_credential(tmp_path):
+    registry = _Registry(manifests={}, blobs={})
+    assert anonymous_pull_token("owner/image", fetch=registry).startswith("anonymous")
+    assert any("scope=repository:owner/image:pull" in url for url in registry.asked_for)
+
+
+# --------------------------------------------------------------------------
+# unpacking, where a skipped whiteout leaves a file the image says is not there
+# --------------------------------------------------------------------------
+
+
+def test_layers_are_applied_in_order_and_later_ones_win(tmp_path):
+    first = _layer({"etc/version": b"one\n"}, tmp_path, "l0.tar")
+    second = _layer({"etc/version": b"two\n"}, tmp_path, "l1.tar")
+
+    report = unpack_layers([first, second], tmp_path / "root")
+
+    assert (tmp_path / "root" / "etc" / "version").read_bytes() == b"two\n"
+    assert report["layers_applied_in_order"] == [first["digest"], second["digest"]]
+
+
+def test_a_whiteout_removes_what_an_earlier_layer_put_there(tmp_path):
+    first = _layer({"usr/secret": b"still here\n"}, tmp_path, "l0.tar")
+    second = _layer({"usr/.wh.secret": b""}, tmp_path, "l1.tar")
+
+    report = unpack_layers([first, second], tmp_path / "root")
+
+    assert not (tmp_path / "root" / "usr" / "secret").exists()
+    assert not (tmp_path / "root" / "usr" / ".wh.secret").exists()
+    assert report["whiteouts_honoured"] == 1
+
+
+def test_an_opaque_whiteout_empties_the_directory_it_sits_in(tmp_path):
+    first = _layer(
+        {"var/cache": None, "var/cache/a": b"a\n", "var/cache/b": b"b\n"},
+        tmp_path,
+        "l0.tar",
+    )
+    second = _layer({"var/cache/.wh..wh..opq": b""}, tmp_path, "l1.tar")
+
+    unpack_layers([first, second], tmp_path / "root")
+
+    assert (tmp_path / "root" / "var" / "cache").is_dir()
+    assert list((tmp_path / "root" / "var" / "cache").iterdir()) == []
+
+
+def test_a_layer_that_climbs_out_of_the_root_is_refused_not_filtered(tmp_path):
+    escaping = _layer({"../outside": b"no\n"}, tmp_path, "l0.tar")
+    with pytest.raises(ImageRefused, match="points outside"):
+        unpack_layers([escaping], tmp_path / "root")
+    assert not (tmp_path / "outside").exists()
+
+
+def test_an_absolute_path_in_a_layer_is_refused(tmp_path):
+    absolute = _layer({"/etc/shadow": b"no\n"}, tmp_path, "l0.tar")
+    with pytest.raises(ImageRefused, match="absolute path"):
+        unpack_layers([absolute], tmp_path / "root")
+
+
+# --------------------------------------------------------------------------
+# the one added file, and the image that is built from all of it
+# --------------------------------------------------------------------------
+
+
+def test_the_added_init_is_recorded_in_full_rather_than_described(tmp_path):
+    (tmp_path / "root").mkdir()
+    record = add_guest_init(tmp_path / "root")
+
+    assert record["path"] == GUEST_INIT_PATH
+    assert record["text"] == GUEST_INIT
+    assert record["sha256"] == hashlib.sha256(GUEST_INIT.encode()).hexdigest()
+    assert (tmp_path / "root" / "gdpval-init").read_text() == GUEST_INIT
+
+
+def test_the_init_opens_no_channel_the_policy_closed():
+    """The guest's only way out is the work disk, and this is where that holds.
+
+    ``network: none`` and the pinned-absent ``vsock`` are enforced by the
+    launcher. They would still be enforced if this script tried — but a script
+    that tried would mean the design had drifted, and the drift is worth
+    catching here rather than in a packet capture.
+    """
+    forbidden = ("vsock", "ip ", "ifconfig", "curl", "wget", "nc ", "ssh")
+    for word in forbidden:
+        assert word not in GUEST_INIT, f"the guest init reaches for {word!r}"
+    assert "/work/out/exit_status" in GUEST_INIT
+    assert "/work/in/command.sh" in GUEST_INIT
+
+
+def test_building_an_ext4_mounts_nothing_and_attaches_no_loop_device(tmp_path):
+    """``mke2fs -d`` populates the image directly, which is the whole point.
+
+    The alternative — mount, copy, unmount — needs privilege the jailed account
+    does not have and hands a guest-written filesystem to the host kernel's ext4
+    driver. Both are avoided, and this test is what stops somebody reaching for
+    the easier one later.
+    """
+    argv = ext4_image_arguments(tmp_path / "x.ext4", size_mib=256, populate_from=tmp_path)
+
+    assert argv[0] == "mke2fs"
+    assert "-d" in argv and argv[argv.index("-d") + 1] == tmp_path.as_posix()
+    assert argv[-1] == "65536", "256 MiB of 4096-byte blocks"
+    assert "mount" not in argv
+    assert not any(part.startswith("/dev/loop") for part in argv)
+
+
+def test_an_ext4_with_nothing_to_populate_it_takes_no_source_directory(tmp_path):
+    argv = ext4_image_arguments(tmp_path / "x.ext4", size_mib=16, populate_from=None)
+    assert "-d" not in argv
+
+
+def test_the_rootfs_is_sized_from_what_is_in_it(tmp_path):
+    small = tmp_path / "small"
+    (small / "a").parent.mkdir(parents=True, exist_ok=True)
+    (small / "a").write_bytes(b"0" * 1024)
+    large = tmp_path / "large"
+    large.mkdir()
+    (large / "a").write_bytes(b"0" * (400 * 1024 * 1024))
+
+    assert rootfs_size_mib(small) == 512, "the floor, for an image smaller than it"
+    assert rootfs_size_mib(large) > 512

--- a/batch-runner/tests/test_agentic_v2_guest_image.py
+++ b/batch-runner/tests/test_agentic_v2_guest_image.py
@@ -51,11 +51,25 @@ def _layer(entries: dict[str, bytes | None], tmp_path: Path, name: str) -> dict:
             info = tarfile.TarInfo(member_name)
             if content is None:
                 info.type = tarfile.DIRTYPE
+                info.mode = 0o755
                 archive.addfile(info)
             else:
                 info.size = len(content)
                 archive.addfile(info, io.BytesIO(content))
     path = tmp_path / name
+    path.write_bytes(buffer.getvalue())
+    return {"digest": _digest(buffer.getvalue()), "path": path.as_posix()}
+
+
+def _special(kind: str, name: str, target: str, tmp_path: Path, file_name: str) -> dict:
+    """A one-member layer holding a symbolic or hard link."""
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w") as archive:
+        info = tarfile.TarInfo(name)
+        info.type = tarfile.SYMTYPE if kind == "symlink" else tarfile.LNKTYPE
+        info.linkname = target
+        archive.addfile(info)
+    path = tmp_path / file_name
     path.write_bytes(buffer.getvalue())
     return {"digest": _digest(buffer.getvalue()), "path": path.as_posix()}
 
@@ -292,13 +306,6 @@ def test_an_opaque_whiteout_empties_the_directory_it_sits_in(tmp_path):
     assert list((tmp_path / "root" / "var" / "cache").iterdir()) == []
 
 
-def test_a_layer_that_climbs_out_of_the_root_is_refused_not_filtered(tmp_path):
-    escaping = _layer({"../outside": b"no\n"}, tmp_path, "l0.tar")
-    with pytest.raises(ImageRefused, match="points outside"):
-        unpack_layers([escaping], tmp_path / "root")
-    assert not (tmp_path / "outside").exists()
-
-
 def test_an_absolute_path_in_a_layer_is_refused(tmp_path):
     absolute = _layer({"/etc/shadow": b"no\n"}, tmp_path, "l0.tar")
     with pytest.raises(ImageRefused, match="absolute path"):
@@ -308,6 +315,100 @@ def test_an_absolute_path_in_a_layer_is_refused(tmp_path):
 # --------------------------------------------------------------------------
 # the one added file, and the image that is built from all of it
 # --------------------------------------------------------------------------
+
+
+def test_the_root_entry_every_layer_starts_with_is_not_an_escape(tmp_path):
+    """``.`` is the first member of a real OCI layer, and it stopped C2's first boot.
+
+    The check was written with ``lstrip("./")``, which takes a set of characters
+    rather than a prefix: ``.`` became the empty string and was refused as an
+    escape. The same call turned ``../x`` into ``x`` and ``/etc/shadow`` into
+    ``etc/shadow``, so the two members it existed to stop were the two it let
+    through. Both directions are held here.
+    """
+    layer = _layer({".": None, "./etc/hostname": b"guest\n"}, tmp_path, "l0.tar")
+
+    report = unpack_layers([layer], tmp_path / "root")
+
+    assert (tmp_path / "root" / "etc" / "hostname").read_bytes() == b"guest\n"
+    assert report["entries_written"] == 1, "the root entry is skipped, not written"
+
+
+@pytest.mark.parametrize(
+    "escape", ["../x", "/etc/shadow", "a/../../b", "./../../y"]
+)
+def test_a_member_that_lands_outside_the_root_is_refused(tmp_path, escape):
+    with pytest.raises(ImageRefused):
+        unpack_layers(
+            [_layer({escape: b"no\n"}, tmp_path, "bad.tar")], tmp_path / "root"
+        )
+    assert not (tmp_path / "x").exists()
+    assert not (tmp_path / "b").exists()
+
+
+def test_a_member_written_through_a_symlinked_parent_is_refused(tmp_path):
+    """Neither member escapes on its own reading, and the pair of them does.
+
+    ``etc`` as a link to ``/`` is a legal thing for a layer to contain. So is a
+    file called ``etc/passwd``. Together they write to the host's own file, and
+    the only moment the pair is visible is the one where the second is about to
+    be extracted and the link already exists.
+    """
+    link = _special("symlink", "etc", "/", tmp_path, "l0.tar")
+    through = _layer({"etc/passwd": b"pwned\n"}, tmp_path, "l1.tar")
+
+    with pytest.raises(ImageRefused, match="symbolic link"):
+        unpack_layers([link, through], tmp_path / "root")
+
+
+def test_a_hardlink_pointing_out_of_the_image_is_refused(tmp_path):
+    """A hardlink is a second name, and tar lets it name something outside.
+
+    It cannot be used to write to the host — but it pulls a host file's contents
+    into the filesystem the guest boots from, which is the same disclosure in
+    the other direction and is not something the manifest describes.
+    """
+    escaping = _special("hardlink", "usr/x", "../../../etc/shadow", tmp_path, "l0.tar")
+    with pytest.raises(ImageRefused, match="points outside"):
+        unpack_layers([escaping], tmp_path / "root")
+
+
+def test_a_narrow_directory_does_not_break_the_layer_it_is_in(tmp_path):
+    """Its own children arrive after it, and its mode is in place by then.
+
+    ``extractall`` defers directory modes to the end for exactly this reason,
+    and cannot be used here because the whiteout and escape checks need each
+    member in hand. So the mode is widened during the unpack and put back
+    afterwards, and this is both halves: the children land, and the image's own
+    mode is what survives.
+    """
+    narrow = io.BytesIO()
+    with tarfile.open(fileobj=narrow, mode="w") as archive:
+        directory = tarfile.TarInfo("var")
+        directory.type = tarfile.DIRTYPE
+        directory.mode = 0o700
+        archive.addfile(directory)
+        child = tarfile.TarInfo("var/log")
+        child.size = 4
+        archive.addfile(child, io.BytesIO(b"log\n"))
+    path = tmp_path / "l0.tar"
+    path.write_bytes(narrow.getvalue())
+    layer = {"digest": _digest(narrow.getvalue()), "path": path.as_posix()}
+
+    report = unpack_layers([layer], tmp_path / "root")
+
+    assert (tmp_path / "root" / "var" / "log").read_bytes() == b"log\n"
+    assert (tmp_path / "root" / "var").stat().st_mode & 0o777 == 0o700
+    assert report["directory_modes_restored"] == 1
+
+
+def test_the_unpack_says_what_the_extraction_filter_changed(tmp_path):
+    """So the artefact does not imply the tree is the image's own permissions."""
+    layer = _layer({"a": b"a\n"}, tmp_path, "l0.tar")
+    report = unpack_layers([layer], tmp_path / "root")
+
+    assert "setuid" in report["what_the_filter_changed"]
+    assert report["extraction_filter"] in {"tar", "none available"}
 
 
 def test_the_added_init_is_recorded_in_full_rather_than_described(tmp_path):

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
@@ -1464,6 +1464,89 @@ honest outcome is that commands do not run, and stage C is allowed to return
 that.
 
 **Not yet run.**
+
+###### C3 ran, and all seven were stopped
+
+Two runs on `gdpval-devhost-vm`. The second is the record; the first is why the
+second exists.
+
+**Run 2 — 2026-09-10T20:36:02Z → 20:40:01Z, 239.2 s, `outcome: all_seven_stopped`.**
+Seven of seven, no escapes.
+
+| # | attack | rule | what stopped it |
+|---|---|---|---|
+| 1 | write 512 MiB into the work disk | `workdir_quota_mib: 256` | the write past the quota failed, `rc=1` |
+| 2 | hold 6,144 MiB in a 4,096 MiB machine | `memory_mib: 4096` | guest sees 3,942 MiB; the allocator reached 3,776 MiB and the kernel took it, `rc=137` |
+| 3 | never finish | `wall_clock_seconds` | stopped at 45.042 s against a 45 s bound, chroot gone |
+| 4 | find an interface and use it | `network: none` | only `lo` in `/proc/net/dev`; `connect_probe=refused:OSError` |
+| 5 | write to `/` | `rootfs: read-only` | write refused **and** `/dev/root / ext4 ro,relatime` |
+| 6 | keep root on the host | `user: jailer-unprivileged` | the Firecracker process runs as uid 999, no supplementary groups |
+| 7 | reach a token the orchestrator holds | `credentials: none-inherited` | 0 environment entries, none of the canaries, 28 descriptors reaching nothing of ours, all three standard ones `/dev/null`, guest environment clean |
+
+The images were checked against C2's record before anything booted:
+`matches_the_guest_c2_booted: true`, kernel `b36a4a1b…`, rootfs `489188004ad4eb8a…`.
+These are seven verdicts about the machine whose boot C2 recorded, not about a
+rebuild that happens to be similar. Host unchanged: Firecracker/Jailer v1.13.1,
+`6.17.0-1022-azure`, cgroup v2, KVM present, 8 processors. Jail account
+`gdpvaljail` uid 999 gid 988 `/usr/sbin/nologin`, no groups beyond its own.
+
+Four boots, each with its plan and work disk pinned:
+
+| boot | outcome | ran | plan sha256 | policy is the required one |
+|---|---|---|---|---|
+| `probes` | booted, exit 0 | 9.272 s | `f79f1fe7…` | yes (`wall_clock_seconds: 1200`) |
+| `workdir-quota` | booted, exit 0 | 1.518 s | `d9e43128…` | yes |
+| `memory` | booted, exit 0 | 4.020 s | `6e342ead…` | yes |
+| `wall-clock` | stopped by the deadline | 45.042 s | `d3aef11c…` | **no — 45 s, recorded as such** |
+
+The deadline was tested against a shortened bound so the stop could be watched
+inside a run. That was done by handing `build_launch_plan` a different policy
+dict — an argument it already takes, and one it still refuses if a rule is
+missing, unknown or out of reach — and the artefact carries
+`policy_is_the_required_one: false` for that boot alone. Attack 3 demonstrates
+that the deadline fires and tears the chroot down. **It does not demonstrate
+1,200 seconds**, and nothing here should be read as if it did.
+
+Attacks 6 and 7 were read from `/proc/1979` while the machine was alive, because
+neither is visible from inside it: PID 1 in that guest was uid 0, as it is in
+every guest here including the ones that pass. The probe boot now holds itself
+open for 8 s so the read can land — C2's guest was gone in 1.269 s, which is not
+reliably long enough.
+
+###### Run 1 came back six of seven, and the seventh was the attack, not the rule
+
+**2026-09-10T20:0x, `outcome: escaped`, `escapes: ['memory']`.** The verdict was
+*"the allocation probe did not report, so it did not run"* — correct on the
+evidence, and the wrong conclusion about the machine. `/out/stderr` held
+`Killed`; `/out/stdout` stopped after `MemTotal`. The bound had held. The attack
+destroyed the evidence proving it.
+
+Two causes, both in the attack:
+
+- **The allocation went into a tmpfs.** Those pages are shmem and are charged to
+  no process's RSS, so when the machine filled, `oom_badness` had nothing large
+  to weigh and the kernel took a bystander.
+- **The reporter was that bystander.** `rc=$?` inside a command substitution runs
+  in a fork; the fork died holding the exit status.
+
+It is now anonymous memory, written to a page at a time — `bytearray(n)` is
+`calloc`, and `calloc` over a fresh mapping is a promise of zeroes rather than
+pages, so untouched it would have taken address space and never reached the
+bound. The report is made by the top-level shell, which allocates nothing and is
+never a candidate. The allocator prints its high-water mark as it goes, because a
+process the kernel kills does not reach its last line.
+
+That mark is now the primary check: **holding more than `memory_mib` is an escape
+whatever the exit status says**, since a guest with no swap cannot give back
+anonymous memory it has touched. A machine that handed over every requested byte
+and then failed on the way out would have passed on the exit status alone.
+
+**The judge was not loosened to reach seven.** `Killed` in `/out/stderr` is real
+evidence the bound held, and it is still not accepted, because it does not say
+*which* process was killed — and accepting it would be reading a bystander's
+death as containment. The first run's six-of-seven stands in the record as a
+failed run.
+
 ### Stage D — not yet run
 ### Stage E — not yet run
 ### Stage F — not yet run

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
@@ -1342,6 +1342,93 @@ is not `exec_run`, not a model call, and not a task. `foundation_only` and
 `anything_applies_the_containment_rules` is expected to stay `false` until a
 caller actually runs these arguments in the product path, which is stage D.
 
+###### C2 ran, and this is what came back
+
+Two runs on `gdpval-devhost-vm`, both through `az vm run-command invoke` — no
+public IP, no inbound rule, no SSH, no new access of any kind. The host is
+`6.17.0-1022-azure`, 8 processors, KVM present, **cgroup v2** by the evidence
+`/sys/fs/cgroup/cgroup.controllers` exists, running `Firecracker v1.13.1` and
+`Jailer v1.13.1` at `/usr/local/bin/`. The jail account is `gdpvaljail`,
+uid 999, gid 988, shell `/usr/sbin/nologin`, `groups_beyond_its_own: []`.
+
+**Run 1 refused the real image, and the refusal was the bug.** It stopped at the
+first member of the first layer: `layer sha256:68629629… contains '.', which
+points outside the filesystem it describes`. The check was written with
+`member.name.lstrip("./")`, and `str.lstrip` takes a *set of characters* rather
+than a prefix. So `"."` became `""` and was read as an escape, while `"../x"`
+became `"x"` and `"/etc/shadow"` became `"etc/shadow"` — the two members the
+check existed to stop were the two it let through. Rewritten around
+`os.path.normpath`, with a refusal for members written through a symlinked
+parent and for hardlinks naming something outside the image, both of which the
+first version also missed. Fixing it surfaced a second defect that had nothing
+to do with the first: the boot arguments carried no `init=`, so the guest would
+have fallen through to `/bin/sh` on a console `--daemonize` had already pointed
+at `/dev/null` — a machine that boots, runs nothing, writes nothing, and waits
+out the full 1,200 seconds, which is the failure hardest to tell from a broken
+image.
+
+**Run 2 booted.** `outcome: booted`, `exit_status: 0`, `ran_for_seconds: 1.269`
+against a 1,200 s bound, `jailer` returncode 0 with empty stderr, PID file
+present, and `teardown.all_gone: true`. The whole run took 475.6 s wall clock
+including both image builds, from `2026-09-10T19:57:42Z` to `20:05:37Z`.
+
+Off the work disk — the only channel, since there is no network, `vsock` is
+pinned absent, and the console goes to `/dev/null`:
+
+```
+/out/guest_kernel          6.1.141
+/out/guest_uid             0
+/out/init_reached_the_end  done
+/out/exit_status           0
+/out/stdout                this ran inside the guest
+                           python answered 4
+                           0
+                           /dev/vda on / type ext4 (ro,relatime)
+                           rootfs refused a write, as the rule says it must
+```
+
+**What was booted, fixed by hash.** The kernel is
+`firecracker-ci/v1.13/x86_64/vmlinux-6.1.141`, 41,865,904 bytes, sha256
+`b36a4a1b10f33b9cfdcde3d1a787d9c090556a3edb211cd06d1f3f9a6c7e8724`. That digest
+was **computed here on download**. Upstream publishes neither a checksum nor a
+signature for it, the bucket listing is plain HTTP, and the S3 ETag is a
+multipart tag rather than a content hash — so this figure shows the file did not
+change between download and boot, and nothing more. It is not a provider
+signature and is not recorded as one. Its minimum end-of-support date is
+`2026-09-02`, which has passed; the pin carries `support_window_has_lapsed:
+true` rather than being quiet about it.
+
+The rootfs was built from `ghcr.io/hyeonsangjeon/gdpval-sandbox` pinned at index
+`sha256:ee6ef798631d3c3aeaed28658c640e6f5d021677449852bf2e1f18be5bd24edb`,
+which resolved to manifest
+`sha256:91b524c7dc8f21d653f829d19a283ea269a36cc85e0569ca38c85bfac92d0fe2` for
+`linux/amd64` — the index digest is the reproducible pin, but it cannot say
+which child booted, so both are recorded. Ten layers, each checked against its
+own digest, applied in order: 119,175 entries written, 78 whiteouts honoured,
+12,709 directory modes widened during the unpack and restored afterwards. The
+extraction filter was `tar`, which clears setuid, setgid and sticky bits, so the
+tree is not byte-for-byte the image's own permissions and the artefact says so.
+Result: `rootfs.ext4`, 8,714 MiB, sha256 `489188004ad4eb8a…`; work disk 256 MiB,
+sha256 `111ad3b79c44db73…`; guest init at `/gdpval-init`, sha256
+`191ccbb58fc6b1ed…`. Both images were built with `mke2fs -d` and read back with
+`debugfs` — nothing mounted, no loop device, and the host kernel's ext4 driver
+never touched a filesystem the guest had been writing.
+
+**The deadline fired.** A second machine ran a command that never finishes:
+`stopped_by_the_deadline: true` at 45.042 s, `chroot_destroyed: true`. It used
+45 s rather than 1,200 s, and the artefact carries
+`policy_used_is_not_the_required_one: true` next to that number. The bound was
+not relaxed to get the result — the same builder was handed a different policy
+dictionary, and that builder still refuses a policy with a missing rule, an
+unknown rule, or a rule it cannot reach. What this shows is that the launcher's
+enforcement path works, on a bound short enough to watch.
+
+**Attack 5 answered early, by accident.** `/dev/vda on / type ext4
+(ro,relatime)` and a refused write are the read-only-root rule holding, observed
+in the C2 boot before C3 was written. It is recorded here because it happened
+here, and C3 will still run it as an attack rather than cite this line — one
+observation inside a friendly command is not the same as a probe that was trying.
+
 ##### C3 — the seven attacks
 
 **Builds.** `tests/test_agentic_v2_containment_rules.py` gains the test its own

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
@@ -1513,6 +1513,34 @@ every guest here including the ones that pass. The probe boot now holds itself
 open for 8 s so the read can land — C2's guest was gone in 1.269 s, which is not
 reliably long enough.
 
+Both artefacts are committed unedited beside this document —
+`c2_first_boot.json` and `c3_attacks.json`. Everything above is a reading of
+them, and a reading nobody can check is worth less than the thing it reads,
+particularly once the host it was written on is deallocated.
+
+###### Seven attacks, eleven rules — what the other four are
+
+`REQUIRED_MICROVM_POLICY` has eleven keys and seven of them were attacked. **7/7
+is not 11/11**, and the difference is not an oversight to be quietly carried:
+
+| key | why there is no attack |
+|---|---|
+| `required: true` | a flag saying the policy applies, not a boundary a guest can push on |
+| `runtime: firecracker` | demonstrated by the boots themselves — Firecracker v1.13.1 is what ran them, recorded per boot with the plan's sha256 |
+| `on_breach: stop-and-report` | this *is* attack 3's outcome: the deadline stopped the machine and the artefact reported it |
+| `workdir: ephemeral-quota` | the `quota` half is attack 1. The **`ephemeral` half is not attacked.** |
+
+The last one is the real gap and it is named here rather than folded into the
+seven. Every boot ended with `teardown.all_gone: true` and every boot was handed
+a freshly built work disk, so nothing observed contradicts it — but that is the
+*runner* being careful, not the machine refusing. A guest cannot make its own
+disk survive; only the code that hands out disks can fail to replace one.
+
+So it is not a microVM property and does not belong among attacks on microVM
+rules. **It becomes stage D's problem the moment one machine per task starts
+reusing this machinery**, because the failure it guards against is one task's
+data reaching the next, and that failure would be silent. Stage D carries it.
+
 ###### Run 1 came back six of seven, and the seventh was the attack, not the rule
 
 **2026-09-10T20:0x, `outcome: escaped`, `escapes: ['memory']`.** The verdict was

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
@@ -1224,6 +1224,124 @@ no describing a weaker boundary as this one.
 immediately after, on the same terms as stage B: measured minutes, price
 `partial` if the rate is not established.
 
+###### C2's inputs, measured and decided before any of it was written
+
+The plan above leaves four things open. Each is settled here, with the reading
+it was settled from, so that none of them arrives as an implicit choice inside
+the code.
+
+**The host, re-read rather than remembered.** Allocated 2026-09-10T19:33Z and
+measured through `az vm run-command` — no inbound port, no session, the same
+control-plane path stage B used. `cgroup2fs`, `cgroup.controllers` present:
+the hierarchy is **v2**, so the memory bound is `memory.max` and
+`--cgroup-version 2` is passed explicitly. That is the exact failure
+:data:`CGROUP_MEMORY_FILE_BY_VERSION` was written against, and it is now a
+reading rather than an assumption. `/dev/kvm` is present, the processor reports
+`svm`, there are 8 processors and 122 GiB free, and `firecracker` and `jailer`
+are both v1.13.1 at `/usr/local/bin` — they survived the deallocation because
+stage B installed them onto the disk, which is kept.
+
+Two readings contradict what was expected. **Docker is not installed**, so the
+rootfs cannot be produced by a daemon pulling an image; the registry is spoken
+to directly instead, which is a better fit for a chain that is about digests.
+And **uid 1000 (`gdpval`) is in the `sudo` group**, so it is not the
+unprivileged account rule `user` asks for. C2 creates a dedicated account with
+no password, no login shell and no group beyond its own, and jails to that.
+Reusing an account that can become root would leave the host-side process one
+`sudo` away from the thing the rule exists to prevent, and the rule would still
+have read as met.
+
+**Which rootfs boots, since no candidate digest exists.** The professional-work
+candidate has never been built, so there is no digest for it anywhere in the
+repository — C2 does not invent one and does not build one as a side quest.
+It boots the **parent**, `ghcr.io/hyeonsangjeon/gdpval-sandbox`, pinned by the
+digest `batch-runner/sandbox/v2/parent.lock.json` already records. That lock
+pins the multi-architecture *index*; the artefact additionally records the
+`linux/amd64` manifest digest that index resolved to, because the index digest
+alone does not say which of its children was unpacked. The image is public: an
+anonymous pull token fetches the manifest, so no credential is issued and none
+is needed. **What boots in C2 is therefore the signed, scanned parent and not
+the candidate D will need**, and the artefact says so in those words.
+
+**The kernel, and exactly how its provenance is weaker.** Pinned to the one key
+`firecracker-ci/v1.13/x86_64/vmlinux-6.1.141` in bucket `spec.ccfc.min`,
+41,865,904 bytes, published 2025-08-12 — one exact key, not the discovery logic
+upstream's getting-started uses, which resolves `sort -V | tail -1` against a
+listing fetched over plain `http` and would let the guest kernel change
+underneath the containment tests without anything saying so. Three disclosures
+travel with it, and they are the content of "weaker than the OCI chain's":
+
+1. **Upstream publishes no checksum and no signature for these artifacts.**
+   Its documented verification step prints filenames. The bucket's ETag is a
+   multipart tag (`…-5`) and is not a content hash of the object. So the hash
+   in the artefact is one **we** computed on download and enforce thereafter.
+   It proves the file did not change between our download and this boot. It
+   does not mean anybody vouched for the file, and the artefact must not be
+   read as if a signature had been checked.
+2. `docs/kernel-policy.md` at the v1.13.1 tag validates exactly two guest
+   kernels, v5.10 and v6.1. **v6.1's minimum end-of-support date is
+   2026-09-02, which is eight days before this run.** 6.1.141 is used anyway,
+   knowingly, and recorded as lapsed rather than pinned in silence. The
+   alternative on that page, v5.10, expired in 2024 and is worse.
+3. The rootfs does **not** come from upstream's path. Upstream builds one from
+   an Ubuntu squashfs with `sudo mkfs.ext4 -d squashfs-root`; C2 builds it from
+   the verified OCI layers instead, which is the whole point of having the
+   chain. Only the kernel comes from the bucket.
+
+**How a command gets in and its result gets out — one channel, not two.**
+`REQUIRED_MICROVM_POLICY` says `network: none`, and
+:data:`DEVICES_THAT_MUST_BE_ABSENT` rules out `vsock` for the same reason — a
+host-to-guest socket is a channel whether or not it is an interface. The first
+draft of this section named the serial console as a second channel and **that
+was wrong**: C1 passes `--daemonize`, which is what points the three standard
+descriptors at `/dev/null`, and its own docstring already says so — "that is
+acceptable only because it is not where results come from". No `logger` section
+is written into the configuration either. So Firecracker's stdout goes nowhere
+and there is no console to read.
+
+That leaves exactly one channel, which is the one the policy already names.
+The **work disk** carries the command in and the results out: `/in/command.sh`
+going in, `/out/stdout`, `/out/stderr` and `/out/exit_status` coming back. It
+is read with `debugfs`, which walks the ext4 image directly — nothing is
+mounted, no loop device is attached, and no privilege is needed to take a file
+out of it. The rootfs is read-only, so the guest is given one added file,
+`/gdpval-init`, whose whole text and hash go into the artefact; everything else
+is the image's own layers unpacked in order.
+
+**One consequence worth naming: a failure to boot is nearly silent.** With no
+console and no network, a guest that panics leaves an empty work disk and
+nothing else, which is the same evidence as a guest that booted and wrote
+nothing. So C2 also does a **separate, deliberately unjailed** Firecracker run
+of the same kernel and rootfs with the console attached, before the jailed one,
+and records it as `unjailed_image_check`. It proves the two images boot and
+nothing more — it is **not** the contained run, it does not count towards the
+exit condition, and it is labelled that way in the artefact so no reader can
+mistake the weaker boundary for this one. If it were allowed to substitute for
+the jailed run, that would be the exact dishonesty this stage forbids.
+
+**Where root is used, stated plainly so it is not mistaken for an escalation.**
+`jailer` must start as root: building the chroot means `mknod` for `/dev/kvm`,
+`chown` to the jailed account, `chroot` and then `setuid`. Dropping privilege
+is the thing it is *for*, and the run-command channel already arrives as root.
+So root starts the jailer and the jailer drops. Nothing else runs as root,
+**no `--privileged`, no added capability, no sysctl changed, no host security
+setting turned off, no guard removed and `exec_run` untouched** — that list is
+stage C's own, and C2 does not spend any of it. In particular
+`kernel.apparmor_restrict_unprivileged_userns` reads `1` on this host and stays
+`1`; it constrains bubblewrap, which is A's Codex path, and Firecracker does
+not depend on it.
+
+**When it stops.** `wall_clock_seconds` has no jailer flag behind it — the
+launcher enforces it by watching for the PID file C1 derives from the binary's
+own name and killing the process when the deadline passes. C2 exercises that,
+because a deadline that has never fired is a deadline nobody has tested.
+
+**What C2 is still not.** Booting a guest and getting one command's output back
+is not `exec_run`, not a model call, and not a task. `foundation_only` and
+`production_activation: disabled` are untouched, and the answer to
+`anything_applies_the_containment_rules` is expected to stay `false` until a
+caller actually runs these arguments in the product path, which is stage D.
+
 ##### C3 — the seven attacks
 
 **Builds.** `tests/test_agentic_v2_containment_rules.py` gains the test its own

--- a/tasks/0822_saturday/c2_first_boot.json
+++ b/tasks/0822_saturday/c2_first_boot.json
@@ -1,0 +1,415 @@
+{
+  "boot": {
+    "channel": "the work disk only: no network by policy, vsock pinned absent, and --daemonize sends the console to /dev/null",
+    "command_exit_status": 0,
+    "deadline_seconds": 1200.0,
+    "jailer": {
+      "argv": [
+        "--id",
+        "c2-first-boot",
+        "--exec-file",
+        "/usr/local/bin/firecracker",
+        "--uid",
+        "999",
+        "--gid",
+        "988",
+        "--chroot-base-dir",
+        "/srv/jailer",
+        "--cgroup-version",
+        "2",
+        "--cgroup",
+        "memory.max=4563402752",
+        "--resource-limit",
+        "fsize=268435456",
+        "--new-pid-ns",
+        "--daemonize",
+        "--",
+        "--config-file",
+        "/vmconfig.json",
+        "--no-api"
+      ],
+      "returncode": 0,
+      "stderr": ""
+    },
+    "outcome": "booted",
+    "pid_file": {
+      "appeared": true,
+      "path": "/srv/jailer/firecracker/c2-first-boot/root/firecracker.pid",
+      "pid_recorded": true
+    },
+    "placement": {
+      "chroot_dir": "/srv/jailer/firecracker/c2-first-boot/root",
+      "placed": [
+        {
+          "bytes": 41865904,
+          "in_jail": "/vmlinux",
+          "mode": "0o444",
+          "owned_by_the_jailed_user": false,
+          "sha256": "b36a4a1b10f33b9cfdcde3d1a787d9c090556a3edb211cd06d1f3f9a6c7e8724"
+        },
+        {
+          "bytes": 9137291264,
+          "in_jail": "/rootfs.ext4",
+          "mode": "0o444",
+          "owned_by_the_jailed_user": false,
+          "sha256": "489188004ad4eb8a90191b3b5f58eb9fb246d158535d0bc655001f438a7a32ea"
+        },
+        {
+          "bytes": 268435456,
+          "in_jail": "/work.ext4",
+          "mode": "0o644",
+          "owned_by_the_jailed_user": true,
+          "sha256": "111ad3b79c44db7325e2b8514b0b0315e8c0b7de541b79939355552c9ff9bb7f"
+        },
+        {
+          "bytes": 545,
+          "in_jail": "/vmconfig.json",
+          "mode": "0o444",
+          "owned_by_the_jailed_user": false,
+          "sha256": "de668f79dac7fe51ebe12ba1e0d37936ff8ca6859247cae7324f1c5b4a3cbaf7"
+        }
+      ]
+    },
+    "plan_sha256": "f3269e71ec693ed1c6e6204f72230bb18a6f63fb757b495b5142dc7af34d56cb",
+    "policy_sha256": "6a5e665d3253c80302f001e8fd624b77838c38f92add1af63024277c5215888e",
+    "ran_for_seconds": 1.269,
+    "results": {
+      "/out/exit_status": "0\n",
+      "/out/guest_kernel": "6.1.141\n",
+      "/out/guest_uid": "0\n",
+      "/out/init_reached_the_end": "done\n",
+      "/out/stderr": "",
+      "/out/stdout": "this ran inside the guest\npython answered 4\n0\n/dev/vda on / type ext4 (ro,relatime)\nrootfs refused a write, as the rule says it must\n"
+    },
+    "schema_version": "1.0",
+    "stopped_by_the_deadline": false,
+    "teardown": {
+      "all_gone": true,
+      "removed": {
+        "/srv/jailer/firecracker/c2-first-boot/root": true
+      }
+    },
+    "vm_id": "c2-first-boot"
+  },
+  "deadline_test": {
+    "chroot_destroyed": true,
+    "outcome": "stopped_by_the_deadline",
+    "policy_used_is_not_the_required_one": true,
+    "ran_for_seconds": 45.042,
+    "stopped_by_the_deadline": true,
+    "wall_clock_seconds": 45,
+    "why": "the real bound is 1200s; this run hands the same builder a different policy with 45s so the stop can be watched"
+  },
+  "elapsed_seconds": 475.6,
+  "finished_at": "2026-09-10T20:05:37Z",
+  "host": {
+    "cgroup_evidence": "/sys/fs/cgroup/cgroup.controllers exists",
+    "cgroup_version": 2,
+    "firecracker": "/usr/local/bin/firecracker",
+    "firecracker_version": "Firecracker v1.13.1",
+    "jailer": "/usr/local/bin/jailer",
+    "jailer_version": "Jailer v1.13.1",
+    "kernel_release": "6.17.0-1022-azure",
+    "kvm_present": true,
+    "processors": 8,
+    "read_at": "2026-09-10T19:57:42Z"
+  },
+  "images": {
+    "command": "set -eu\necho 'this ran inside the guest'\npython3 -c \"print('python answered', 2 + 2)\" 2>/dev/null || echo 'no python3 in the image'\nid -u\nmount | grep ' / ' || true\n( echo write-to-root > /root-write-probe.txt && echo 'ROOTFS WAS WRITABLE' ) 2>/dev/null || echo 'rootfs refused a write, as the rule says it must'\n",
+    "guest_init": {
+      "bytes": 967,
+      "path": "/gdpval-init",
+      "sha256": "191ccbb58fc6b1edd4323c76bcd8c1a895496b8cf3c7f1e9f982a0e6adbbe30a",
+      "text": "#!/bin/sh\n# PID 1 in the guest. There is no console: the launcher passes --daemonize,\n# which points Firecracker's standard descriptors at /dev/null, so everything\n# this script has to say it says on the work disk.\nPATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\nexport PATH\nmount -t proc proc /proc 2>/dev/null\nmount -t sysfs sys /sys 2>/dev/null\nmount -t devtmpfs dev /dev 2>/dev/null\nmkdir -p /work\nmount -t ext4 /dev/vdb /work\nmkdir -p /work/out\nuname -r > /work/out/guest_kernel 2>/dev/null\nid -u > /work/out/guest_uid 2>/dev/null\nsh /work/in/command.sh > /work/out/stdout 2> /work/out/stderr\necho $? > /work/out/exit_status\necho done > /work/out/init_reached_the_end\nsync\numount /work 2>/dev/null\nsync\n# Reset through the i8042 controller, which is what boot_args' reboot=k selects\n# and what makes Firecracker exit rather than sit on a halted guest.\nreboot -f 2>/dev/null\necho b > /proc/sysrq-trigger 2>/dev/null\nwhile true; do sleep 1; done\n",
+      "why": "the rootfs is read-only and the image has no init that would run one command and stop, so exactly one file is added and its whole text is recorded here rather than described"
+    },
+    "image": {
+      "credential_used": "none \u2014 anonymous pull token for a public repository",
+      "layer_count": 10,
+      "layers": [
+        {
+          "digest": "sha256:68629629b516c3cd6f5e71ffbe18e32afb1ae5b4926c92d058c0f11ef1fd58a3",
+          "media_type": "application/vnd.oci.image.layer.v1.tar+gzip",
+          "path": "/var/tmp/gdpval-c2/oci/blobs/sha256/68629629b516c3cd6f5e71ffbe18e32afb1ae5b4926c92d058c0f11ef1fd58a3",
+          "size_bytes": 28237639
+        },
+        {
+          "digest": "sha256:9465a3b5326202cdeda1f1439e4aaadfe4f4527dd8f9d020ef76b8a8432e5816",
+          "media_type": "application/vnd.oci.image.layer.v1.tar+gzip",
+          "path": "/var/tmp/gdpval-c2/oci/blobs/sha256/9465a3b5326202cdeda1f1439e4aaadfe4f4527dd8f9d020ef76b8a8432e5816",
+          "size_bytes": 3520822
+        },
+        {
+          "digest": "sha256:3ea3516015d200ef3f1407147986285b706de588d42b96b2cd33c6380e1ff0f1",
+          "media_type": "application/vnd.oci.image.layer.v1.tar+gzip",
+          "path": "/var/tmp/gdpval-c2/oci/blobs/sha256/3ea3516015d200ef3f1407147986285b706de588d42b96b2cd33c6380e1ff0f1",
+          "size_bytes": 15990074
+        },
+        {
+          "digest": "sha256:c3a88133a8c61d848bb024e0392659b2e45433e836462906b04884dd326a01d2",
+          "media_type": "application/vnd.oci.image.layer.v1.tar+gzip",
+          "path": "/var/tmp/gdpval-c2/oci/blobs/sha256/c3a88133a8c61d848bb024e0392659b2e45433e836462906b04884dd326a01d2",
+          "size_bytes": 249
+        },
+        {
+          "digest": "sha256:e6c539ae3e58fd1b55f481bdfc5fa9f18c77e2bdb29c759b0c86f99195eab661",
+          "media_type": "application/vnd.oci.image.layer.v1.tar+gzip",
+          "path": "/var/tmp/gdpval-c2/oci/blobs/sha256/e6c539ae3e58fd1b55f481bdfc5fa9f18c77e2bdb29c759b0c86f99195eab661",
+          "size_bytes": 828406215
+        },
+        {
+          "digest": "sha256:0b5c91a253a39038b53c1fd4d4b21349beacdbd92bc959687e6fb1d15a2f3d1e",
+          "media_type": "application/vnd.oci.image.layer.v1.tar+gzip",
+          "path": "/var/tmp/gdpval-c2/oci/blobs/sha256/0b5c91a253a39038b53c1fd4d4b21349beacdbd92bc959687e6fb1d15a2f3d1e",
+          "size_bytes": 1370
+        },
+        {
+          "digest": "sha256:aa76a4f5622059cff46430efef5311aa99365d1056fe62cde6268e87abdfdf23",
+          "media_type": "application/vnd.oci.image.layer.v1.tar+gzip",
+          "path": "/var/tmp/gdpval-c2/oci/blobs/sha256/aa76a4f5622059cff46430efef5311aa99365d1056fe62cde6268e87abdfdf23",
+          "size_bytes": 1516991400
+        },
+        {
+          "digest": "sha256:1acaebe50d44b5446d5e3d43480c829386b6453558886cb8e97625a65a390782",
+          "media_type": "application/vnd.oci.image.layer.v1.tar+gzip",
+          "path": "/var/tmp/gdpval-c2/oci/blobs/sha256/1acaebe50d44b5446d5e3d43480c829386b6453558886cb8e97625a65a390782",
+          "size_bytes": 14335
+        },
+        {
+          "digest": "sha256:30c4d4e9cb5bf0c30aa016d634edcbe8ec9880077386e85b2ed3faf17d87e2bf",
+          "media_type": "application/vnd.oci.image.layer.v1.tar+gzip",
+          "path": "/var/tmp/gdpval-c2/oci/blobs/sha256/30c4d4e9cb5bf0c30aa016d634edcbe8ec9880077386e85b2ed3faf17d87e2bf",
+          "size_bytes": 94
+        },
+        {
+          "digest": "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+          "media_type": "application/vnd.oci.image.layer.v1.tar+gzip",
+          "path": "/var/tmp/gdpval-c2/oci/blobs/sha256/4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+          "size_bytes": 32
+        }
+      ],
+      "manifest_digest": "sha256:91b524c7dc8f21d653f829d19a283ea269a36cc85e0569ca38c85bfac92d0fe2",
+      "pinned_digest": "sha256:ee6ef798631d3c3aeaed28658c640e6f5d021677449852bf2e1f18be5bd24edb",
+      "pinned_digest_is_an_index": true,
+      "platform": "linux/amd64",
+      "repository": "ghcr.io/hyeonsangjeon/gdpval-sandbox"
+    },
+    "kernel": {
+      "path": "/var/tmp/gdpval-c2/vmlinux",
+      "sha256": "b36a4a1b10f33b9cfdcde3d1a787d9c090556a3edb211cd06d1f3f9a6c7e8724",
+      "size_bytes": 41865904,
+      "source": {
+        "bucket": "spec.ccfc.min",
+        "key": "firecracker-ci/v1.13/x86_64/vmlinux-6.1.141",
+        "minimum_end_of_support": "2026-09-02",
+        "published": "2025-08-12",
+        "size_bytes": 41865904,
+        "support_window_has_lapsed": true,
+        "upstream_publishes_a_checksum": false,
+        "upstream_publishes_a_signature": false,
+        "validated_by": "firecracker docs/kernel-policy.md at tag v1.13.1",
+        "version": "6.1.141"
+      },
+      "url": "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.13/x86_64/vmlinux-6.1.141",
+      "vouched_for_by_upstream": false,
+      "what_the_digest_means": "computed here on download, not published by upstream. It shows the file did not change between that download and this boot. It is not a signature and nothing upstream attests to it."
+    },
+    "rootfs": {
+      "argv": [
+        "mke2fs",
+        "-q",
+        "-F",
+        "-t",
+        "ext4",
+        "-b",
+        "4096",
+        "-d",
+        "/var/tmp/gdpval-c2/root",
+        "/var/tmp/gdpval-c2/rootfs.ext4",
+        "2230784"
+      ],
+      "path": "/var/tmp/gdpval-c2/rootfs.ext4",
+      "populated_from": "/var/tmp/gdpval-c2/root",
+      "sha256": "489188004ad4eb8a90191b3b5f58eb9fb246d158535d0bc655001f438a7a32ea",
+      "size_mib": 8714
+    },
+    "unpacked": {
+      "directory_modes_restored": 12709,
+      "entries_written": 119175,
+      "extraction_filter": "tar",
+      "layers_applied_in_order": [
+        "sha256:68629629b516c3cd6f5e71ffbe18e32afb1ae5b4926c92d058c0f11ef1fd58a3",
+        "sha256:9465a3b5326202cdeda1f1439e4aaadfe4f4527dd8f9d020ef76b8a8432e5816",
+        "sha256:3ea3516015d200ef3f1407147986285b706de588d42b96b2cd33c6380e1ff0f1",
+        "sha256:c3a88133a8c61d848bb024e0392659b2e45433e836462906b04884dd326a01d2",
+        "sha256:e6c539ae3e58fd1b55f481bdfc5fa9f18c77e2bdb29c759b0c86f99195eab661",
+        "sha256:0b5c91a253a39038b53c1fd4d4b21349beacdbd92bc959687e6fb1d15a2f3d1e",
+        "sha256:aa76a4f5622059cff46430efef5311aa99365d1056fe62cde6268e87abdfdf23",
+        "sha256:1acaebe50d44b5446d5e3d43480c829386b6453558886cb8e97625a65a390782",
+        "sha256:30c4d4e9cb5bf0c30aa016d634edcbe8ec9880077386e85b2ed3faf17d87e2bf",
+        "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1"
+      ],
+      "root": "/var/tmp/gdpval-c2/root",
+      "what_the_filter_changed": "the tar filter clears setuid, setgid and sticky bits. Nothing in this guest depends on them: it boots one process as root and has no second user to escalate from. Recorded because it means the unpacked tree is not byte-for-byte the image's own permissions.",
+      "whiteouts_honoured": 78
+    },
+    "work_disk": {
+      "argv": [
+        "mke2fs",
+        "-q",
+        "-F",
+        "-t",
+        "ext4",
+        "-b",
+        "4096",
+        "-d",
+        "/var/tmp/gdpval-c2/work-in",
+        "/var/tmp/gdpval-c2/work.ext4",
+        "65536"
+      ],
+      "path": "/var/tmp/gdpval-c2/work.ext4",
+      "populated_from": "/var/tmp/gdpval-c2/work-in",
+      "sha256": "111ad3b79c44db7325e2b8514b0b0315e8c0b7de541b79939355552c9ff9bb7f",
+      "size_mib": 256
+    }
+  },
+  "jail_account": {
+    "gid": 988,
+    "groups_beyond_its_own": [],
+    "name": "gdpvaljail",
+    "shell": "/usr/sbin/nologin",
+    "uid": 999
+  },
+  "outcome": "booted",
+  "plan": {
+    "devices_pinned": {
+      "balloon": null,
+      "mmds-config": null,
+      "vsock": null
+    },
+    "firecracker": {
+      "config": {
+        "boot-source": {
+          "boot_args": "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda ro init=/gdpval-init",
+          "kernel_image_path": "/vmlinux"
+        },
+        "drives": [
+          {
+            "drive_id": "rootfs",
+            "is_read_only": true,
+            "is_root_device": true,
+            "path_on_host": "/rootfs.ext4"
+          },
+          {
+            "drive_id": "work",
+            "is_read_only": false,
+            "is_root_device": false,
+            "path_on_host": "/work.ext4"
+          }
+        ],
+        "machine-config": {
+          "mem_size_mib": 4096,
+          "vcpu_count": 1
+        },
+        "network-interfaces": []
+      }
+    },
+    "host_could_run_this": true,
+    "host_reading_sha256": "6a31b3eada654b27a7f6a2c965bc050958b3dc079de743b2a8e2bc8280a8fde7",
+    "host_side": {
+      "chroot_dir": "/srv/jailer/firecracker/c2-first-boot/root",
+      "deadline_seconds": 1200,
+      "destroy_after_the_run": [
+        "/srv/jailer/firecracker/c2-first-boot/root"
+      ],
+      "on_deadline": "stop-and-report",
+      "pid_file": "/srv/jailer/firecracker/c2-first-boot/root/firecracker.pid"
+    },
+    "jailer": {
+      "argv": [
+        "--id",
+        "c2-first-boot",
+        "--exec-file",
+        "/usr/local/bin/firecracker",
+        "--uid",
+        "999",
+        "--gid",
+        "988",
+        "--chroot-base-dir",
+        "/srv/jailer",
+        "--cgroup-version",
+        "2",
+        "--cgroup",
+        "memory.max=4563402752",
+        "--resource-limit",
+        "fsize=268435456",
+        "--new-pid-ns",
+        "--daemonize",
+        "--",
+        "--config-file",
+        "/vmconfig.json",
+        "--no-api"
+      ],
+      "program": "jailer"
+    },
+    "place_in_jail": [
+      {
+        "from_host": "/var/tmp/gdpval-c2/vmlinux",
+        "how": "copy",
+        "in_jail": "/vmlinux",
+        "sha256": "b36a4a1b10f33b9cfdcde3d1a787d9c090556a3edb211cd06d1f3f9a6c7e8724",
+        "writable_by_the_jailed_user": false
+      },
+      {
+        "from_host": "/var/tmp/gdpval-c2/rootfs.ext4",
+        "how": "copy",
+        "in_jail": "/rootfs.ext4",
+        "sha256": "489188004ad4eb8a90191b3b5f58eb9fb246d158535d0bc655001f438a7a32ea",
+        "writable_by_the_jailed_user": false
+      },
+      {
+        "from_host": "/var/tmp/gdpval-c2/work.ext4",
+        "how": "create-empty",
+        "in_jail": "/work.ext4",
+        "size_mib": 256,
+        "writable_by_the_jailed_user": true
+      },
+      {
+        "from_host": null,
+        "how": "write",
+        "in_jail": "/vmconfig.json",
+        "writable_by_the_jailed_user": false
+      }
+    ],
+    "plan_sha256": "f3269e71ec693ed1c6e6204f72230bb18a6f63fb757b495b5142dc7af34d56cb",
+    "policy_sha256": "6a5e665d3253c80302f001e8fd624b77838c38f92add1af63024277c5215888e",
+    "rules_applied": {
+      "credentials": "the jailer clears the environment and closes every descriptor but three, and --daemonize points those three at /dev/null; nothing of the orchestrator's is passed in",
+      "memory_mib": "machine-config.mem_size_mib inside the guest, and --cgroup memory.max= outside it with 256 MiB of headroom for the monitor itself",
+      "network": "no interface is configured and no --netns is passed, so there is no interface to bring up; mmds-config and vsock are absent from the configuration and --no-api stops either being added later",
+      "on_breach": "LaunchRefused carries the rule by name, and host_side.on_deadline says the same for the deadline",
+      "required": "any rule this builder cannot express raises LaunchRefused naming that rule, rather than producing arguments without it",
+      "rootfs": "the root drive's is_read_only, and 'ro' on the kernel command line",
+      "runtime": "--exec-file names the Firecracker binary the jailer execs, and the jailer refuses a name that does not contain 'firecracker'",
+      "user": "--uid and --gid, both refused at 0",
+      "wall_clock_seconds": "host_side.deadline_seconds, enforced against the PID the jailer writes to host_side.pid_file \u2014 a guest cannot be trusted to time itself",
+      "workdir": "a second drive, writable, on an image created for this run and destroyed with the jail",
+      "workdir_quota_mib": "the size of that image, and --resource-limit fsize= in bytes for any single file within it"
+    },
+    "schema_version": "1.0",
+    "starts_nothing": true,
+    "vm_id": "c2-first-boot"
+  },
+  "schema_version": "1.0",
+  "stage": "C2",
+  "started_at": "2026-09-10T19:57:42Z",
+  "unjailed_image_check": {
+    "applied_containment": false,
+    "console_tail": "protocols = UNLABELED CIPSOv4 CALIPSO\n[    0.308213] NetLabel:  unlabeled traffic allowed by default\n[    0.309387] PCI: Using ACPI for IRQ routing\n[    0.311469] PCI: System does not support PCI\n[    0.313443] vgaarb: loaded\n[    0.314959] clocksource: Switched to clocksource kvm-clock\n[    0.317374] VFS: Disk quotas dquot_6.6.0\n[    0.318262] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)\n[    0.321718] pnp: PnP ACPI init\n[    0.323506] pnp: PnP ACPI: found 5 devices\n[    0.327109] NET: Registered PF_INET protocol family\n[    0.329540] IP idents hash table entries: 16384 (order: 5, 131072 bytes, linear)\n[    0.333554] tcp_listen_portaddr_hash hash table entries: 512 (order: 1, 8192 bytes, linear)\n[    0.337733] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)\n[    0.341612] TCP established hash table entries: 8192 (order: 4, 65536 bytes, linear)\n[    0.345504] TCP bind hash table entries: 8192 (order: 6, 262144 bytes, linear)\n[    0.349141] TCP: Hash tables configured (established 8192 bind 8192)\n[    0.352379] MPTCP token hash table entries: 1024 (order: 2, 24576 bytes, linear)\n[    0.356099] UDP hash table entries: 512 (order: 2, 16384 bytes, linear)\n[    0.359413] UDP-Lite hash table entries: 512 (order: 2, 16384 bytes, linear)\n[    0.362959] NET: Registered PF_UNIX/PF_LOCAL protocol family\n[    0.366064] RPC: Registered named UNIX socket transport module.\n[    0.369082] RPC: Registered udp transport module.\n[    0.371451] RPC: Registered tcp transport module.\n[    0.373787] RPC: Registered tcp NFSv4.1 backchannel transport module.\n[    0.377049] NET: Registered PF_XDP protocol family\n[    0.379463] PCI: CLS 0 bytes, default 64\n[    0.381605] clocksource: tsc: mask: 0xffffffffffffffff max_cycles: 0x233fdd7d99c, max_idle_ns: 440795312688 ns\n[    0.386653] clocksource: Switched to clocksource tsc\n[    0.389155] platform rtc_cmos: registered platform RTC device (no PNP device found)\n2026-09-10T20:03:28.769623864 [anonymous-instance:fc_vcpu 0] vcpu: IO read @ 0x87:0x1 failed: bus_error: MissingAddressRange\n[    0.393592] Initialise system trusted keyrings\n[    0.395867] Key type blacklist registered\n[    0.398335] workingset: timestamp_bits=36 max_order=18 bucket_order=0\n[    0.403549] zbud: loaded\n[    0.405358] squashfs: version 4.0 (2009/01/31) Phillip Lougher\n[    0.408546] NFS: Registering the id_resolver key type\n[    0.411100] Key type id_resolver registered\n[    0.413186] Key type id_legacy registered\n[    0.415255] nfs4filelayout_init: NFSv4 File Layout Driver Registering...\n[    0.418670] SGI XFS with ACLs, security attributes, quota, no debug enabled\n[    0.438871] Key type asymmetric registered\n[    0.440916] Asymmetric key parser 'x509' registered\n[    0.443417] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 251)\n[    0.447216] io scheduler mq-deadline registered\n[    0.449471] io scheduler kyber registered\n[    0.451547] io scheduler bfq registered\n[    0.454390] Serial: 8250/16550 driver, 1 ports, IRQ sharing disabled\n[    0.457791] 00:00: ttyS0 at I/O 0x3f8 (irq = 27, base_baud = 115200) is a 16550A\n[    0.464826] loop: module loaded\n[    0.466640] virtio_blk virtio0: 1/0/0 default/read/poll queues\n[    0.470352] virtio_blk virtio0: [vda] 17846272 512-byte logical blocks (9.14 GB/8.51 GiB)\n[    0.475082] virtio_blk virtio1: 1/0/0 default/read/poll queues\n[    0.478411] virtio_blk virtio1: [vdb] 524288 512-byte logical blocks (268 MB/256 MiB)\n[    0.482926] Loading iSCSI transport class v2.0-870.\n[    0.485671] iscsi: registered transport (tcp)\n[    0.487932] i8042: PNP: PS/2 Controller [PNP0303:PS2] at 0x60,0x64 irq 29\n[    0.491360] i8042: PNP: PS/2 appears to have AUX port disabled, if this is incorrect please boot with i8042.nopnp\n[    0.496875] serio: i8042 KBD port at 0x60,0x64 irq 29\n[    0.500003] hid: raw HID events driver (C) Jiri Kosina\n[    0.502808] Initializing XFRM netlink socket\n[    0.505077] NET: Registered PF_INET6 protocol family\n[    0.508196] Segment Routing with IPv6\n[    0.510034] In-situ OAM (IOAM) with IPv6\n[    0.512577] bpfilter: Loaded bpfilter_umh pid 161\n[    0.515413] NET: Registered PF_PACKET protocol family\n[    0.517909] Bridge firewalling registered\n[    0.519991] Key type dns_resolver registered\n[    0.522219] NET: Registered PF_VSOCK protocol family\n[    0.524751] IPI shorthand broadcast: enabled\n[    0.526936] sched_clock: Marking stable (324812158, 202079187)->(628943549, -102052204)\n[    0.531132] registered taskstats version 1\n[    0.533333] Loading compiled-in X.509 certificates\n[    0.535876] zswap: loaded using pool lzo/zbud\n[    0.538229] Key type .fscrypt registered\n[    0.540184] Key type fscrypt-provisioning registered\n[    0.542831] Key type encrypted registered\n[    0.546206] clk: Disabling unused clocks\n[    1.006898] input: AT Raw Set 2 keyboard as /devices/platform/i8042/serio0/input/input0\n[    1.010806] EXT4-fs (vda): mounted filesystem with ordered data mode. Quota mode: none.\n[    1.012937] VFS: Mounted root (ext4 filesystem) readonly on device 254:0.\n[    1.014954] devtmpfs: mounted\n[    1.016174] Freeing unused kernel image (initmem) memory: 2664K\n[    1.017737] Write protecting the kernel read-only data: 18432k\n[    1.019754] Freeing unused kernel image (text/rodata gap) memory: 2044K\n[    1.021663] Freeing unused kernel image (rodata/data gap) memory: 1792K\n[    1.023482] Run /gdpval-init as init process\n[    1.043688] EXT4-fs (vdb): mounted filesystem with ordered data mode. Quota mode: none.\n[    1.084521] EXT4-fs (vdb): unmounting filesystem.\n[    1.087197] sysrq: Resetting\n2026-09-10T20:03:29.464756131 [anonymous-instance:main] Vmm is stopping.\n2026-09-10T20:03:29.464797561 [anonymous-instance:fc_vcpu 0] Requested a vCPU run with immediate_exit enabled. The operation was skipped\n2026-09-10T20:03:29.464936779 [anonymous-instance:main] Vmm is stopping.\n2026-09-10T20:03:29.484062834 [anonymous-instance:main] Firecracker exiting successfully. exit_code=0\n",
+    "returncode": 0,
+    "this_is_not_the_contained_run": true,
+    "timed_out": false,
+    "what_it_proves": "only that these two images boot; no rule was applied"
+  },
+  "what_this_is_not": "not exec_run, not a model call, not a task. No flag was changed and nothing here is wired into the product path."
+}

--- a/tasks/0822_saturday/c3_attacks.json
+++ b/tasks/0822_saturday/c3_attacks.json
@@ -1,0 +1,669 @@
+{
+ "boots": {
+  "memory": {
+   "channel": "the work disk only: no network by policy, vsock pinned absent, and --daemonize sends the console to /dev/null",
+   "command": "\ngrep MemTotal /proc/meminfo\n\n# Two things about the shape of this attack, both learned from a run where the\n# bound held and the attack reported nothing, which reads as a failure.\n#\n# The allocation has to be charged to the process making it. tmpfs pages are\n# shmem and count against no process's RSS, so when the machine filled, the\n# kernel's OOM killer found nothing large to pick and took a bystander. And the\n# reporter cannot be a child: `rc=$?` inside a command substitution runs in a\n# fork, and that fork was the bystander it took. The attack destroyed its own\n# evidence.\n#\n# So: anonymous memory, touched a page at a time, which makes the allocator the\n# largest thing in the machine and the unambiguous target; and the report is\n# made by the top-level shell, which allocates nothing and is never picked.\ncat > /work/gdpval-allocate.py <<'PY'\nimport sys\n\nstep = 64 * 1024 * 1024\ntarget = 6144 * 1024 * 1024\nheld = []\nallocated = 0\nwhile allocated < target:\n    # bytearray(n) is calloc, and calloc over a fresh mapping is a promise of\n    # zeroes rather than pages. Untouched it would allocate address space and\n    # never reach the bound at all.\n    block = bytearray(step)\n    for offset in range(0, step, 4096):\n        block[offset] = 1\n    held.append(block)\n    allocated += step\n    sys.stdout.write(\"allocated_mib=%d\\n\" % (allocated // (1024 * 1024)))\n    sys.stdout.flush()\nsys.stdout.write(\"ALLOCATED_ALL\\n\")\nPY\npython3 /work/gdpval-allocate.py &\nallocator=$!\nwait \"$allocator\"\necho \"rc=$?\"\nrm -f /work/gdpval-allocate.py\n",
+   "command_exit_status": 0,
+   "deadline_seconds": 1200.0,
+   "jailer": {
+    "argv": [
+     "--id",
+     "c3-memory",
+     "--exec-file",
+     "/usr/local/bin/firecracker",
+     "--uid",
+     "999",
+     "--gid",
+     "988",
+     "--chroot-base-dir",
+     "/srv/jailer",
+     "--cgroup-version",
+     "2",
+     "--cgroup",
+     "memory.max=4563402752",
+     "--resource-limit",
+     "fsize=268435456",
+     "--new-pid-ns",
+     "--daemonize",
+     "--",
+     "--config-file",
+     "/vmconfig.json",
+     "--no-api"
+    ],
+    "returncode": 0,
+    "stderr": ""
+   },
+   "outcome": "booted",
+   "pid_file": {
+    "appeared": true,
+    "path": "/srv/jailer/firecracker/c3-memory/root/firecracker.pid",
+    "pid_recorded": true
+   },
+   "placement": {
+    "chroot_dir": "/srv/jailer/firecracker/c3-memory/root",
+    "placed": [
+     {
+      "bytes": 41865904,
+      "in_jail": "/vmlinux",
+      "mode": "0o444",
+      "owned_by_the_jailed_user": false,
+      "sha256": "b36a4a1b10f33b9cfdcde3d1a787d9c090556a3edb211cd06d1f3f9a6c7e8724"
+     },
+     {
+      "bytes": 9137291264,
+      "in_jail": "/rootfs.ext4",
+      "mode": "0o444",
+      "owned_by_the_jailed_user": false,
+      "sha256": "489188004ad4eb8a90191b3b5f58eb9fb246d158535d0bc655001f438a7a32ea"
+     },
+     {
+      "bytes": 268435456,
+      "in_jail": "/work.ext4",
+      "mode": "0o644",
+      "owned_by_the_jailed_user": true,
+      "sha256": "d0f5906b016eb0898837a686f9af1cc179257e08532dc10a7a5c2f017644d4fd"
+     },
+     {
+      "bytes": 545,
+      "in_jail": "/vmconfig.json",
+      "mode": "0o444",
+      "owned_by_the_jailed_user": false,
+      "sha256": "de668f79dac7fe51ebe12ba1e0d37936ff8ca6859247cae7324f1c5b4a3cbaf7"
+     }
+    ]
+   },
+   "plan_sha256": "6e342ead12ecbe962721397998abd8b04057e1b07364deb2fdfb6801fda18804",
+   "policy_is_the_required_one": true,
+   "policy_sha256": "6a5e665d3253c80302f001e8fd624b77838c38f92add1af63024277c5215888e",
+   "policy_used": {
+    "credentials": "none-inherited",
+    "memory_mib": 4096,
+    "network": "none",
+    "on_breach": "stop-and-report",
+    "required": true,
+    "rootfs": "read-only",
+    "runtime": "firecracker",
+    "user": "jailer-unprivileged",
+    "wall_clock_seconds": 1200,
+    "workdir": "ephemeral-quota",
+    "workdir_quota_mib": 256
+   },
+   "ran_for_seconds": 4.02,
+   "results": {
+    "/out/exit_status": "0\n",
+    "/out/guest_kernel": "6.1.141\n",
+    "/out/guest_uid": "0\n",
+    "/out/init_reached_the_end": "done\n",
+    "/out/stderr": "Killed\n",
+    "/out/stdout": "MemTotal:        4036852 kB\nallocated_mib=64\nallocated_mib=128\nallocated_mib=192\nallocated_mib=256\nallocated_mib=320\nallocated_mib=384\nallocated_mib=448\nallocated_mib=512\nallocated_mib=576\nallocated_mib=640\nallocated_mib=704\nallocated_mib=768\nallocated_mib=832\nallocated_mib=896\nallocated_mib=960\nallocated_mib=1024\nallocated_mib=1088\nallocated_mib=1152\nallocated_mib=1216\nallocated_mib=1280\nallocated_mib=1344\nallocated_mib=1408\nallocated_mib=1472\nallocated_mib=1536\nallocated_mib=1600\nallocated_mib=1664\nallocated_mib=1728\nallocated_mib=1792\nallocated_mib=1856\nallocated_mib=1920\nallocated_mib=1984\nallocated_mib=2048\nallocated_mib=2112\nallocated_mib=2176\nallocated_mib=2240\nallocated_mib=2304\nallocated_mib=2368\nallocated_mib=2432\nallocated_mib=2496\nallocated_mib=2560\nallocated_mib=2624\nallocated_mib=2688\nallocated_mib=2752\nallocated_mib=2816\nallocated_mib=2880\nallocated_mib=2944\nallocated_mib=3008\nallocated_mib=3072\nallocated_mib=3136\nallocated_mib=3200\nallocated_mib=3264\nallocated_mib=3328\nallocated_mib=3392\nallocated_mib=3456\nallocated_mib=3520\nallocated_mib=3584\nallocated_mib=3648\nallocated_mib=3712\nallocated_mib=3776\nrc=137\n"
+   },
+   "schema_version": "1.0",
+   "stopped_by_the_deadline": false,
+   "teardown": {
+    "all_gone": true,
+    "removed": {
+     "/srv/jailer/firecracker/c3-memory/root": true
+    }
+   },
+   "vm_id": "c3-memory",
+   "work_disk": {
+    "argv": [
+     "mke2fs",
+     "-q",
+     "-F",
+     "-t",
+     "ext4",
+     "-b",
+     "4096",
+     "-d",
+     "/var/tmp/gdpval-c3/work-in-memory",
+     "/var/tmp/gdpval-c3/work-memory.ext4",
+     "65536"
+    ],
+    "path": "/var/tmp/gdpval-c3/work-memory.ext4",
+    "populated_from": "/var/tmp/gdpval-c3/work-in-memory",
+    "sha256": "d0f5906b016eb0898837a686f9af1cc179257e08532dc10a7a5c2f017644d4fd",
+    "size_mib": 256
+   }
+  },
+  "probes": {
+   "channel": "the work disk only: no network by policy, vsock pinned absent, and --daemonize sends the console to /dev/null",
+   "command": "\necho \"== network ==\"\ncat /proc/net/dev 2>/dev/null | awk 'NR>2 {print $1}' | tr -d ':'\npython3 - <<'PY' 2>&1 || echo \"connect_probe=no-python\"\nimport socket\ntry:\n    socket.create_connection((\"1.1.1.1\", 443), 5).close()\n    print(\"connect_probe=CONNECTED\")\nexcept OSError as failure:\n    print(\"connect_probe=refused:%s\" % failure.__class__.__name__)\nPY\n\necho \"== rootfs ==\"\ngrep ' / ' /proc/mounts\nif echo probe > /gdpval-root-write-probe 2>/dev/null; then\n  echo \"rootfs_write=SUCCEEDED\"\n  rm -f /gdpval-root-write-probe\nelse\n  echo \"rootfs_write=refused\"\nfi\n\necho \"== memory bound ==\"\ngrep MemTotal /proc/meminfo\n\necho \"== credentials ==\"\necho \"env_count=$(env | wc -l)\"\nenv | grep -Ei 'KEY|TOKEN|SECRET|PASSWORD|AZURE|OPENAI|ANTHROPIC|GITHUB' \\\n  && echo \"guest_env=CARRIES SOMETHING\" || echo \"guest_env=clean\"\necho \"self_environ_bytes=$(wc -c < /proc/1/environ 2>/dev/null || echo unknown)\"\n\n# Two of the seven are facts about the host-side process rather than about\n# anything in here, and they can only be read while it is alive. C2's guest\n# was gone 1.269 seconds after the jailer started it, which is not reliably\n# long enough for a watcher to land a /proc read. This holds the machine open\n# and weakens nothing: the deadline still applies, and a guest that hangs past\n# it is attack 3.\necho \"holding_open=8s\"\nsleep 8\n",
+   "command_exit_status": 0,
+   "deadline_seconds": 1200.0,
+   "jailer": {
+    "argv": [
+     "--id",
+     "c3-probes",
+     "--exec-file",
+     "/usr/local/bin/firecracker",
+     "--uid",
+     "999",
+     "--gid",
+     "988",
+     "--chroot-base-dir",
+     "/srv/jailer",
+     "--cgroup-version",
+     "2",
+     "--cgroup",
+     "memory.max=4563402752",
+     "--resource-limit",
+     "fsize=268435456",
+     "--new-pid-ns",
+     "--daemonize",
+     "--",
+     "--config-file",
+     "/vmconfig.json",
+     "--no-api"
+    ],
+    "returncode": 0,
+    "stderr": ""
+   },
+   "outcome": "booted",
+   "pid_file": {
+    "appeared": true,
+    "path": "/srv/jailer/firecracker/c3-probes/root/firecracker.pid",
+    "pid_recorded": true
+   },
+   "placement": {
+    "chroot_dir": "/srv/jailer/firecracker/c3-probes/root",
+    "placed": [
+     {
+      "bytes": 41865904,
+      "in_jail": "/vmlinux",
+      "mode": "0o444",
+      "owned_by_the_jailed_user": false,
+      "sha256": "b36a4a1b10f33b9cfdcde3d1a787d9c090556a3edb211cd06d1f3f9a6c7e8724"
+     },
+     {
+      "bytes": 9137291264,
+      "in_jail": "/rootfs.ext4",
+      "mode": "0o444",
+      "owned_by_the_jailed_user": false,
+      "sha256": "489188004ad4eb8a90191b3b5f58eb9fb246d158535d0bc655001f438a7a32ea"
+     },
+     {
+      "bytes": 268435456,
+      "in_jail": "/work.ext4",
+      "mode": "0o644",
+      "owned_by_the_jailed_user": true,
+      "sha256": "21ac5e388f0ef036a391182fffd95030f57eebfa212790eb524038c4205c2dca"
+     },
+     {
+      "bytes": 545,
+      "in_jail": "/vmconfig.json",
+      "mode": "0o444",
+      "owned_by_the_jailed_user": false,
+      "sha256": "de668f79dac7fe51ebe12ba1e0d37936ff8ca6859247cae7324f1c5b4a3cbaf7"
+     }
+    ]
+   },
+   "plan_sha256": "f79f1fe72aae66d543721713bc49938b90ef429e38020081825d4cbd5fe3b45d",
+   "policy_is_the_required_one": true,
+   "policy_sha256": "6a5e665d3253c80302f001e8fd624b77838c38f92add1af63024277c5215888e",
+   "policy_used": {
+    "credentials": "none-inherited",
+    "memory_mib": 4096,
+    "network": "none",
+    "on_breach": "stop-and-report",
+    "required": true,
+    "rootfs": "read-only",
+    "runtime": "firecracker",
+    "user": "jailer-unprivileged",
+    "wall_clock_seconds": 1200,
+    "workdir": "ephemeral-quota",
+    "workdir_quota_mib": 256
+   },
+   "ran_for_seconds": 9.272,
+   "results": {
+    "/out/exit_status": "0\n",
+    "/out/guest_kernel": "6.1.141\n",
+    "/out/guest_uid": "0\n",
+    "/out/init_reached_the_end": "done\n",
+    "/out/stderr": "/work/in/command.sh: 15: cannot create /gdpval-root-write-probe: Read-only file system\n",
+    "/out/stdout": "== network ==\nlo\nconnect_probe=refused:OSError\n== rootfs ==\n/dev/root / ext4 ro,relatime 0 0\nrootfs_write=refused\n== memory bound ==\nMemTotal:        4036852 kB\n== credentials ==\nenv_count=4\nguest_env=clean\nself_environ_bytes=18\nholding_open=8s\n"
+   },
+   "schema_version": "1.0",
+   "stopped_by_the_deadline": false,
+   "teardown": {
+    "all_gone": true,
+    "removed": {
+     "/srv/jailer/firecracker/c3-probes/root": true
+    }
+   },
+   "vm_id": "c3-probes",
+   "watched": {
+    "canaries_in_environment": [],
+    "descriptors": {
+     "0": "/dev/null",
+     "1": "/dev/null",
+     "10": "/work.ext4",
+     "11": "anon_inode:[timerfd]",
+     "12": "anon_inode:[eventfd]",
+     "13": "anon_inode:[eventfd]",
+     "14": "/dev/kvm",
+     "15": "anon_inode:kvm-vm",
+     "16": "anon_inode:[eventfd]",
+     "17": "anon_inode:[eventfd]",
+     "18": "anon_inode:kvm-vcpu:0",
+     "19": "anon_inode:[eventfd]",
+     "2": "/dev/null",
+     "20": "anon_inode:[eventfd]",
+     "21": "anon_inode:[eventfd]",
+     "22": "anon_inode:[eventfd]",
+     "23": "anon_inode:[eventfd]",
+     "24": "anon_inode:[eventfd]",
+     "25": "anon_inode:[eventfd]",
+     "26": "anon_inode:[eventfd]",
+     "27": "anon_inode:[eventfd]",
+     "28": "anon_inode:[eventfd]",
+     "3": "anon_inode:[eventpoll]",
+     "4": "anon_inode:[timerfd]",
+     "6": "/rootfs.ext4",
+     "7": "anon_inode:[timerfd]",
+     "8": "anon_inode:[eventfd]",
+     "9": "anon_inode:[eventfd]"
+    },
+    "descriptors_reaching_the_orchestrator": [],
+    "environment_names": [],
+    "environment_seen": 0,
+    "expected_uid": 999,
+    "pid": 1979,
+    "read_at": "2026-09-10T20:36:49Z",
+    "real_uid": 999,
+    "standard_descriptors": {
+     "0": "/dev/null",
+     "1": "/dev/null",
+     "2": "/dev/null"
+    },
+    "supplementary_groups": []
+   },
+   "work_disk": {
+    "argv": [
+     "mke2fs",
+     "-q",
+     "-F",
+     "-t",
+     "ext4",
+     "-b",
+     "4096",
+     "-d",
+     "/var/tmp/gdpval-c3/work-in-probes",
+     "/var/tmp/gdpval-c3/work-probes.ext4",
+     "65536"
+    ],
+    "path": "/var/tmp/gdpval-c3/work-probes.ext4",
+    "populated_from": "/var/tmp/gdpval-c3/work-in-probes",
+    "sha256": "21ac5e388f0ef036a391182fffd95030f57eebfa212790eb524038c4205c2dca",
+    "size_mib": 256
+   }
+  },
+  "wall-clock": {
+   "channel": "the work disk only: no network by policy, vsock pinned absent, and --daemonize sends the console to /dev/null",
+   "command": "\necho 'about to hang on purpose'\nwhile true; do sleep 5; done\n",
+   "command_exit_status": null,
+   "deadline_seconds": 45.0,
+   "jailer": {
+    "argv": [
+     "--id",
+     "c3-wall-clock",
+     "--exec-file",
+     "/usr/local/bin/firecracker",
+     "--uid",
+     "999",
+     "--gid",
+     "988",
+     "--chroot-base-dir",
+     "/srv/jailer",
+     "--cgroup-version",
+     "2",
+     "--cgroup",
+     "memory.max=4563402752",
+     "--resource-limit",
+     "fsize=268435456",
+     "--new-pid-ns",
+     "--daemonize",
+     "--",
+     "--config-file",
+     "/vmconfig.json",
+     "--no-api"
+    ],
+    "returncode": 0,
+    "stderr": ""
+   },
+   "outcome": "stopped_by_the_deadline",
+   "pid_file": {
+    "appeared": true,
+    "path": "/srv/jailer/firecracker/c3-wall-clock/root/firecracker.pid",
+    "pid_recorded": true
+   },
+   "placement": {
+    "chroot_dir": "/srv/jailer/firecracker/c3-wall-clock/root",
+    "placed": [
+     {
+      "bytes": 41865904,
+      "in_jail": "/vmlinux",
+      "mode": "0o444",
+      "owned_by_the_jailed_user": false,
+      "sha256": "b36a4a1b10f33b9cfdcde3d1a787d9c090556a3edb211cd06d1f3f9a6c7e8724"
+     },
+     {
+      "bytes": 9137291264,
+      "in_jail": "/rootfs.ext4",
+      "mode": "0o444",
+      "owned_by_the_jailed_user": false,
+      "sha256": "489188004ad4eb8a90191b3b5f58eb9fb246d158535d0bc655001f438a7a32ea"
+     },
+     {
+      "bytes": 268435456,
+      "in_jail": "/work.ext4",
+      "mode": "0o644",
+      "owned_by_the_jailed_user": true,
+      "sha256": "7b71d29c2b4b8f5784c03b4bbab30198d65b1908115b1db2993ef71144346888"
+     },
+     {
+      "bytes": 545,
+      "in_jail": "/vmconfig.json",
+      "mode": "0o444",
+      "owned_by_the_jailed_user": false,
+      "sha256": "de668f79dac7fe51ebe12ba1e0d37936ff8ca6859247cae7324f1c5b4a3cbaf7"
+     }
+    ]
+   },
+   "plan_sha256": "d3aef11ce67a5d16a83b6682c6e7020fb6cc6d5dee4f475dd8e36ba0e9db4c3f",
+   "policy_is_the_required_one": false,
+   "policy_sha256": "10cd2a5130ecdc1e6b29912b1b8ffc192319fb7c7ba44b86ad56bed2c86b5f10",
+   "policy_used": {
+    "credentials": "none-inherited",
+    "memory_mib": 4096,
+    "network": "none",
+    "on_breach": "stop-and-report",
+    "required": true,
+    "rootfs": "read-only",
+    "runtime": "firecracker",
+    "user": "jailer-unprivileged",
+    "wall_clock_seconds": 45,
+    "workdir": "ephemeral-quota",
+    "workdir_quota_mib": 256
+   },
+   "ran_for_seconds": 45.042,
+   "results": {
+    "/out/exit_status": null,
+    "/out/guest_kernel": "6.1.141\n",
+    "/out/guest_uid": "0\n",
+    "/out/init_reached_the_end": null,
+    "/out/stderr": "",
+    "/out/stdout": "about to hang on purpose\n"
+   },
+   "schema_version": "1.0",
+   "stopped_by_the_deadline": true,
+   "teardown": {
+    "all_gone": true,
+    "removed": {
+     "/srv/jailer/firecracker/c3-wall-clock/root": true
+    }
+   },
+   "vm_id": "c3-wall-clock",
+   "work_disk": {
+    "argv": [
+     "mke2fs",
+     "-q",
+     "-F",
+     "-t",
+     "ext4",
+     "-b",
+     "4096",
+     "-d",
+     "/var/tmp/gdpval-c3/work-in-wall-clock",
+     "/var/tmp/gdpval-c3/work-wall-clock.ext4",
+     "65536"
+    ],
+    "path": "/var/tmp/gdpval-c3/work-wall-clock.ext4",
+    "populated_from": "/var/tmp/gdpval-c3/work-in-wall-clock",
+    "sha256": "7b71d29c2b4b8f5784c03b4bbab30198d65b1908115b1db2993ef71144346888",
+    "size_mib": 256
+   }
+  },
+  "workdir-quota": {
+   "channel": "the work disk only: no network by policy, vsock pinned absent, and --daemonize sends the console to /dev/null",
+   "command": "\necho \"quota_mib_configured=256\"\noutcome=$(dd if=/dev/zero of=/work/gdpval-filler bs=1M count=512 2>&1; echo \"rc=$?\")\nrm -f /work/gdpval-filler\nsync\necho \"$outcome\" | tail -3\n",
+   "command_exit_status": 0,
+   "deadline_seconds": 1200.0,
+   "jailer": {
+    "argv": [
+     "--id",
+     "c3-workdir-quota",
+     "--exec-file",
+     "/usr/local/bin/firecracker",
+     "--uid",
+     "999",
+     "--gid",
+     "988",
+     "--chroot-base-dir",
+     "/srv/jailer",
+     "--cgroup-version",
+     "2",
+     "--cgroup",
+     "memory.max=4563402752",
+     "--resource-limit",
+     "fsize=268435456",
+     "--new-pid-ns",
+     "--daemonize",
+     "--",
+     "--config-file",
+     "/vmconfig.json",
+     "--no-api"
+    ],
+    "returncode": 0,
+    "stderr": ""
+   },
+   "outcome": "booted",
+   "pid_file": {
+    "appeared": true,
+    "path": "/srv/jailer/firecracker/c3-workdir-quota/root/firecracker.pid",
+    "pid_recorded": true
+   },
+   "placement": {
+    "chroot_dir": "/srv/jailer/firecracker/c3-workdir-quota/root",
+    "placed": [
+     {
+      "bytes": 41865904,
+      "in_jail": "/vmlinux",
+      "mode": "0o444",
+      "owned_by_the_jailed_user": false,
+      "sha256": "b36a4a1b10f33b9cfdcde3d1a787d9c090556a3edb211cd06d1f3f9a6c7e8724"
+     },
+     {
+      "bytes": 9137291264,
+      "in_jail": "/rootfs.ext4",
+      "mode": "0o444",
+      "owned_by_the_jailed_user": false,
+      "sha256": "489188004ad4eb8a90191b3b5f58eb9fb246d158535d0bc655001f438a7a32ea"
+     },
+     {
+      "bytes": 268435456,
+      "in_jail": "/work.ext4",
+      "mode": "0o644",
+      "owned_by_the_jailed_user": true,
+      "sha256": "a28def4e56a72a65ec975a8740257b509ae2f820b4fc773ffe94d1f85276cca8"
+     },
+     {
+      "bytes": 545,
+      "in_jail": "/vmconfig.json",
+      "mode": "0o444",
+      "owned_by_the_jailed_user": false,
+      "sha256": "de668f79dac7fe51ebe12ba1e0d37936ff8ca6859247cae7324f1c5b4a3cbaf7"
+     }
+    ]
+   },
+   "plan_sha256": "d9e4312842d0a7399fde18f4b7ff859745fcef3b60e3a859d131c758d3bf97ab",
+   "policy_is_the_required_one": true,
+   "policy_sha256": "6a5e665d3253c80302f001e8fd624b77838c38f92add1af63024277c5215888e",
+   "policy_used": {
+    "credentials": "none-inherited",
+    "memory_mib": 4096,
+    "network": "none",
+    "on_breach": "stop-and-report",
+    "required": true,
+    "rootfs": "read-only",
+    "runtime": "firecracker",
+    "user": "jailer-unprivileged",
+    "wall_clock_seconds": 1200,
+    "workdir": "ephemeral-quota",
+    "workdir_quota_mib": 256
+   },
+   "ran_for_seconds": 1.518,
+   "results": {
+    "/out/exit_status": "0\n",
+    "/out/guest_kernel": "6.1.141\n",
+    "/out/guest_uid": "0\n",
+    "/out/init_reached_the_end": "done\n",
+    "/out/stderr": "",
+    "/out/stdout": "quota_mib_configured=256\n218+0 records out\n229175296 bytes (229 MB, 219 MiB) copied, 0.297843 s, 769 MB/s\nrc=1\n"
+   },
+   "schema_version": "1.0",
+   "stopped_by_the_deadline": false,
+   "teardown": {
+    "all_gone": true,
+    "removed": {
+     "/srv/jailer/firecracker/c3-workdir-quota/root": true
+    }
+   },
+   "vm_id": "c3-workdir-quota",
+   "work_disk": {
+    "argv": [
+     "mke2fs",
+     "-q",
+     "-F",
+     "-t",
+     "ext4",
+     "-b",
+     "4096",
+     "-d",
+     "/var/tmp/gdpval-c3/work-in-workdir-quota",
+     "/var/tmp/gdpval-c3/work-workdir-quota.ext4",
+     "65536"
+    ],
+    "path": "/var/tmp/gdpval-c3/work-workdir-quota.ext4",
+    "populated_from": "/var/tmp/gdpval-c3/work-in-workdir-quota",
+    "sha256": "a28def4e56a72a65ec975a8740257b509ae2f820b4fc773ffe94d1f85276cca8",
+    "size_mib": 256
+   }
+  }
+ },
+ "elapsed_seconds": 239.2,
+ "finished_at": "2026-09-10T20:40:01Z",
+ "host": {
+  "cgroup_evidence": "/sys/fs/cgroup/cgroup.controllers exists",
+  "cgroup_version": 2,
+  "firecracker": "/usr/local/bin/firecracker",
+  "firecracker_version": "Firecracker v1.13.1",
+  "jailer": "/usr/local/bin/jailer",
+  "jailer_version": "Jailer v1.13.1",
+  "kernel_release": "6.17.0-1022-azure",
+  "kvm_present": true,
+  "processors": 8,
+  "read_at": "2026-09-10T20:36:02Z"
+ },
+ "images": {
+  "c2_recorded": {
+   "kernel_sha256": "b36a4a1b10f33b9cfdcde3d1a787d9c090556a3edb211cd06d1f3f9a6c7e8724",
+   "rootfs_sha256": "489188004ad4eb8a90191b3b5f58eb9fb246d158535d0bc655001f438a7a32ea"
+  },
+  "kernel_sha256": "b36a4a1b10f33b9cfdcde3d1a787d9c090556a3edb211cd06d1f3f9a6c7e8724",
+  "matches_the_guest_c2_booted": true,
+  "rootfs_sha256": "489188004ad4eb8a90191b3b5f58eb9fb246d158535d0bc655001f438a7a32ea"
+ },
+ "jail_account": {
+  "gid": 988,
+  "groups_beyond_its_own": [],
+  "name": "gdpvaljail",
+  "shell": "/usr/sbin/nologin",
+  "uid": 999
+ },
+ "judgement": {
+  "all_seven_stopped": true,
+  "attempted": 7,
+  "escapes": [],
+  "how_absent_evidence_is_treated": "as a failure of that attack. A probe that did not run and a rule that did not hold leave the same silence, and calling silence a pass would let a guest that never booted sweep all seven.",
+  "schema_version": "1.0",
+  "stopped": 7,
+  "verdicts": [
+   {
+    "evidence": "the write past the quota failed: rc=1",
+    "id": "workdir-quota",
+    "number": 1,
+    "observed": "guest",
+    "rule_it_enforced": "workdir_quota_mib",
+    "rule_value": 256,
+    "stopped": true,
+    "what_it_tried": "write twice the quota into the ephemeral work disk"
+   },
+   {
+    "evidence": "the guest sees 3942 MiB against a 4096 MiB bound and the over-allocation was stopped, having reached 3776 MiB: rc=137",
+    "id": "memory",
+    "number": 2,
+    "observed": "guest",
+    "rule_it_enforced": "memory_mib",
+    "rule_value": 4096,
+    "stopped": true,
+    "what_it_tried": "allocate half again the memory bound inside the guest"
+   },
+   {
+    "evidence": "the guest hung and was stopped after 45.042s against a 45.0s bound, and its chroot is gone",
+    "id": "wall-clock",
+    "number": 3,
+    "observed": "host",
+    "rule_it_enforced": "wall_clock_seconds",
+    "rule_value": 1200,
+    "stopped": true,
+    "what_it_tried": "never finish"
+   },
+   {
+    "evidence": "no interface but loopback in /proc/net/dev and the connection attempt failed: connect_probe=refused:OSError",
+    "id": "network",
+    "number": 4,
+    "observed": "guest",
+    "rule_it_enforced": "network",
+    "rule_value": "none",
+    "stopped": true,
+    "what_it_tried": "find an interface and open a connection through it"
+   },
+   {
+    "evidence": "the write was refused and / is mounted read-only: /dev/root / ext4 ro,relatime 0 0",
+    "id": "read-only-root",
+    "number": 5,
+    "observed": "guest",
+    "rule_it_enforced": "rootfs",
+    "rule_value": "read-only",
+    "stopped": true,
+    "what_it_tried": "write a file into the root filesystem"
+   },
+   {
+    "evidence": "the host-side Firecracker process runs as uid 999 with no supplementary groups",
+    "id": "privileged-user",
+    "number": 6,
+    "observed": "host",
+    "rule_it_enforced": "user",
+    "rule_value": "jailer-unprivileged",
+    "stopped": true,
+    "what_it_tried": "be a host-side process that kept root, which the guest cannot see and so cannot be asked about"
+   },
+   {
+    "evidence": "the host process's environment holds 0 entries with none of the canaries, its 28 descriptors reach nothing of the orchestrator's, all three standard ones are /dev/null, and the guest's environment is clean",
+    "id": "inherited-credentials",
+    "number": 7,
+    "observed": "host and guest",
+    "rule_it_enforced": "credentials",
+    "rule_value": "none-inherited",
+    "stopped": true,
+    "what_it_tried": "reach a token the orchestrator holds, through the environment and through an inherited descriptor"
+   }
+  ]
+ },
+ "outcome": "all_seven_stopped",
+ "schema_version": "1.0",
+ "stage": "C3",
+ "started_at": "2026-09-10T20:36:02Z",
+ "what_this_is_not": "not exec_run, not a model call, not a task. No flag was changed, no rule was relaxed, and nothing here is wired into the product path."
+}


### PR DESCRIPTION
## What this is

Stage C2 of Agentic Sandbox V2: **a guest actually booted under the jailer**, on a
real host, under the policy C1 turned into arguments. Plus the C3 attack module
that judges whether those arguments have the effect their names suggest.

No flag was flipped. `foundation_only`, `production_activation` and the `exec_run`
guard are all untouched — this stage is evidence, not activation.

## The boot that happened

`gdpval-devhost-vm` (`RG-GDPVAL-DEVHOST-KRC`), 2026-09-10T19:57:42Z → 20:05:37Z,
475.6 s wall clock for the whole run.

| | |
|---|---|
| outcome | `booted`, guest command `exit_status: 0` |
| ran for | 1.269 s against a 1200 s bound |
| jailer | rc 0, empty stderr, PID file present |
| teardown | `all_gone: true` |

What the guest itself reported back through the work disk: kernel `6.1.141`,
uid 0 *inside its own machine*, `/dev/vda on / type ext4 (ro,relatime)`,
"rootfs refused a write, as the rule says it must", and `python answered 4`.

The deadline was tested separately in the same run with a guest that hangs on
purpose: it fired at 45.042 s and the chroot was destroyed.

Everything is pinned by hash — Firecracker/Jailer v1.13.1, host kernel
`6.17.0-1022-azure`, cgroup v2, jail account `gdpvaljail` uid 999 gid 988
`/usr/sbin/nologin`, guest kernel `b36a4a1b…`, image index `sha256:ee6ef798…`
→ amd64 manifest `sha256:91b524c7…`, rootfs `489188004ad4eb8a…`.

**On kernel provenance, stated plainly:** upstream publishes no checksum and no
signature for `vmlinux-6.1.141`, and its support window lapsed 2026-09-02. The
sha256 recorded here was computed locally on download. That is a record of what
we fetched, not a provider attestation, and the artefact says so.

## Two bugs the real image found

1. `member.name.lstrip("./")` takes a *set of characters*, not a prefix. `"."`
   became `""` and was refused; `"../x"` became `"x"` and `"/etc/shadow"` became
   `"etc/shadow"` — both silently allowed. So the check refused the real image
   and would have let a real escape through. Now `os.path.normpath`.
2. Fixing that surfaced a latent one: **no `init=` in the boot args.** Without it
   the kernel falls through to `/bin/sh` on a `/dev/null` console — a machine
   that boots, runs nothing, writes nothing, and waits out the full deadline.

## The seven attacks (C3), and the one way of judging them that would be a lie

`core/agentic_v2_containment_attacks.py` is pure data and pure judging, so it is
unit-testable on a box that cannot boot anything. `scripts/run_agentic_c3_attacks.py`
is the host side.

**Absent evidence is never a pass.** A guest that panicked on boot and a guest
that was contained leave identical silence. Every verdict starts at *not stopped*
and has to be argued into *stopped* by something actually read back. There is a
parametrized test over all seven attacks that drops each one's boot and asserts
it fails.

**Two of the seven cannot be answered from inside the guest.** `user` and
`credentials` are facts about the host-side Firecracker process — inside the
machine PID 1 is root in every guest, including the ones that pass. Those are
read from `/proc/<pid>` by a watcher while the machine is alive, which is why the
probe boot now holds itself open for 8 s (C2's guest was gone in 1.269 s).

`credentials` checks both halves. The jailer wipes the environment unconditionally,
but the three standard descriptors are redirected by `--daemonize` and by nothing
else — so an attack that checked only the environment would pass on a launcher
that had quietly dropped the flag.

**The destructive attacks get their own boots.** Filling the work disk destroys
the only channel the guest can answer on; provoking the memory bound can take the
guest down with it. Either would erase another attack's evidence, and erased
evidence reads as failure.

The deadline attack is run against a shortened bound so the stop can be watched.
That is done by handing `build_launch_plan` a *different policy dict* — a supported
argument that still refuses missing, unknown or out-of-reach rules — and the
artefact records `policy_is_the_required_one: false`. No rule was relaxed to make
a test pass.

## Tests

`9874 passed, 18 skipped` on the full backend suite. 33 of those are the new C3
judging tests; the C2 boot and guest-image modules add 24 and 26.

## Not done here

C3 has not run on the host yet — that is the next commit, and its exit condition
is all seven stopped with each stop naming the rule it enforced. Six and a note
is a failure.
