### PR TITLE
fix(codex): publish how far a turn got and what refused it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,6 +261,29 @@ entries land under a fresh dated heading the day they merge to `main`.
   file is the decision the pin asks to see.
 
 ### Fixed
+- **How far a Codex turn got was measured and then left behind.** The
+  preceding entry added `items_seen` and the provider's own
+  `http_status_code`, and wrote both to `CodexAgentRunner.last_run_diagnostics`
+  — an attribute nothing in production reads. `grep -rn last_run_diagnostics
+  --include=*.py` finds the assignment and one test. The two numbers therefore
+  reached no results file, no report and no artifact of any run, and the
+  rate-limit question they were added to answer still could not be answered
+  from a downloaded run.
+
+  They now travel out on the runner's result, and Step 2 puts them in the
+  task's `observability` record under `codex`, beside `error_category` — which
+  was moved there for exactly this reason: every backend produced it, and the
+  backends that kept it kept it inside their own metrics, where a caller that
+  does not know which backend ran cannot find it.
+
+  What the turn spent is deliberately not carried along. The cost ledger
+  already records it against the same task id, and a second copy is a second
+  figure that can disagree with the first. A status outside 100–599 is
+  dropped rather than published, on the same reasoning as `bounded_count`
+  beside it: a published number is read as a measurement, so saying nothing
+  beats saying something wrong. An absent `codex` key means no Codex turn ran,
+  not a turn that completed zero items.
+
 - **A refused turn threw away the measurement of what it had already spent.**
   Run `34500590783` wrote nine ledger rows and settled two. The seven with
   empty token fields are the tasks the provider refused mid-stream, and they

--- a/batch-runner/core/codex_runner.py
+++ b/batch-runner/core/codex_runner.py
@@ -1026,6 +1026,16 @@ class CodexAgentRunner(RecordsItsFirstRequest):
             "success": outcome.success,
             "text": outcome.text,
             "files": outcome.files,
+            # The same two numbers, on the way out rather than on the runner.
+            # `last_run_diagnostics` is an attribute no caller reads, so until
+            # now how far a turn got and what refused it were measured and then
+            # left behind here. What the turn spent is deliberately not
+            # repeated: the cost ledger already carries it under this task id,
+            # and a second copy is a second thing to disagree with the first.
+            "codex_diagnostics": {
+                "items_seen": outcome.items_seen,
+                "http_status_code": outcome.http_status_code,
+            },
         }
         if outcome.error:
             result["error"] = outcome.error

--- a/batch-runner/step2_run_inference.py
+++ b/batch-runner/step2_run_inference.py
@@ -1135,6 +1135,9 @@ def _build_execution_observability(
     agentic_metrics = _bounded_agentic_metrics((result or {}).get("agentic_metrics"))
     if agentic_metrics:
         observability["agentic_metrics"] = agentic_metrics
+    codex = _bounded_codex_diagnostics((result or {}).get("codex_diagnostics"))
+    if codex:
+        observability["codex"] = codex
     budget_metrics = _bounded_budget_metrics((result or {}).get("budget_metrics"))
     if budget_metrics:
         observability["budget_metrics"] = budget_metrics
@@ -1190,6 +1193,35 @@ def _build_execution_observability(
             "final_status": manifest.get("final_status"),
         }
     return observability
+
+
+def _bounded_codex_diagnostics(raw: Optional[dict]) -> Optional[dict]:
+    """Allow only the two bounded numbers a Codex turn reports about itself.
+
+    How far the turn got before it ended, and what answered it. A turn refused
+    after forty completed items is a different fact from one refused after two,
+    and only the first is evidence that the rate limit is reached by what a
+    single turn spends rather than by how quickly turns arrive -- so this is
+    the number the narrowing is down to, and it had nowhere to be written.
+
+    What the turn spent is not carried here. The cost ledger already records it
+    against the same task id, and a second copy is a second thing that can
+    disagree with the first.
+
+    A status is only published when it is one a server can send. ``None`` for
+    an out-of-range value says nothing rather than saying something wrong,
+    which is the same choice ``bounded_count`` makes beside it.
+    """
+    if not isinstance(raw, dict):
+        return None
+    output: dict = {}
+    items_seen = bounded_count(raw.get("items_seen"))
+    if items_seen is not None:
+        output["items_seen"] = items_seen
+    status = raw.get("http_status_code")
+    if type(status) is int and 100 <= status <= 599:
+        output["http_status_code"] = status
+    return output or None
 
 
 def _bounded_agentic_metrics(raw: Optional[dict]) -> Optional[dict]:

--- a/batch-runner/tests/test_a_refused_turn_still_reports_what_it_spent.py
+++ b/batch-runner/tests/test_a_refused_turn_still_reports_what_it_spent.py
@@ -79,6 +79,8 @@ from core.execution_environment_readiness import (  # noqa: E402
     retry_counts_by_reason,
 )
 
+import step2_run_inference as step2  # noqa: E402
+
 
 # ── Stand-ins for the SDK's notification shapes ─────────────────────────────
 #
@@ -659,3 +661,108 @@ def test_the_counts_satisfy_the_field_the_run_record_requires():
     )
 
     assert check_run_record_fields(record) == []
+
+
+# ── The measurement has to leave the runner to be evidence ──────────────────
+#
+# `last_run_diagnostics` is written by the runner and read by nothing in
+# production: `grep -rn last_run_diagnostics --include=*.py` finds the
+# assignment, and one test. So the two numbers above were measured, and then
+# left on an object that step 2 drops on the floor -- they reached no results
+# file, no report, no artifact of any run. The rate-limit question they were
+# added to answer could still not be answered from a downloaded run.
+#
+# They travel out on the result dict instead, and step 2 puts them in the
+# task's `observability` record, beside `error_category`, which was moved
+# there for this same reason: every backend produced it, and the ones that
+# kept it kept it inside their own metrics, where a caller that does not know
+# which backend ran cannot find it.
+
+
+def test_the_two_numbers_leave_the_runner_on_the_result(
+    ledger: CostReceiptLedger,
+):
+    """Measured is not reported. This is the step between them."""
+    if _load_turn_collector() is None:  # pragma: no cover - SDK absent
+        pytest.skip("the pinned Codex SDK is not installed here")
+
+    handle = _FakeTurnHandle(
+        [_item_event(), _item_event(), _turn_event(_failed_turn())],
+        failure="stream disconnected before completion",
+    )
+    result = _run_the_task(_runner_over(handle, ledger))
+
+    assert result["codex_diagnostics"] == {
+        "items_seen": 2,
+        "http_status_code": 429,
+    }
+
+
+def test_step_two_publishes_how_far_the_turn_got_and_what_refused_it():
+    """The task record a downloaded run is read from."""
+    observability = step2._build_execution_observability(
+        {"codex_diagnostics": {"items_seen": 41, "http_status_code": 429}}, []
+    )
+
+    assert observability["codex"] == {
+        "items_seen": 41,
+        "http_status_code": 429,
+    }
+
+
+def test_what_the_turn_spent_is_not_copied_beside_the_ledger_s_own_figure():
+    """One number, one place.
+
+    The ledger records the tokens against this same task id. A copy here would
+    be a second figure that can disagree with the first, and nothing would say
+    which of the two the run actually spent.
+    """
+    observability = step2._build_execution_observability(
+        {
+            "codex_diagnostics": {
+                "items_seen": 3,
+                "http_status_code": 429,
+                "usage_delta": {"input_tokens": 101, "output_tokens": 7},
+            }
+        },
+        [],
+    )
+
+    assert set(observability["codex"]) == {"items_seen", "http_status_code"}
+
+
+def test_a_status_no_server_could_send_is_not_published():
+    """Saying nothing beats saying something wrong.
+
+    The same choice ``bounded_count`` makes beside it: a value outside the
+    range is dropped rather than passed along, because a published number is
+    read as a measurement.
+    """
+    for impossible in (0, 99, 600, 4_290, -429, True, "429", 429.0, None):
+        observability = step2._build_execution_observability(
+            {"codex_diagnostics": {"items_seen": 3, "http_status_code": impossible}},
+            [],
+        )
+        assert "http_status_code" not in observability["codex"], impossible
+        assert observability["codex"]["items_seen"] == 3
+
+
+def test_a_turn_that_nobody_refused_still_reports_how_far_it_got():
+    """A completed turn has no status, and that is not a missing measurement."""
+    observability = step2._build_execution_observability(
+        {"codex_diagnostics": {"items_seen": 12, "http_status_code": None}}, []
+    )
+
+    assert observability["codex"] == {"items_seen": 12}
+
+
+def test_a_backend_that_is_not_codex_publishes_no_codex_key():
+    """An absent key is the absence of a Codex turn, not a zero-item one."""
+    assert "codex" not in step2._build_execution_observability({}, [])
+    assert "codex" not in step2._build_execution_observability(None, [])
+    assert "codex" not in step2._build_execution_observability(
+        {"codex_diagnostics": "not a mapping"}, []
+    )
+    assert "codex" not in step2._build_execution_observability(
+        {"codex_diagnostics": {"items_seen": None, "http_status_code": None}}, []
+    )


### PR DESCRIPTION
`items_seen` and `http_status_code` were added to answer the rate-limit
question, and then written to `CodexAgentRunner.last_run_diagnostics` — an
attribute nothing in production reads.

```
$ grep -rn last_run_diagnostics --include=*.py .
core/codex_runner.py:659:  self.last_run_diagnostics: dict[str, Any] | None = None
core/codex_runner.py:1002: self.last_run_diagnostics = {
tests/test_a_refused_turn_still_reports_what_it_spent.py:415: diagnostics = ...
```

One assignment, one test. The two numbers reached no results file, no report
and no artifact of any run, so a downloaded run still could not answer the
question they were added for. The measurement was real; the reporting was not.

## Where they go instead

Out on the runner's result, and into the task's `observability` record under
`codex`. That record is already persisted per task and already carries
`error_category`, which was moved there for this exact reason: every backend
produced it, and the ones that kept it kept it inside their own metrics, where
a caller that does not know which backend ran cannot find it. Same defect, same
fix, adjacent lines.

Two deliberate omissions:

- **What the turn spent is not carried here.** The cost ledger already records
  it against the same `task_id`, so a copy would be a second figure that can
  disagree with the first, with nothing to say which one the run spent.
- **A status outside 100–599 is dropped, not published.** Same reasoning as
  `bounded_count` beside it — a published number is read as a measurement, so
  saying nothing beats saying something wrong. An absent `codex` key means no
  Codex turn ran; it does not mean a turn that completed zero items.

## What the merged change has already produced

Run `34528903950` re-ran the same five pinned tasks with a byte-identical
experiment YAML, so only the code differed. Against `34500590783`:

| | `34500590783` | `34528903950` |
|---|---|---|
| ledger rows | 9 | 9 |
| settled | **2** | **9** |
| rows carrying a token figure | **2/9** | **9/9** |
| `retry_kind` values | `{none: 9}` | `{none: 5, infrastructure: 4}` |
| `summary.retry_counts_by_reason` | absent | `{infrastructure_error: 4, …}` |

Both defects are closed in production. The four retries that were recorded as
first attempts are now recorded as retries, and the seven turns that reported
spending nothing now report what they spent — 237,968 input tokens that the
previous run's ledger left blank. That figure is the run's 595,243 input
tokens less the 357,275 belonging to the two tasks that succeeded; under the
old code only successes settled, so all seven rows of the three failed tasks
stayed `reserved` with nothing in them.

`summary.retried_count` still reads `0` beside `infrastructure_error: 4`.
That is the documented divergence, not a discrepancy: `retried_count` counts
self-QA retries, and this run had none.

## What that measurement immediately settled

The reason it mattered is that the correlation below could not be computed
before — seven of nine rows were blank. Reconstructing both runs' timelines
from the job logs (GitHub timestamps a line when its terminating newline is
written, and `run_with_infra_retries` prints before it sleeps; the
reconstruction matches every recorded `latency_ms` to the millisecond), and
joining the ledger in insertion order:

| call | t+s | dur | input | non-cached | 60 s prior | outcome |
|------|----:|----:|------:|-----------:|-----------:|---------|
| t1a1 | 0 | 64.3 s | 42,254 | 18,446 | **0** | refused |
| t1a2 | 124 | 47.1 s | 26,949 | 26,949 | 0 | content filter |
| t2a1 | 171 | 83.5 s | 67,871 | 28,575 | 26,949 | ✓ |
| t3a1 | 255 | 106.2 s | **289,404** | 36,988 | 48,775 | ✓ |
| t4a1 | 361 | 59.7 s | 11,524 | 2,308 | 163,428 | refused |
| t4a2 | 481 | 36.6 s | 11,488 | 2,272 | 0 | transport error |
| t5a1 | 518 | 12.9 s | 11,586 | 11,586 | 11,488 | refused |
| t5a2 | 590 | 69.4 s | 37,077 | 11,349 | 0 | refused |
| t5a3 | 780 | 81.2 s | 97,090 | 39,362 | **0** | refused, *rate limit* |

`t5a3` is the call that came back with `Your requests to gpt-5.4 for gpt-5.4 in
eastus2 have exceeded rate limit.` It started after a **120-second idle wait**,
with **zero** tokens of this run's traffic in the preceding minute. `t1a1` was
the first call of the entire run and was refused the same way.

That rules out the last reading standing:

- **not the interval between our calls** — two refusals follow a minute in
  which this run sent nothing at all;
- **not what we send** — the two tasks refused three times each in
  `34500590783` have zero reference files, and the largest sender succeeded in
  both runs;
- **not admission** — turns stream for 13 to 106 seconds before being cut;
- **not what one turn spends inside itself** — the turn that spent 289,404
  input tokens *succeeded*, and a turn spending 11,586 after an idle gap did
  not. This was the hypothesis the measurement was added to test, and the
  measurement refutes it.

## Which task fails reproduces; why it fails does not

Between two runs of an identical config the **same three tasks failed and the
same two succeeded**, and not one of the three failed for the same reason
twice:

| task | `34500590783` | `34528903950` |
|---|---|---|
| `02aa1805` | exceeded rate limit, 3 attempts | `reason: content_filter` |
| `3baa0009` | exceeded rate limit, 3 attempts | `Transport error` |
| `0818571f` | `reason: content_filter`, 1 attempt | exceeded rate limit, 3 attempts |

An earlier draft of this description said the set of failing tasks changed
between the runs. That was wrong — it is the same set both times — and the
correction is the more interesting result.

So there are two findings here, not one, and they do not have the same remedy.
A rate ceiling cannot be why one task is refused for rate and then filtered for
content the next time; and something that reproduces per task is not explained
by contention alone. What all six sentences share is their prefix: every one of
them is `stream disconnected before completion:`. What reproduces is that these
particular turns get cut, and the wording is whatever the server said on the
way out.

The contention half still stands on the evidence above — a refusal arriving
after sixty seconds in which this run sent nothing is not a consequence of what
this run sent. The per-task half is not settled and five tasks cannot settle
it. Several task properties separate the two groups perfectly at n=5: the two
that succeeded also have the two longest task statements, 2,902 and 3,632
characters against 1,589, 1,548 and 996. At five points that is as likely to be
coincidence as cause, and it is written here as something for the thirty-task
stage to test rather than as a conclusion. What this PR contributes to that
test is the ability to run it: with every attempt settled and categorised, the
next run can be counted instead of guessed at.

For the contention half the remedy is surviving it rather than sending less,
and the levers are already in the config: `max_retries: 2` spends only 180 s of the
600 s `INFRA_RETRY_MAX_TOTAL_WAIT_SECONDS` budget before giving up, and
`resume_max_rounds: 0` means a task refused three times is never tried again.
Those are separate runs to record, not part of this PR.

No task is reclassified here, and the content-filtered failure stays a
benchmark failure.

## Tests

Six added to the file named for this concern (35 in it now): the numbers leave
the runner; step 2 publishes them; the tokens are *not* copied beside the
ledger's own figure; an impossible status is dropped for each of nine shapes
including `True` and `"429"`; a completed turn with no status still reports how
far it got; and a non-Codex backend publishes no `codex` key at all.

## Files and ownership

- `batch-runner/core/codex_runner.py` — A's file. One key on the returned dict.
- `batch-runner/step2_run_inference.py` — shared; one bounded helper and one
  conditional key, additive. `_build_execution_observability` grows the same
  way it grew for `agentic_metrics`, `budget_metrics` and `substrate`.

No isolation is weakened, no environment name is added to the inherited set,
`HOME` is still rewritten, and no credential is read, logged or stored.

