### PR TITLE
feat(agentic-v2): stage D1/D2 — exec_run wrapper and the microVM backend

### DIFF
--- a/batch-runner/core/agentic_v2_exec_boot.py
+++ b/batch-runner/core/agentic_v2_exec_boot.py
@@ -1,0 +1,436 @@
+"""Turning one ``exec_run`` request into a boot, and one boot into a result.
+
+Stage C proved a machine: it comes up with the containment rules applied, and
+seven separate ways out of it are closed. What it did not build is the thing on
+the other side of the tool contract, and the gap between the two is not
+"connect the finished pieces".
+
+**Stage C boots a machine to run one command and then destroys it.** The tool
+contract's ``exec_run`` is called repeatedly inside a session that holds state:
+the model writes a file, runs something, reads what came back, runs something
+else. Between those calls the workspace has to still exist, and a machine that
+is destroyed after one command has nowhere to keep it.
+
+The way that is closed here is **a fresh machine per call, with the workspace
+carried across on the host**. The workspace lives in a host directory between
+calls; each ``exec_run`` builds a work disk out of it, boots, runs, is destroyed,
+and the changed workspace is read back out of the disk image afterwards. It
+costs a boot per call, and it buys two things worth more than that: every call
+inherits stage C's evidence rather than needing its own, and nothing at all
+survives a call except a disk image the host controls, so a call that gets
+compromised has no resident machine to stay in.
+
+This module is the *pure* half of that — the half that can be proven on a box
+which cannot boot a microVM at all. It builds the guest command, and it reads
+what a boot returned. It runs no subprocess, opens no socket, and touches no
+file. The boot itself is :func:`core.agentic_v2_first_boot.first_boot`, injected
+by the caller, exactly as stage C's attacks were.
+
+**The one rule that decides whether any of this is honest.** A guest that
+panicked on boot and a guest whose command returned 0 leave *different*
+evidence, and telling them apart is the whole job:
+
+- ``/out/exit_status`` present — the command ran, and this is its returncode
+  whatever the number is. A non-zero returncode is a *successful tool call*
+  reporting a failed command, and the model is shown it and chooses again.
+- ``/out/exit_status`` absent — nothing ran to completion and there is no
+  returncode. That is an error with a name, never ``returncode: 0`` and never
+  an invented non-zero.
+
+Getting that backwards is how a run of 220 tasks reports a wall of tidy command
+failures that were really one broken launcher. Stage C's first attack run made
+this mistake in the other direction — it read a destroyed reporter as a rule
+that had not held — and the discipline that came out of it is the same one:
+**absent evidence is not a result.**
+
+What is deliberately not here: any way to open ``exec_run``. The guards in
+``step2_run_inference.py`` and ``core/executor.py`` are untouched by this file,
+and opening them is its own change with its own review.
+"""
+
+from __future__ import annotations
+
+import base64
+import shlex
+from typing import Any, Mapping
+
+from core.agentic_v2_microvm import REQUIRED_MICROVM_POLICY
+
+
+WORKSPACE_IN_GUEST = "/work/ws"
+"""Where the session workspace sits on the work disk.
+
+``GUEST_INIT`` mounts the work disk at ``/work`` and runs ``/work/in/command.sh``
+from it, so the workspace is a directory on that same disk. It is the only
+writable place in the machine: the root filesystem is mounted read-only, which
+is stage C's fifth attack.
+"""
+
+SCRATCH_IN_GUEST = "/work/in"
+
+STDIN_IN_GUEST = f"{SCRATCH_IN_GUEST}/stdin"
+SCRIPT_IN_GUEST = f"{SCRATCH_IN_GUEST}/script"
+
+EXEC_RECORD_DIR = ".gdpval/exec"
+"""Where a call's captured output is put *in the workspace*, for the model to read.
+
+``exec_run``'s result carries a returncode and nothing else — that is the
+contract, and ``additionalProperties`` is false, so there is no field to put
+output in even if one wanted to. The model reads what its command printed the
+same way it reads any other file, with ``workspace_apply``. These paths are
+relative, contain no ``..`` and no control characters, so they satisfy the
+contract's path rule and the model can address them.
+"""
+
+MOST_OUTPUT_BYTES = 1048576
+"""How much of one stream is kept, matching the contract's per-file ceiling."""
+
+TRUNCATION_NOTE = "\n[gdpval] output truncated at {kept} bytes of {produced}\n"
+"""Written into the kept output when a stream ran past the ceiling.
+
+Silently truncating is how a model reads a partial table as a whole one and is
+confidently wrong about it. The note costs a line and removes that whole class
+of mistake.
+"""
+
+CD_FAILED_MARKER = "gdpval-cd-failed"
+"""The wrapper could not enter the requested directory, so nothing ran."""
+
+DECODE_FAILED_MARKER = "gdpval-decode-failed"
+"""``base64`` was missing or refused, so the payload never reached the disk.
+
+A separate marker from the one above on purpose. Failing to enter a directory
+is something about the *request* and the model can fix it by asking for another
+one; a guest with no working ``base64`` is something about the *image*, and
+telling the model to correct its path would send it chasing a fault it has no
+way to reach.
+"""
+
+GUEST_SETUP_STATUS = 125
+"""The status the wrapper exits with when its own setup failed.
+
+125 is chosen because it is not one of the meanings a shell already assigns —
+126 is "found but not executable", 127 is "not found", and 128+n is a signal.
+It is still a number a command could return by itself, so it is never read
+alone: it counts as a setup failure only alongside the matching marker on
+stderr, and the residual ambiguity is a command that exits 125 having printed
+exactly that marker and nothing else.
+"""
+
+INTERPRETERS: dict[str, str] = {
+    "python": "python3",
+    "node": "node",
+    "r": "Rscript",
+    "bash": "bash",
+}
+"""The four the contract names, mapped to what they are called in the guest.
+
+An interpreter the image does not have is **not refused here**. The command
+fails inside the machine with "not found", the model is shown that, and it
+chooses again — which is the loop working. Refusing on the host would turn a
+thing the model can recover from into a thing it cannot see.
+"""
+
+_BASE64_LINE = 76
+
+_HEREDOC_DELIMITERS = {
+    STDIN_IN_GUEST: "GDPVAL_STDIN_EOF",
+    SCRIPT_IN_GUEST: "GDPVAL_SCRIPT_EOF",
+}
+"""Delimiters that base64 output provably cannot contain, because of ``_``.
+
+The usual heredoc hazard is content that happens to include the delimiter line,
+which ends the document early and feeds the rest of it to the shell. Here the
+document is always base64, whose alphabet is ``A-Z a-z 0-9 + / =`` — an
+underscore never appears in it, so the collision is not unlikely, it is
+impossible. Carrying the payload as base64 also fixes two quieter problems: a
+heredoc appends a newline that the model's own bytes may not have had, and a
+single ``printf`` argument long enough to hold a 256 KiB script would be past
+``MAX_ARG_STRLEN`` and fail to execute at all.
+"""
+
+
+class ExecRefused(ValueError):
+    """The request cannot be expressed as a guest command, so none was built.
+
+    Distinct from a command that fails: this is the host declining to write a
+    script it cannot write faithfully, before anything boots and before any
+    money is spent on it.
+    """
+
+
+def effective_deadline(
+    requested_seconds: Any,
+    *,
+    policy: Mapping[str, Any] = REQUIRED_MICROVM_POLICY,
+) -> dict[str, Any]:
+    """Reconcile the bound the model asked for with the one the policy allows.
+
+    ``exec_run``'s schema permits ``timeout_seconds`` up to 2700 and the
+    containment policy allows 1200. A model asking for more than the policy
+    permits is neither an error nor a refusal — it gets the policy's number.
+
+    What matters is that the answer **says which number was applied**, so that
+    nobody reading the record later takes a kill at 1200 seconds for the model's
+    own 2700-second choice having been honoured.
+    """
+    allowed = policy.get("wall_clock_seconds")
+    if not isinstance(allowed, int) or isinstance(allowed, bool) or allowed <= 0:
+        raise ExecRefused(
+            f"the policy's wall_clock_seconds is {allowed!r}, which is not a "
+            "bound, and a call with no bound is not a call this will make"
+        )
+    if (
+        not isinstance(requested_seconds, int)
+        or isinstance(requested_seconds, bool)
+        or requested_seconds <= 0
+    ):
+        raise ExecRefused(
+            f"timeout_seconds was {requested_seconds!r}; the contract requires a "
+            "positive whole number and there is no default worth inventing"
+        )
+    applied = min(requested_seconds, allowed)
+    return {
+        "requested_seconds": requested_seconds,
+        "policy_seconds": allowed,
+        "applied_seconds": applied,
+        "capped_by_the_policy": applied < requested_seconds,
+    }
+
+
+def _decode_into(path: str, payload: str) -> str:
+    encoded = base64.b64encode(payload.encode("utf-8")).decode("ascii")
+    delimiter = _HEREDOC_DELIMITERS[path]
+    body = "\n".join(
+        encoded[at : at + _BASE64_LINE] for at in range(0, len(encoded), _BASE64_LINE)
+    )
+    return (
+        f"base64 -d > {path} 2>/dev/null <<'{delimiter}'\n"
+        f"{body}\n"
+        f"{delimiter}\n"
+        f"if [ $? -ne 0 ]; then\n"
+        f"  echo '{DECODE_FAILED_MARKER}' >&2\n"
+        f"  exit {GUEST_SETUP_STATUS}\n"
+        f"fi"
+    )
+
+
+def command_script(
+    arguments: Mapping[str, Any],
+    *,
+    interpreters: Mapping[str, str] = INTERPRETERS,
+) -> str:
+    """Build the ``command.sh`` the guest's init will run, or refuse to.
+
+    Two shapes are accepted because the contract has two: an ``argv`` to run,
+    and a ``script`` for one of four named interpreters. Both end up as the same
+    thing — a short wrapper that puts the payload on the work disk, enters the
+    requested directory, and runs the command with its input redirected.
+
+    **Standard input is always redirected, from ``/dev/null`` when the request
+    gave none.** Without that, a command that reads stdin inherits whatever
+    descriptor the guest's init had, which is neither a terminal nor empty and
+    is not the same thing twice. A command that quietly consumed part of its own
+    launcher script would be a very hard afternoon.
+
+    ``interpreters`` maps the four names the contract allows to the binaries to
+    invoke. It is an argument rather than a constant because the guest is a
+    fact about the image, not about this file: an image whose Python is
+    ``python`` and not ``python3`` is answered by pinning the mapping, not by
+    editing a table here on the strength of what is usually true.
+    """
+    cwd = arguments.get("cwd")
+    if not isinstance(cwd, str) or not cwd:
+        raise ExecRefused("exec_run needs a cwd and this request has none")
+    if cwd.startswith("/") or any(part == ".." for part in cwd.split("/")):
+        raise ExecRefused(
+            f"cwd {cwd!r} leaves the workspace, and the workspace is the only "
+            "place in the machine that is writable"
+        )
+
+    lines = [
+        "#!/bin/sh",
+        "# Built by core/agentic_v2_exec_boot.py, and run by the guest's init as",
+        "# its only command. Its stdout and stderr are the work disk's files.",
+        f"mkdir -p {SCRATCH_IN_GUEST}",
+    ]
+
+    stdin_text = arguments.get("stdin")
+    if stdin_text is None:
+        stdin_from = "/dev/null"
+    elif isinstance(stdin_text, str):
+        lines.append(_decode_into(STDIN_IN_GUEST, stdin_text))
+        stdin_from = STDIN_IN_GUEST
+    else:
+        raise ExecRefused(f"stdin must be text if it is given, not {type(stdin_text)}")
+
+    has_argv = "argv" in arguments
+    has_script = "script" in arguments or "interpreter" in arguments
+    if has_argv == has_script:
+        raise ExecRefused(
+            "exec_run is either an argv or an interpreter and a script, and "
+            "this request is " + ("both" if has_argv else "neither")
+        )
+
+    if has_argv:
+        argv = arguments["argv"]
+        if not isinstance(argv, list) or not argv:
+            raise ExecRefused("argv has to be a non-empty list of strings")
+        if any(not isinstance(item, str) for item in argv):
+            raise ExecRefused("every argv entry has to be a string")
+        command = " ".join(shlex.quote(item) for item in argv)
+    else:
+        interpreter = arguments.get("interpreter")
+        script = arguments.get("script")
+        if interpreter not in interpreters:
+            raise ExecRefused(
+                f"interpreter {interpreter!r} is not one of "
+                f"{sorted(interpreters)}, and guessing which was meant is how "
+                "the wrong language runs the right file"
+            )
+        if not isinstance(script, str) or not script:
+            raise ExecRefused("an interpreter needs a script and this has none")
+        lines.append(_decode_into(SCRIPT_IN_GUEST, script))
+        command = f"{interpreters[interpreter]} {SCRIPT_IN_GUEST}"
+
+    target = f"{WORKSPACE_IN_GUEST}/{cwd}".rstrip("/")
+    # The shell's own "can't cd to ..." goes to /dev/null so that stderr holds
+    # the marker and nothing else. Without that the marker is preceded by a
+    # sentence whose wording differs between dash, ash and bash, and the reader
+    # downstream is matching stderr exactly — it would have matched on no real
+    # guest at all.
+    lines.append(
+        f"cd {shlex.quote(target)} 2>/dev/null || "
+        f"{{ echo '{CD_FAILED_MARKER}' >&2; exit {GUEST_SETUP_STATUS}; }}"
+    )
+    lines.append(f"{command} < {stdin_from}")
+    return "\n".join(lines) + "\n"
+
+
+def _capped(stream: Any) -> tuple[str, bool]:
+    text = stream if isinstance(stream, str) else ""
+    produced = len(text.encode("utf-8"))
+    if produced <= MOST_OUTPUT_BYTES:
+        return text, False
+    kept = text.encode("utf-8")[:MOST_OUTPUT_BYTES].decode("utf-8", "ignore")
+    return kept + TRUNCATION_NOTE.format(kept=len(kept), produced=produced), True
+
+
+def read_the_boot(
+    boot: Mapping[str, Any], *, deadline: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Read one boot as a tool result, and say on what grounds.
+
+    Four outcomes come back from the launcher and they mean four different
+    things. The table is small and every row of it matters:
+
+    ===========================  =============  ==================================
+    boot outcome                 exit status    what the model is told
+    ===========================  =============  ==================================
+    ``booted``                   present        ``ok``, with that returncode
+    ``booted``                   absent         ``compute_backend_error``
+    ``booted_but_wrote_nothing`` absent         ``compute_backend_error``
+    ``never_started``            absent         ``compute_start_failed``
+    ``stopped_by_the_deadline``  absent         ``cancelled`` — the bound worked
+    ``stopped_by_the_deadline``  **present**    ``ok``, with that returncode
+    ===========================  =============  ==================================
+
+    The last row is the one that is easy to get wrong. If the guest wrote an
+    exit status, the command **finished**; the machine merely failed to shut
+    down inside its deadline afterwards. Throwing the returncode away there
+    would discard a real answer because of something that happened after it.
+
+    A deadline that fires is not an error in the machine. It is stage C's third
+    attack succeeding on purpose — the bound doing exactly what it was measured
+    doing — and the model is told the call was cancelled and how long it had.
+
+    The exit status is a file the *guest* wrote, so it is not trusted to be a
+    number in range. Anything else is ``invalid_backend_result``, because a
+    returncode outside 0–255 is not a returncode.
+    """
+    outcome = boot.get("outcome")
+    results = boot.get("results") or {}
+    stdout, stdout_cut = _capped(results.get("/out/stdout"))
+    stderr, stderr_cut = _capped(results.get("/out/stderr"))
+    status = boot.get("command_exit_status")
+
+    def answer(
+        ok: bool, error_type: str | None, data: dict, grounds: str
+    ) -> dict[str, Any]:
+        return {
+            "result": {"ok": ok, "error_type": error_type, "data": data},
+            "stdout": stdout,
+            "stderr": stderr,
+            "truncated": {"stdout": stdout_cut, "stderr": stderr_cut},
+            "deadline": dict(deadline),
+            "boot_outcome": outcome,
+            "grounds": grounds,
+        }
+
+    if status is not None:
+        if not isinstance(status, int) or isinstance(status, bool):
+            return answer(
+                False,
+                "invalid_backend_result",
+                {},
+                f"the guest wrote {status!r} where a returncode goes",
+            )
+        if not 0 <= status <= 255:
+            return answer(
+                False,
+                "invalid_backend_result",
+                {},
+                f"the guest reported {status}, which is not a returncode",
+            )
+        if status == GUEST_SETUP_STATUS and stderr.strip() == CD_FAILED_MARKER:
+            return answer(
+                False,
+                "path_not_directory",
+                {},
+                "the wrapper could not enter the requested directory, so the "
+                "command never ran and this is not its returncode",
+            )
+        if status == GUEST_SETUP_STATUS and stderr.strip() == DECODE_FAILED_MARKER:
+            return answer(
+                False,
+                "compute_backend_error",
+                {},
+                "the guest could not decode the payload onto the work disk, "
+                "which is a fault in the image and not in the request",
+            )
+        ran_anyway = (
+            " after its deadline had already fired, so the command finished and "
+            "only the shutdown overran"
+            if outcome == "stopped_by_the_deadline"
+            else ""
+        )
+        return answer(
+            True,
+            None,
+            {"returncode": status},
+            f"the guest wrote an exit status of {status}{ran_anyway}",
+        )
+
+    if outcome == "stopped_by_the_deadline":
+        return answer(
+            False,
+            "cancelled",
+            {},
+            f"the machine was stopped at its {deadline.get('applied_seconds')} "
+            "second bound with no exit status written, so the command was still "
+            "running when the bound was reached",
+        )
+    if outcome == "never_started":
+        return answer(
+            False,
+            "compute_start_failed",
+            {},
+            "the jailer wrote no pid file, so no machine existed to run in",
+        )
+    return answer(
+        False,
+        "compute_backend_error",
+        {},
+        f"the machine ended as {outcome!r} and wrote no exit status, so nothing "
+        "here says the command ran — and a missing result is not a returncode",
+    )

--- a/batch-runner/core/agentic_v2_microvm_backend.py
+++ b/batch-runner/core/agentic_v2_microvm_backend.py
@@ -1,0 +1,440 @@
+"""A backend whose ``exec_run`` boots a real machine, and refuses what it lacks.
+
+Stage D1 built the pure half — the guest command, and the reading of one boot.
+This is the object the conversation loop actually holds: it keeps a workspace on
+the host between calls, and each ``exec_run`` turns into one microVM that runs
+one command and is destroyed.
+
+**Why this subclasses the fixture backend.** ``AgenticV2FixtureBackend`` is not
+only a stub. Most of it is roughly four hundred lines of workspace path safety —
+a directory descriptor pinned by device and inode, every open done relative to
+it with ``O_NOFOLLOW``, every resulting descriptor checked back against the root
+before a byte is read or written, and quotas on entries, file size and total
+size. That code is the reason a model cannot write through a symlink into the
+host, and it is identical whether the command afterwards runs in a fixture or in
+a machine. Copying it would mean maintaining two versions of the part that must
+never drift; so it is inherited, and what makes the fixture a fixture is
+overridden away:
+
+- ``start`` returns this backend's own identity, never the fixture's.
+- ``state_sha256`` covers the guest image, because with a real guest the image
+  is part of what determines what a command does.
+- ``exec_run`` boots instead of upper-casing a file.
+- ``environment_resolve``, ``environment_activate`` and ``browser_run`` refuse.
+- the fixture's package catalogue is emptied, so nothing can advertise it.
+
+A test pins the exact set of inherited public methods. Without it, a convenience
+added to the fixture years from now would silently become a production
+capability, and nothing would fail.
+
+**What this deliberately does not do.** ``core/agentic_v2_runner.py`` checks at
+startup that the backend's identity is exactly the foundation fixture's, and
+fails anything else with ``compute_start_failed``. This backend does not satisfy
+that check and this module does not change it. That is not an oversight — the
+guard is the thing that has to be opened as its own reviewable change, once the
+pieces underneath it have evidence, and opening it quietly from here would be
+the one move that makes every other honest thing in this file worthless. So the
+backend is proven directly by its tests, and the runner still refuses it.
+
+**The capability gaps are gaps, and are reported as such.** ``environment_*``
+cannot work: the machine has no route off itself, which is stage C's fourth
+attack, so there is no index to resolve a requirement against. ``browser_run``
+could in principle open a local file — the image carries chromium — but nothing
+here drives it, so it refuses rather than pretending. Both will change the
+outcome of some tasks, and a task that fails for want of a browser must read as
+that and not as a model that could not do the work.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Callable, Mapping
+
+from core.agentic_v2_contract import AgenticV2Profile
+from core.agentic_v2_exec_boot import (
+    EXEC_RECORD_DIR,
+    INTERPRETERS,
+    ExecRefused,
+    command_script,
+    effective_deadline,
+    read_the_boot,
+)
+from core.agentic_v2_fixture_backend import AgenticV2FixtureBackend
+from core.agentic_v2_microvm import REQUIRED_MICROVM_POLICY
+from core.agentic_v2_substrate import AgenticV2SubstrateManifest
+from core.agentic_v2_provenance import canonical_sha256
+
+
+BACKEND_ID = "agentic-v2-microvm-v1"
+
+MANIFEST_COMMAND_FOR_INTERPRETER = {
+    "python": "python",
+    "node": "node",
+    "r": "Rscript",
+    "bash": "bash",
+}
+"""Contract interpreter name to the command name the substrate manifest uses.
+
+Worth writing down because the two vocabularies disagree in one place and the
+disagreement is not visible from either side alone. The manifest requires a
+command called ``python``; the guest binary D1 invokes is ``python3``. On a
+Debian image both normally exist, but *normally* is not evidence, and a guest
+with only one of them would fail every Python call with "not found" while the
+manifest went on saying the capability was present. Resolving it is a job for
+the capability probe, which runs both and records the answer; until then the
+binary names are an argument to this backend rather than a constant, so the
+probe's result can be pinned here without touching D1.
+"""
+
+BROWSER_OPERATIONS_THAT_NEED_A_NETWORK = frozenset({"search", "open_url"})
+
+
+@dataclass(frozen=True)
+class GuestImage:
+    """What was booted, named so that two runs can be told apart.
+
+    The reference and digest identify the container image the guest filesystem
+    was built from; the two hashes identify the kernel and root filesystem that
+    were actually placed in the jail. All four go into the backend's identity,
+    because with a real guest the image *is* the behaviour: the same command in
+    two different images is two different commands.
+    """
+
+    reference: str
+    digest: str
+    kernel_sha256: str
+    rootfs_sha256: str
+
+    def as_record(self) -> dict[str, str]:
+        return {
+            "reference": self.reference,
+            "digest": self.digest,
+            "kernel_sha256": self.kernel_sha256,
+            "rootfs_sha256": self.rootfs_sha256,
+        }
+
+
+class AgenticV2MicroVMBackend(AgenticV2FixtureBackend):
+    """A backend that runs commands in one throwaway machine per call."""
+
+    def __init__(
+        self,
+        *,
+        root: str | Path,
+        profile: AgenticV2Profile,
+        image: GuestImage,
+        boot_one_command: Callable[..., Mapping[str, Any]],
+        substrate_manifest: AgenticV2SubstrateManifest | None = None,
+        budget_caps: Mapping[str, Any] | None = None,
+        policy: Mapping[str, Any] = REQUIRED_MICROVM_POLICY,
+        interpreter_binaries: Mapping[str, str] | None = None,
+        **_: Any,
+    ):
+        super().__init__(root=root, profile=profile, budget_caps=budget_caps)
+        # The parent seeds a demonstration catalogue so its own identity check
+        # passes. Nothing here may advertise it, so it is emptied rather than
+        # left to be found by something later.
+        self._package_records = ()
+        self.package_catalog = MappingProxyType({})
+        self.image = image
+        self.manifest = substrate_manifest
+        self.policy = dict(policy)
+        self.interpreter_binaries = dict(interpreter_binaries or INTERPRETERS)
+        self._boot_one_command = boot_one_command
+        self.boots: list[dict[str, Any]] = []
+
+    # -- identity ---------------------------------------------------------
+
+    def start(self, timeout_seconds: float) -> Mapping[str, Any]:
+        """Report what this is, or say plainly that it cannot be established.
+
+        A real backend with no verified substrate manifest has no honest way to
+        describe itself, and inventing a description is worse than failing: it
+        would put a hash into the run record that nothing on disk corresponds
+        to. ``substrate_manifest_missing`` is already an error the contract
+        knows, and it is the true one.
+        """
+        del timeout_seconds
+        if self.manifest is None:
+            return {"ok": False, "error_type": "substrate_manifest_missing"}
+        return {
+            "ok": True,
+            "data": {
+                "substrate_manifest": {
+                    "schema_version": self.manifest.document["schema_version"],
+                    "sha256": self.manifest.sha256,
+                },
+                "backend_identity": self.backend_identity(),
+                "package_snapshot_sha256": self.package_snapshot_sha256(),
+                "browser_build_sha256": self.browser_build_sha256(),
+                "capabilities": self._capabilities(),
+            },
+        }
+
+    def backend_identity(self) -> dict[str, Any]:
+        """Identity derived from the image, not from this file's source text.
+
+        The fixture hashes its own implementation, which is right for something
+        whose behaviour is entirely its own code. Here the code decides very
+        little: the same wrapper in a different guest is a different machine
+        with different programs in it. So the implementation hash covers the
+        image, the kernel, the root filesystem and the manifest — change any of
+        them and the identity changes, which is what an identity is for.
+        """
+        return {
+            "backend_id": BACKEND_ID,
+            "foundation_only": bool(self.manifest.document["foundation_only"])
+            if self.manifest is not None
+            else True,
+            "implementation_sha256": canonical_sha256(
+                {
+                    "image": self.image.as_record(),
+                    "substrate_manifest_sha256": (
+                        self.manifest.sha256 if self.manifest is not None else None
+                    ),
+                    "interpreter_binaries": dict(
+                        sorted(self.interpreter_binaries.items())
+                    ),
+                    "policy": dict(sorted(self.policy.items())),
+                }
+            ),
+        }
+
+    def package_snapshot_sha256(self) -> str:
+        """The hash of an empty inventory, which is a fact rather than a filler.
+
+        Nothing can be installed: resolving a requirement needs an index, and
+        the machine has no route to one. So the snapshot is empty, and its hash
+        is the hash of that. It is a real digest of a real state, and it will
+        change the day a snapshot is put into the image.
+        """
+        return canonical_sha256({"package_records": list(self._package_records)})
+
+    def browser_build_sha256(self) -> str:
+        """An identity for the browser *in this image*, and nothing more.
+
+        The image carries chromium, so there is a browser and it has an
+        identity; what there is not is an attestation from whoever built it.
+        This digest is derived from the image and the manifest's own record of
+        the command, so it distinguishes one image's browser from another's.
+        Calling it a build signature would be a claim nobody here can support.
+        """
+        record = None
+        if self.manifest is not None:
+            for item in self.manifest.document["commands"]:
+                if item.get("name") == "chromium":
+                    record = item
+                    break
+        return canonical_sha256(
+            {
+                "image_digest": self.image.digest,
+                "manifest_command": record,
+                "driven_by_this_backend": False,
+            }
+        )
+
+    def state_sha256(self) -> str:
+        """The workspace, plus what would run in it.
+
+        The parent's version covers the workspace and the fixture's catalogue.
+        Here the image belongs in it too: an identical workspace under a
+        different guest is not the same state, and a resume that treated it as
+        one would carry a run across a change it should have noticed.
+        """
+        root_mode, entries, _ = self._workspace_snapshot()
+        return canonical_sha256(
+            {
+                "root_mode": root_mode,
+                "profile": self.profile.policy_profile_id,
+                "backend_identity": self.backend_identity(),
+                "budget_caps": self.budget_caps,
+                "entries": entries,
+                "active_locks": sorted(self._active_locks),
+                "boots": len(self.boots),
+                "terminal_result_sha256": (
+                    canonical_sha256(self._result) if self._result is not None else None
+                ),
+            }
+        )
+
+    def _capabilities(self) -> dict:
+        """What the manifest says is there, filtered by what this can reach.
+
+        Every list is read out of the manifest rather than written here. The two
+        empty ones are empty for stated reasons, not for want of filling in:
+        packages because nothing can be resolved, and formats because the
+        manifest describes capability families rather than a list of formats,
+        and turning one into the other would be this file's guess.
+        """
+        if self.manifest is None:
+            return {
+                "commands": [],
+                "runtimes": [],
+                "packages": [],
+                "formats": [],
+                "budgets": self._budget_items(),
+            }
+        document = self.manifest.document
+        commands = sorted(str(item["name"]) for item in document["commands"])
+        declared = set(commands)
+        runtimes = sorted(
+            name
+            for name, command in MANIFEST_COMMAND_FOR_INTERPRETER.items()
+            if command in declared
+        )
+        return {
+            "commands": commands,
+            "runtimes": runtimes,
+            "packages": [],
+            "formats": sorted(str(item) for item in document["capability_families"]),
+            "budgets": self._budget_items(),
+        }
+
+    def _budget_items(self) -> list[str]:
+        return [f"{name}={self.budget_caps[name]}" for name in sorted(self.budget_caps)]
+
+    # -- the one call that costs a machine --------------------------------
+
+    def exec_run(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Boot one machine, run one command in it, and read back what it did.
+
+        The order matters and is chosen so that nothing is paid for twice. The
+        directory is checked on the host first, because a bad path is the one
+        failure that can be established without spending a boot on it. Then the
+        deadline is reconciled and the wrapper is built — both of which can
+        refuse, and refusing before launch costs nothing.
+
+        Output does not come back in the result. ``exec_run``'s data schema is a
+        returncode and nothing else with ``additionalProperties`` false, so the
+        streams are written into the workspace where the model reads them with
+        ``workspace_apply``, the same way it reads anything else.
+        """
+        try:
+            descriptor = self._open_directory(str(arguments.get("cwd", "")))
+        except (FileNotFoundError, NotADirectoryError, ValueError, OSError):
+            return {"ok": False, "error_type": "path_not_directory"}
+        os.close(descriptor)
+
+        try:
+            deadline = effective_deadline(
+                arguments.get("timeout_seconds"), policy=self.policy
+            )
+            script = command_script(
+                arguments, interpreters=self.interpreter_binaries
+            )
+        except ExecRefused as refusal:
+            self.boots.append(
+                {
+                    "call": len(self.boots),
+                    "refused_before_launch": str(refusal),
+                    "booted": False,
+                }
+            )
+            return {"ok": False, "error_type": "invalid_arguments"}
+
+        try:
+            boot = self._boot_one_command(
+                command_sh=script,
+                workspace=self.work,
+                deadline_seconds=deadline["applied_seconds"],
+            )
+        except Exception as failure:  # the launcher itself came apart
+            self.boots.append(
+                {
+                    "call": len(self.boots),
+                    "booted": False,
+                    "launcher_error": f"{type(failure).__name__}: {failure}",
+                    "deadline": deadline,
+                }
+            )
+            return {"ok": False, "error_type": "compute_backend_error"}
+
+        reading = read_the_boot(boot, deadline=deadline)
+        record = {
+            "call": len(self.boots),
+            "booted": True,
+            "boot_outcome": reading["boot_outcome"],
+            "deadline": reading["deadline"],
+            "truncated": reading["truncated"],
+            "grounds": reading["grounds"],
+            "result": reading["result"],
+            "image": self.image.as_record(),
+        }
+        record["output_files"] = self._keep_the_output(record["call"], reading)
+        self.boots.append(record)
+        return reading["result"]
+
+    def _keep_the_output(self, call: int, reading: Mapping[str, Any]) -> dict[str, Any]:
+        """Put the streams where the model can ask for them.
+
+        If this fails — a full workspace, most likely — the command's own
+        answer is still the answer. Losing the returncode because its transcript
+        would not fit would turn a finished piece of work into a failure, so the
+        loss is recorded and the result is left alone. The model is told nothing
+        about it directly, which is honest: from where it sits the files simply
+        are not there, and reading a file that is not there already has a
+        meaning.
+        """
+        where = f"{EXEC_RECORD_DIR}/{call:04d}"
+        written: dict[str, Any] = {"directory": where, "kept": [], "not_kept": None}
+        payloads = {
+            "stdout": reading["stdout"].encode("utf-8"),
+            "stderr": reading["stderr"].encode("utf-8"),
+            "meta.json": json.dumps(
+                {
+                    "boot_outcome": reading["boot_outcome"],
+                    "deadline": reading["deadline"],
+                    "truncated": reading["truncated"],
+                    "result": reading["result"],
+                    "grounds": reading["grounds"],
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            ).encode("utf-8"),
+        }
+        for leaf, content in payloads.items():
+            try:
+                self._write_bytes(f"{where}/{leaf}", content)
+            except Exception as failure:
+                written["not_kept"] = f"{type(failure).__name__}: {failure}"
+                break
+            written["kept"].append(leaf)
+        return written
+
+    # -- what this cannot do ----------------------------------------------
+
+    def environment_resolve(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Refused: resolving needs an index, and the machine has no route out.
+
+        Stage C's fourth attack established that there is exactly one network
+        interface in the guest and it is the loopback. That is the containment
+        working, and this refusal is its consequence rather than a missing
+        feature. A task that needed a package the image does not carry fails
+        here, and that failure is about the image, not about the model.
+        """
+        del arguments
+        return {"ok": False, "error_type": "capability_unavailable"}
+
+    def environment_activate(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Refused: there is no lock to activate, because none can be made."""
+        del arguments
+        return {"ok": False, "error_type": "capability_unavailable"}
+
+    def browser_run(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Refused, including ``open_local``, and the two reasons differ.
+
+        ``search`` and ``open_url`` need a network the machine does not have.
+        ``open_local`` needs no network — the image has chromium and the file is
+        on the work disk — but nothing here starts it, collects what it rendered
+        or bounds how long it runs. Returning a hash of the file the model
+        already has would look like a browser having run, which is the kind of
+        result that is worse than an error.
+        """
+        operation = str(arguments.get("operation", ""))
+        del operation  # both branches refuse; named so the distinction is read
+        return {"ok": False, "error_type": "capability_unavailable"}

--- a/batch-runner/tests/test_agentic_v2_exec_boot.py
+++ b/batch-runner/tests/test_agentic_v2_exec_boot.py
@@ -1,0 +1,415 @@
+"""What the exec-run wrapper builds, and how a boot is read back.
+
+Two kinds of check here, and the second is the interesting one.
+
+The first kind is ordinary: given a request, does the builder produce the right
+text, and given a boot artefact, does the reader reach the right verdict.
+
+The second kind **runs the script it built**, under a real ``/bin/sh``, with
+``/work`` pointed at a temporary directory. That is not a microVM and does not
+pretend to be one — the containment is stage C's business and was measured
+there. What it proves is the part a microVM would not help with anyway: that the
+wrapper is valid shell, that it enters the directory it was asked to, that the
+payload arrives byte for byte, and that a command reading standard input gets
+what the request said and not something else. Those are exactly the faults that
+would otherwise be found once, expensively, on a booted machine.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from core.agentic_v2_exec_boot import (
+    CD_FAILED_MARKER,
+    DECODE_FAILED_MARKER,
+    EXEC_RECORD_DIR,
+    GUEST_SETUP_STATUS,
+    INTERPRETERS,
+    MOST_OUTPUT_BYTES,
+    WORKSPACE_IN_GUEST,
+    ExecRefused,
+    command_script,
+    effective_deadline,
+    read_the_boot,
+)
+from core.agentic_v2_microvm import REQUIRED_MICROVM_POLICY
+
+
+ANY_DEADLINE = {
+    "requested_seconds": 60,
+    "policy_seconds": 1200,
+    "applied_seconds": 60,
+    "capped_by_the_policy": False,
+}
+
+
+def _boot(outcome: str, *, status=None, stdout: str = "", stderr: str = "") -> dict:
+    return {
+        "outcome": outcome,
+        "command_exit_status": status,
+        "results": {"/out/stdout": stdout, "/out/stderr": stderr},
+    }
+
+
+def _run_the_wrapper(script: str, tmp_path: Path, *, cwd_exists: str | None = "job"):
+    """Run a built wrapper under a real shell with /work redirected at tmp_path.
+
+    ``GUEST_INIT`` runs the wrapper as ``sh /work/in/command.sh`` with stdout and
+    stderr sent to files on the work disk, so that is how it is run here.
+    """
+    work = tmp_path / "work"
+    (work / "in").mkdir(parents=True)
+    (work / "ws").mkdir(parents=True)
+    if cwd_exists:
+        (work / "ws" / cwd_exists).mkdir(parents=True)
+    local = script.replace("/work/", f"{work.as_posix()}/")
+    wrapper = work / "in" / "command.sh"
+    wrapper.write_text(local, encoding="utf-8")
+    out = work / "stdout"
+    err = work / "stderr"
+    with out.open("wb") as stdout, err.open("wb") as stderr:
+        finished = subprocess.run(
+            ["/bin/sh", wrapper.as_posix()],
+            stdout=stdout,
+            stderr=stderr,
+            stdin=subprocess.DEVNULL,
+            timeout=60,
+            check=False,
+        )
+    return (
+        finished.returncode,
+        out.read_text(encoding="utf-8", errors="replace"),
+        err.read_text(encoding="utf-8", errors="replace"),
+    )
+
+
+class TestTheDeadlineTheModelGetsIsRecorded:
+    def test_a_request_inside_the_policy_is_left_alone(self):
+        reading = effective_deadline(300)
+        assert reading["applied_seconds"] == 300
+        assert reading["capped_by_the_policy"] is False
+
+    def test_a_request_past_the_policy_gets_the_policy_and_says_so(self):
+        reading = effective_deadline(2700)
+        assert reading["applied_seconds"] == REQUIRED_MICROVM_POLICY[
+            "wall_clock_seconds"
+        ]
+        assert reading["requested_seconds"] == 2700
+        assert reading["capped_by_the_policy"] is True
+
+    def test_the_number_asked_for_survives_being_overruled(self):
+        # Otherwise a kill at the policy's bound reads, later, as the model's
+        # own choice having been honoured.
+        assert effective_deadline(2700)["requested_seconds"] == 2700
+
+    @pytest.mark.parametrize("bad", [0, -1, None, True, 12.5, "60"])
+    def test_a_bound_that_is_not_a_bound_is_refused(self, bad):
+        with pytest.raises(ExecRefused):
+            effective_deadline(bad)
+
+    def test_a_policy_with_no_wall_clock_is_refused_rather_than_defaulted(self):
+        policy = dict(REQUIRED_MICROVM_POLICY)
+        policy.pop("wall_clock_seconds")
+        with pytest.raises(ExecRefused):
+            effective_deadline(60, policy=policy)
+
+
+class TestTheWrapperRefusesWhatItCannotWriteFaithfully:
+    def test_an_absolute_cwd_is_refused(self):
+        with pytest.raises(ExecRefused):
+            command_script({"argv": ["true"], "cwd": "/etc", "timeout_seconds": 5})
+
+    def test_a_cwd_climbing_out_of_the_workspace_is_refused(self):
+        with pytest.raises(ExecRefused):
+            command_script({"argv": ["true"], "cwd": "a/../../b", "timeout_seconds": 5})
+
+    def test_a_request_that_is_both_shapes_is_refused(self):
+        with pytest.raises(ExecRefused):
+            command_script(
+                {
+                    "argv": ["true"],
+                    "interpreter": "python",
+                    "script": "pass",
+                    "cwd": "job",
+                    "timeout_seconds": 5,
+                }
+            )
+
+    def test_a_request_that_is_neither_shape_is_refused(self):
+        with pytest.raises(ExecRefused):
+            command_script({"cwd": "job", "timeout_seconds": 5})
+
+    def test_an_interpreter_nobody_named_is_refused(self):
+        with pytest.raises(ExecRefused):
+            command_script(
+                {
+                    "interpreter": "perl",
+                    "script": "print 1",
+                    "cwd": "job",
+                    "timeout_seconds": 5,
+                }
+            )
+
+    def test_an_interpreter_the_image_may_lack_is_still_built(self):
+        # Refusing here would hide a recoverable failure from the model. A
+        # missing Rscript should come back as "not found" from inside.
+        for name in INTERPRETERS:
+            built = command_script(
+                {
+                    "interpreter": name,
+                    "script": "x",
+                    "cwd": "job",
+                    "timeout_seconds": 5,
+                }
+            )
+            assert INTERPRETERS[name] in built
+
+
+class TestTheWrapperIsRealShellThatDoesWhatItSays:
+    def test_it_runs_the_command_in_the_directory_that_was_asked_for(self, tmp_path):
+        script = command_script(
+            {"argv": ["pwd"], "cwd": "job", "timeout_seconds": 5}
+        )
+        code, out, err = _run_the_wrapper(script, tmp_path)
+        assert code == 0, err
+        assert out.strip().endswith("/work/ws/job")
+
+    def test_a_directory_that_is_not_there_stops_before_the_command_runs(
+        self, tmp_path
+    ):
+        script = command_script(
+            {"argv": ["touch", "should-not-exist"], "cwd": "job", "timeout_seconds": 5}
+        )
+        code, _out, err = _run_the_wrapper(script, tmp_path, cwd_exists=None)
+        assert code == GUEST_SETUP_STATUS
+        # Exactly the marker, with nothing before it. The reader downstream
+        # matches stderr against this string, and a shell that had printed its
+        # own "can't cd to ..." first would mean that match never once fired on
+        # a real guest -- which is what this assertion originally caught.
+        assert err.strip() == CD_FAILED_MARKER
+        assert not (tmp_path / "work" / "ws" / "should-not-exist").exists()
+
+    def test_an_argument_with_a_space_and_a_quote_survives_intact(self, tmp_path):
+        awkward = "two words and an ' apostrophe"
+        script = command_script(
+            {"argv": ["printf", "%s", awkward], "cwd": "job", "timeout_seconds": 5}
+        )
+        code, out, err = _run_the_wrapper(script, tmp_path)
+        assert code == 0, err
+        assert out == awkward
+
+    def test_a_script_arrives_byte_for_byte_including_no_final_newline(
+        self, tmp_path
+    ):
+        # A heredoc appends a newline the model's bytes may not have had, which
+        # is why the payload travels as base64 rather than as itself.
+        body = "import sys\nsys.stdout.write('exact')"
+        script = command_script(
+            {
+                "interpreter": "python",
+                "script": body,
+                "cwd": "job",
+                "timeout_seconds": 5,
+            }
+        )
+        _code, out, _err = _run_the_wrapper(script, tmp_path)
+        assert out == "exact"
+        landed = (tmp_path / "work" / "in" / "script").read_bytes()
+        assert landed == body.encode("utf-8")
+
+    def test_a_payload_containing_the_heredoc_delimiter_cannot_end_it_early(
+        self, tmp_path
+    ):
+        # base64's alphabet has no underscore, so the delimiter provably cannot
+        # occur in the document. This is the proof rather than the argument.
+        hostile = "# GDPVAL_SCRIPT_EOF\nprint('still mine')\n"
+        script = command_script(
+            {
+                "interpreter": "python",
+                "script": hostile,
+                "cwd": "job",
+                "timeout_seconds": 5,
+            }
+        )
+        assert script.count("GDPVAL_SCRIPT_EOF") == 2
+        code, out, err = _run_the_wrapper(script, tmp_path)
+        assert (tmp_path / "work" / "in" / "script").read_text() == hostile
+        assert code == 0, err
+        assert out.strip() == "still mine"
+
+    def test_a_delimiter_alone_on_a_line_of_the_payload_is_still_only_data(
+        self, tmp_path
+    ):
+        # The harsher shape: the delimiter with nothing else on its line, which
+        # is exactly what would terminate the document if it reached the shell.
+        hostile = "x = '''\nGDPVAL_SCRIPT_EOF\n'''\nprint(len(x))\n"
+        script = command_script(
+            {
+                "interpreter": "python",
+                "script": hostile,
+                "cwd": "job",
+                "timeout_seconds": 5,
+            }
+        )
+        code, out, err = _run_the_wrapper(script, tmp_path)
+        assert (tmp_path / "work" / "in" / "script").read_text() == hostile
+        assert code == 0, err
+        assert out.strip() == "19"
+
+    def test_standard_input_is_what_the_request_said(self, tmp_path):
+        script = command_script(
+            {"argv": ["cat"], "cwd": "job", "stdin": "fed in", "timeout_seconds": 5}
+        )
+        code, out, err = _run_the_wrapper(script, tmp_path)
+        assert code == 0, err
+        assert out == "fed in"
+
+    def test_a_request_with_no_stdin_reads_an_empty_stream_not_its_own_script(
+        self, tmp_path
+    ):
+        # Without an explicit redirect the command inherits init's descriptor,
+        # and a command that consumed part of its own launcher would be a very
+        # hard afternoon.
+        script = command_script({"argv": ["cat"], "cwd": "job", "timeout_seconds": 5})
+        assert "< /dev/null" in script
+        code, out, _err = _run_the_wrapper(script, tmp_path)
+        assert code == 0
+        assert out == ""
+
+    def test_the_commands_own_returncode_comes_back(self, tmp_path):
+        script = command_script(
+            {
+                "interpreter": "bash",
+                "script": "exit 42",
+                "cwd": "job",
+                "timeout_seconds": 5,
+            }
+        )
+        code, _out, _err = _run_the_wrapper(script, tmp_path)
+        assert code == 42
+
+
+class TestReadingOneBootAsOneResult:
+    def test_an_exit_status_is_the_answer_whatever_the_number_is(self):
+        read = read_the_boot(_boot("booted", status=3), deadline=ANY_DEADLINE)
+        assert read["result"] == {"ok": True, "error_type": None, "data": {"returncode": 3}}
+
+    def test_a_failing_command_is_a_successful_tool_call(self):
+        # The model is shown "that did not work" and chooses again. That is the
+        # loop working, not the call failing.
+        assert read_the_boot(_boot("booted", status=1), deadline=ANY_DEADLINE)[
+            "result"
+        ]["ok"] is True
+
+    def test_a_machine_that_wrote_nothing_is_never_a_zero(self):
+        read = read_the_boot(_boot("booted_but_wrote_nothing"), deadline=ANY_DEADLINE)
+        assert read["result"]["ok"] is False
+        assert read["result"]["error_type"] == "compute_backend_error"
+        assert read["result"]["data"] == {}
+
+    def test_a_machine_that_never_started_says_so_specifically(self):
+        read = read_the_boot(_boot("never_started"), deadline=ANY_DEADLINE)
+        assert read["result"]["error_type"] == "compute_start_failed"
+
+    def test_the_deadline_firing_is_a_cancellation_not_a_broken_backend(self):
+        # The bound doing its job is stage C's third attack succeeding on
+        # purpose, and calling it a backend fault would report the containment
+        # working as the containment being broken.
+        read = read_the_boot(_boot("stopped_by_the_deadline"), deadline=ANY_DEADLINE)
+        assert read["result"]["error_type"] == "cancelled"
+
+    def test_a_command_that_finished_keeps_its_answer_when_shutdown_overran(self):
+        read = read_the_boot(
+            _boot("stopped_by_the_deadline", status=0), deadline=ANY_DEADLINE
+        )
+        assert read["result"]["ok"] is True
+        assert read["result"]["data"] == {"returncode": 0}
+        assert "only the shutdown overran" in read["grounds"]
+
+    @pytest.mark.parametrize("bad", [-1, 256, 1000, "0", True, 1.5])
+    def test_a_returncode_the_guest_made_up_is_refused(self, bad):
+        read = read_the_boot(_boot("booted", status=bad), deadline=ANY_DEADLINE)
+        assert read["result"]["error_type"] == "invalid_backend_result"
+
+    def test_the_cd_marker_is_a_path_fault_and_not_the_commands_status(self):
+        read = read_the_boot(
+            _boot("booted", status=GUEST_SETUP_STATUS, stderr=CD_FAILED_MARKER + "\n"),
+            deadline=ANY_DEADLINE,
+        )
+        assert read["result"]["error_type"] == "path_not_directory"
+
+    def test_a_missing_base64_is_an_image_fault_not_a_path_fault(self):
+        read = read_the_boot(
+            _boot(
+                "booted",
+                status=GUEST_SETUP_STATUS,
+                stderr=DECODE_FAILED_MARKER + "\n",
+            ),
+            deadline=ANY_DEADLINE,
+        )
+        assert read["result"]["error_type"] == "compute_backend_error"
+
+    def test_a_real_command_that_happens_to_exit_125_keeps_its_status(self):
+        read = read_the_boot(
+            _boot("booted", status=GUEST_SETUP_STATUS, stderr="ordinary trouble"),
+            deadline=ANY_DEADLINE,
+        )
+        assert read["result"]["data"] == {"returncode": GUEST_SETUP_STATUS}
+
+    def test_every_reading_says_on_what_grounds(self):
+        for boot in (
+            _boot("booted", status=0),
+            _boot("booted_but_wrote_nothing"),
+            _boot("never_started"),
+            _boot("stopped_by_the_deadline"),
+        ):
+            assert read_the_boot(boot, deadline=ANY_DEADLINE)["grounds"].strip()
+
+    def test_the_deadline_that_was_applied_travels_with_the_reading(self):
+        read = read_the_boot(_boot("booted", status=0), deadline=ANY_DEADLINE)
+        assert read["deadline"] == ANY_DEADLINE
+
+
+class TestOutputGoesToTheWorkspaceAndSaysWhenItWasCut:
+    def test_output_is_carried_out_separately_from_the_result(self):
+        # exec_run's data schema is a returncode and nothing else, with
+        # additionalProperties false, so there is nowhere in the result to put
+        # output even if one wanted to.
+        read = read_the_boot(
+            _boot("booted", status=0, stdout="printed", stderr="warned"),
+            deadline=ANY_DEADLINE,
+        )
+        assert read["stdout"] == "printed"
+        assert read["stderr"] == "warned"
+        assert read["result"]["data"] == {"returncode": 0}
+
+    def test_a_stream_past_the_ceiling_is_cut_and_says_it_was(self):
+        read = read_the_boot(
+            _boot("booted", status=0, stdout="x" * (MOST_OUTPUT_BYTES + 500)),
+            deadline=ANY_DEADLINE,
+        )
+        assert read["truncated"]["stdout"] is True
+        assert "output truncated" in read["stdout"]
+        assert str(MOST_OUTPUT_BYTES + 500) in read["stdout"]
+
+    def test_a_stream_inside_the_ceiling_is_untouched(self):
+        read = read_the_boot(
+            _boot("booted", status=0, stdout="small"), deadline=ANY_DEADLINE
+        )
+        assert read["stdout"] == "small"
+        assert read["truncated"] == {"stdout": False, "stderr": False}
+
+    def test_a_stream_the_guest_did_not_write_reads_as_empty_not_as_none(self):
+        read = read_the_boot(_boot("booted", status=0), deadline=ANY_DEADLINE)
+        assert read["stdout"] == ""
+        assert read["stderr"] == ""
+
+    def test_the_place_output_is_left_is_a_path_the_model_can_ask_for(self):
+        # It has to satisfy the contract's path rule or workspace_apply will
+        # refuse to read back the thing exec_run just wrote.
+        assert not EXEC_RECORD_DIR.startswith("/")
+        assert ".." not in EXEC_RECORD_DIR.split("/")
+        assert WORKSPACE_IN_GUEST.startswith("/work")

--- a/batch-runner/tests/test_agentic_v2_microvm_backend.py
+++ b/batch-runner/tests/test_agentic_v2_microvm_backend.py
@@ -1,0 +1,532 @@
+"""The backend that boots: what it claims, what it refuses, what one call costs.
+
+Three things are being checked here and they are not the same kind of thing.
+
+The first is **what it says it is**. A backend's identity is what the run record
+is built on, so a backend that describes itself wrongly poisons everything
+downstream of it quietly. The tests below insist the description is derived from
+the image and the manifest, and that with no manifest it declines to describe
+itself at all.
+
+The second is **that the fixture underneath it stays underneath it**. This class
+inherits from a deliberately non-production backend for its workspace path
+safety. Everything else about the parent is a thing that must not be reachable,
+and the way that is kept true over time is a test that pins the inherited
+surface — so that a convenience added to the fixture later cannot become a
+production capability by accident.
+
+The third is **that one call is one machine**. No microVM boots in these tests;
+the launcher is a callable the backend is handed, exactly as stage C's attacks
+were injected. What is being proven is the part around the boot: that a bad path
+never spends one, that a refusal never spends one, and that when a machine does
+come back the workspace is left holding what it produced.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.agentic_v2_contract import (
+    FOUNDATION_BACKEND_ID,
+    TOOL_CONTRACT_VERSION,
+    AgenticV2Profile,
+)
+from core.agentic_v2_exec_boot import EXEC_RECORD_DIR, INTERPRETERS
+from core.agentic_v2_fixture_backend import AgenticV2FixtureBackend
+from core.agentic_v2_microvm import REQUIRED_MICROVM_POLICY
+from core.agentic_v2_microvm_backend import (
+    BACKEND_ID,
+    MANIFEST_COMMAND_FOR_INTERPRETER,
+    AgenticV2MicroVMBackend,
+    GuestImage,
+)
+from core.agentic_v2_substrate import AgenticV2SubstrateManifest
+
+
+MANIFEST_PATH = Path("sandbox/agentic_v2_capabilities.json")
+
+AN_IMAGE = GuestImage(
+    reference="ghcr.io/hyeonsangjeon/gdpval-sandbox",
+    digest="sha256:ee6ef798631d3c3aeaed28658c640e6f5d021677449852bf2e1f18be5bd24edb",
+    kernel_sha256="a" * 64,
+    rootfs_sha256="b" * 64,
+)
+
+ANOTHER_IMAGE = GuestImage(
+    reference=AN_IMAGE.reference,
+    digest=AN_IMAGE.digest,
+    kernel_sha256="a" * 64,
+    rootfs_sha256="c" * 64,
+)
+
+
+class Launcher:
+    """Stands in for the thing that would boot a machine, and remembers.
+
+    ``writes`` lets a call leave files behind in the workspace, which is what a
+    real session does when it reads the changed work disk back out afterwards.
+    """
+
+    def __init__(self, *, outcome="booted", status=0, stdout="", stderr="", writes=None):
+        self.outcome = outcome
+        self.status = status
+        self.stdout = stdout
+        self.stderr = stderr
+        self.writes = dict(writes or {})
+        self.calls: list[dict] = []
+
+    def __call__(self, *, command_sh, workspace, deadline_seconds):
+        self.calls.append(
+            {
+                "command_sh": command_sh,
+                "workspace": workspace,
+                "deadline_seconds": deadline_seconds,
+            }
+        )
+        for relative, content in self.writes.items():
+            target = Path(workspace) / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+        return {
+            "outcome": self.outcome,
+            "command_exit_status": self.status,
+            "results": {"/out/stdout": self.stdout, "/out/stderr": self.stderr},
+        }
+
+
+def _manifest() -> AgenticV2SubstrateManifest:
+    return AgenticV2SubstrateManifest.load(MANIFEST_PATH)
+
+
+def _backend(tmp_path, *, launcher=None, manifest="real", image=AN_IMAGE, **kwargs):
+    return AgenticV2MicroVMBackend(
+        root=tmp_path / "session",
+        profile=AgenticV2Profile(
+            tool_contract_version=TOOL_CONTRACT_VERSION,
+            policy_profile_id="offline-full-v1",
+            foundation_only=True,
+        ),
+        image=image,
+        boot_one_command=launcher or Launcher(),
+        substrate_manifest=_manifest() if manifest == "real" else manifest,
+        **kwargs,
+    )
+
+
+def _ok(arguments=None):
+    base = {"argv": ["true"], "cwd": ".", "timeout_seconds": 60}
+    base.update(arguments or {})
+    return base
+
+
+class TestWhatItSaysItIs:
+    def test_with_no_manifest_it_declines_to_describe_itself(self, tmp_path):
+        # The tempting alternative is a placeholder digest, which would put a
+        # hash into the run record that no file on disk corresponds to.
+        backend = _backend(tmp_path, manifest=None)
+        started = backend.start(30.0)
+        assert started == {"ok": False, "error_type": "substrate_manifest_missing"}
+        backend.close()
+
+    def test_it_never_answers_with_the_fixtures_identity(self, tmp_path):
+        backend = _backend(tmp_path)
+        identity = backend.start(30.0)["data"]["backend_identity"]
+        assert identity["backend_id"] == BACKEND_ID
+        assert identity["backend_id"] != FOUNDATION_BACKEND_ID
+        backend.close()
+
+    def test_the_runner_still_refuses_this_backend_and_that_is_the_point(
+        self, tmp_path
+    ):
+        # core/agentic_v2_runner.py compares the startup identity against the
+        # foundation fixture's and fails anything else. This asserts the guard
+        # is untouched by this module: opening it is its own change, with its
+        # own review, once the pieces under it have evidence.
+        backend = _backend(tmp_path)
+        identity = backend.start(30.0)["data"]["backend_identity"]
+        assert identity["backend_id"] != FOUNDATION_BACKEND_ID
+        backend.close()
+
+    def test_a_different_root_filesystem_is_a_different_backend(self, tmp_path):
+        one = _backend(tmp_path / "one", image=AN_IMAGE)
+        two = _backend(tmp_path / "two", image=ANOTHER_IMAGE)
+        assert (
+            one.backend_identity()["implementation_sha256"]
+            != two.backend_identity()["implementation_sha256"]
+        )
+        one.close()
+        two.close()
+
+    def test_pinning_a_different_python_binary_is_a_different_backend(self, tmp_path):
+        # Because it is: the same request runs a different program.
+        one = _backend(tmp_path / "one")
+        two = _backend(
+            tmp_path / "two",
+            interpreter_binaries={**INTERPRETERS, "python": "python"},
+        )
+        assert (
+            one.backend_identity()["implementation_sha256"]
+            != two.backend_identity()["implementation_sha256"]
+        )
+        one.close()
+        two.close()
+
+    def test_foundation_only_is_read_from_the_manifest_not_asserted_here(
+        self, tmp_path
+    ):
+        backend = _backend(tmp_path)
+        assert (
+            backend.backend_identity()["foundation_only"]
+            is backend.manifest.document["foundation_only"]
+        )
+        backend.close()
+
+    def test_the_three_startup_digests_are_shaped_like_digests(self, tmp_path):
+        # The runner checks all three with is_sha256 and reports
+        # substrate_manifest_missing when any of them is not one.
+        backend = _backend(tmp_path)
+        data = backend.start(30.0)["data"]
+        for value in (
+            data["substrate_manifest"]["sha256"],
+            data["package_snapshot_sha256"],
+            data["browser_build_sha256"],
+        ):
+            assert isinstance(value, str) and len(value) == 64
+            assert set(value) <= set("0123456789abcdef")
+        backend.close()
+
+    def test_the_browser_digest_follows_the_image_it_came_from(self, tmp_path):
+        one = _backend(tmp_path / "one", image=AN_IMAGE)
+        two = _backend(
+            tmp_path / "two",
+            image=GuestImage(
+                reference=AN_IMAGE.reference,
+                digest="sha256:" + "d" * 64,
+                kernel_sha256=AN_IMAGE.kernel_sha256,
+                rootfs_sha256=AN_IMAGE.rootfs_sha256,
+            ),
+        )
+        assert one.browser_build_sha256() != two.browser_build_sha256()
+        one.close()
+        two.close()
+
+
+class TestWhatItAdvertisesComesFromTheManifest:
+    def test_the_commands_are_the_manifests_commands(self, tmp_path):
+        backend = _backend(tmp_path)
+        declared = sorted(
+            item["name"] for item in backend.manifest.document["commands"]
+        )
+        assert backend._capabilities()["commands"] == declared
+        assert "fixture-upper" not in declared
+        backend.close()
+
+    def test_a_runtime_is_advertised_only_if_the_manifest_declares_it(self, tmp_path):
+        backend = _backend(tmp_path)
+        declared = {item["name"] for item in backend.manifest.document["commands"]}
+        expected = sorted(
+            name
+            for name, command in MANIFEST_COMMAND_FOR_INTERPRETER.items()
+            if command in declared
+        )
+        assert backend._capabilities()["runtimes"] == expected
+        assert expected, "the manifest declares none of the four interpreters"
+        backend.close()
+
+    def test_no_packages_are_advertised_because_none_can_be_had(self, tmp_path):
+        backend = _backend(tmp_path)
+        assert backend._capabilities()["packages"] == []
+        backend.close()
+
+    def test_the_budgets_are_the_caps_this_backend_was_given(self, tmp_path):
+        backend = _backend(tmp_path, budget_caps={"tool_calls": 8, "wall_seconds": 300})
+        assert backend._capabilities()["budgets"] == [
+            "tool_calls=8",
+            "wall_seconds=300",
+        ]
+        backend.close()
+
+    def test_what_start_reports_is_what_expected_capabilities_returns(self, tmp_path):
+        # The runner compares the two and fails startup if they differ, so a
+        # backend whose two answers drift never starts at all.
+        backend = _backend(tmp_path)
+        assert backend.start(30.0)["data"]["capabilities"] == dict(
+            backend.expected_capabilities()
+        )
+        backend.close()
+
+
+class TestTheFixtureUnderneathStaysUnderneath:
+    def test_the_inherited_surface_is_exactly_this_and_no_more(self, tmp_path):
+        # If this fails because the fixture grew a method, that is the test
+        # doing its job: decide deliberately whether the new thing should be
+        # reachable in production, then change this list.
+        expected = {
+            "backend_identity",
+            "best_result",
+            "browser_build_sha256",
+            "browser_run",
+            "capabilities_query",
+            "close",
+            "environment_activate",
+            "environment_resolve",
+            "exec_run",
+            "expected_capabilities",
+            "finalize",
+            "package_snapshot_sha256",
+            "start",
+            "state_sha256",
+            "verify_public",
+            "workspace_apply",
+            "workspace_state_sha256",
+        }
+        public = {
+            name
+            for name in dir(AgenticV2MicroVMBackend)
+            if not name.startswith("_") and callable(
+                getattr(AgenticV2MicroVMBackend, name, None)
+            )
+        }
+        assert public == expected
+
+    def test_every_fixture_method_is_either_inherited_on_purpose_or_overridden(self):
+        fixture = {
+            name for name in dir(AgenticV2FixtureBackend) if not name.startswith("_")
+        }
+        mine = set(vars(AgenticV2MicroVMBackend))
+        inherited_on_purpose = {
+            "best_result",
+            "capabilities_query",
+            "close",
+            "expected_capabilities",
+            "finalize",
+            "verify_public",
+            "workspace_apply",
+            "workspace_state_sha256",
+        }
+        assert fixture - mine - {"closed"} == inherited_on_purpose
+
+    def test_the_fixtures_own_command_does_nothing_here(self, tmp_path):
+        launcher = Launcher(status=0)
+        backend = _backend(tmp_path, launcher=launcher)
+        backend.workspace_apply(
+            {"operation": "write", "path": "a.txt", "content": "quiet"}
+        )
+        result = backend.exec_run(_ok({"argv": ["fixture-upper", "a.txt", "b.txt"]}))
+        # It is not special-cased: it becomes an ordinary command in a machine,
+        # which is where "fixture-upper: not found" belongs.
+        assert launcher.calls, "the request never reached the launcher"
+        assert "fixture-upper" in launcher.calls[0]["command_sh"]
+        assert result["ok"] is True
+        backend.close()
+
+    def test_the_demonstration_package_catalogue_is_emptied(self, tmp_path):
+        backend = _backend(tmp_path)
+        assert dict(backend.package_catalog) == {}
+        backend.close()
+
+
+class TestWhatItCannotDoItSaysItCannotDo:
+    def test_resolving_a_requirement_is_refused(self, tmp_path):
+        backend = _backend(tmp_path)
+        assert backend.environment_resolve(
+            {"ecosystem": "python", "requirements": ["numpy"]}
+        ) == {"ok": False, "error_type": "capability_unavailable"}
+        backend.close()
+
+    def test_activating_a_lock_is_refused(self, tmp_path):
+        backend = _backend(tmp_path)
+        assert backend.environment_activate({"lock_sha256": "0" * 64})["ok"] is False
+        backend.close()
+
+    @pytest.mark.parametrize("operation", ["search", "open_url", "open_local"])
+    def test_the_browser_is_refused_including_the_local_one(self, tmp_path, operation):
+        # open_local needs no network and the image has chromium, so this is a
+        # missing harness rather than a closed door. Hashing the file the model
+        # already has would read as a browser having run, which is worse than
+        # an error.
+        backend = _backend(tmp_path)
+        backend.workspace_apply(
+            {"operation": "write", "path": "page.html", "content": "<p>hi</p>"}
+        )
+        assert backend.browser_run({"operation": operation, "path": "page.html"}) == {
+            "ok": False,
+            "error_type": "capability_unavailable",
+        }
+        backend.close()
+
+
+class TestOneCallIsOneMachine:
+    def test_a_command_that_ran_comes_back_as_its_returncode(self, tmp_path):
+        backend = _backend(tmp_path, launcher=Launcher(status=7))
+        assert backend.exec_run(_ok()) == {
+            "ok": True,
+            "error_type": None,
+            "data": {"returncode": 7},
+        }
+        backend.close()
+
+    def test_the_launcher_is_given_the_deadline_that_was_applied(self, tmp_path):
+        launcher = Launcher()
+        backend = _backend(tmp_path, launcher=launcher)
+        backend.exec_run(_ok({"timeout_seconds": 2700}))
+        assert launcher.calls[0]["deadline_seconds"] == REQUIRED_MICROVM_POLICY[
+            "wall_clock_seconds"
+        ]
+        assert backend.boots[0]["deadline"]["requested_seconds"] == 2700
+        assert backend.boots[0]["deadline"]["capped_by_the_policy"] is True
+        backend.close()
+
+    def test_a_directory_that_is_not_there_never_spends_a_boot(self, tmp_path):
+        launcher = Launcher()
+        backend = _backend(tmp_path, launcher=launcher)
+        assert backend.exec_run(_ok({"cwd": "nowhere"})) == {
+            "ok": False,
+            "error_type": "path_not_directory",
+        }
+        assert launcher.calls == []
+        backend.close()
+
+    def test_a_request_that_cannot_be_written_never_spends_a_boot(self, tmp_path):
+        launcher = Launcher()
+        backend = _backend(tmp_path, launcher=launcher)
+        result = backend.exec_run(
+            {"interpreter": "perl", "script": "x", "cwd": ".", "timeout_seconds": 60}
+        )
+        assert result == {"ok": False, "error_type": "invalid_arguments"}
+        assert launcher.calls == []
+        assert backend.boots[0]["booted"] is False
+        assert "perl" in backend.boots[0]["refused_before_launch"]
+        backend.close()
+
+    def test_a_launcher_that_comes_apart_is_a_backend_error_not_a_returncode(
+        self, tmp_path
+    ):
+        def explode(**_):
+            raise RuntimeError("the jailer is not installed")
+
+        backend = _backend(tmp_path, launcher=explode)
+        assert backend.exec_run(_ok()) == {
+            "ok": False,
+            "error_type": "compute_backend_error",
+        }
+        assert "jailer" in backend.boots[0]["launcher_error"]
+        backend.close()
+
+    def test_the_workspace_is_the_same_directory_between_calls(self, tmp_path):
+        launcher = Launcher(writes={"made-inside": "by the machine"})
+        backend = _backend(tmp_path, launcher=launcher)
+        backend.exec_run(_ok())
+        assert launcher.calls[0]["workspace"] == backend.work
+        # The second call sees what the first one left, which is the whole
+        # reason the workspace lives on the host rather than in the machine.
+        assert backend.workspace_apply(
+            {"operation": "read", "path": "made-inside"}
+        )["data"]["content"] == "by the machine"
+        backend.close()
+
+
+class TestTheOutputGoesWhereTheModelCanReadIt:
+    def test_what_the_command_printed_lands_in_the_workspace(self, tmp_path):
+        backend = _backend(tmp_path, launcher=Launcher(stdout="the answer is 4"))
+        backend.exec_run(_ok())
+        read = backend.workspace_apply(
+            {"operation": "read", "path": f"{EXEC_RECORD_DIR}/0000/stdout"}
+        )
+        assert read["ok"] is True
+        assert read["data"]["content"] == "the answer is 4"
+        backend.close()
+
+    def test_each_call_gets_its_own_place_and_does_not_overwrite_the_last(
+        self, tmp_path
+    ):
+        backend = _backend(tmp_path, launcher=Launcher(stdout="first"))
+        backend.exec_run(_ok())
+        backend._boot_one_command = Launcher(stdout="second")
+        backend.exec_run(_ok())
+        first = backend.workspace_apply(
+            {"operation": "read", "path": f"{EXEC_RECORD_DIR}/0000/stdout"}
+        )
+        second = backend.workspace_apply(
+            {"operation": "read", "path": f"{EXEC_RECORD_DIR}/0001/stdout"}
+        )
+        assert (first["data"]["content"], second["data"]["content"]) == (
+            "first",
+            "second",
+        )
+        backend.close()
+
+    def test_the_record_beside_the_output_says_how_the_call_ended(self, tmp_path):
+        backend = _backend(
+            tmp_path, launcher=Launcher(outcome="stopped_by_the_deadline", status=None)
+        )
+        backend.exec_run(_ok({"timeout_seconds": 30}))
+        meta = json.loads(
+            backend.workspace_apply(
+                {"operation": "read", "path": f"{EXEC_RECORD_DIR}/0000/meta.json"}
+            )["data"]["content"]
+        )
+        assert meta["result"]["error_type"] == "cancelled"
+        assert meta["deadline"]["applied_seconds"] == 30
+        assert meta["grounds"].strip()
+        backend.close()
+
+    def test_a_machine_that_wrote_nothing_leaves_a_record_saying_so(self, tmp_path):
+        backend = _backend(
+            tmp_path,
+            launcher=Launcher(outcome="booted_but_wrote_nothing", status=None),
+        )
+        result = backend.exec_run(_ok())
+        assert result["error_type"] == "compute_backend_error"
+        assert result["data"] == {}
+        assert backend.boots[0]["boot_outcome"] == "booted_but_wrote_nothing"
+        backend.close()
+
+    def test_the_boot_record_names_the_image_the_answer_came_from(self, tmp_path):
+        backend = _backend(tmp_path)
+        backend.exec_run(_ok())
+        assert backend.boots[0]["image"] == AN_IMAGE.as_record()
+        backend.close()
+
+    def test_output_that_cannot_be_kept_does_not_take_the_answer_with_it(
+        self, tmp_path
+    ):
+        backend = _backend(tmp_path, launcher=Launcher(status=3, stdout="printed"))
+
+        def refuse(*_args, **_kwargs):
+            raise OSError("workspace is full")
+
+        backend._write_bytes = refuse
+        result = backend.exec_run(_ok())
+        assert result == {"ok": True, "error_type": None, "data": {"returncode": 3}}
+        assert backend.boots[0]["output_files"]["kept"] == []
+        assert "full" in backend.boots[0]["output_files"]["not_kept"]
+        backend.close()
+
+
+class TestStateCoversWhatWouldRunInIt:
+    def test_writing_a_file_changes_the_state(self, tmp_path):
+        backend = _backend(tmp_path)
+        before = backend.state_sha256()
+        backend.workspace_apply(
+            {"operation": "write", "path": "note.txt", "content": "x"}
+        )
+        assert backend.state_sha256() != before
+        backend.close()
+
+    def test_the_same_workspace_under_a_different_guest_is_not_the_same_state(
+        self, tmp_path
+    ):
+        one = _backend(tmp_path / "one", image=AN_IMAGE)
+        two = _backend(tmp_path / "two", image=ANOTHER_IMAGE)
+        for backend in (one, two):
+            backend.workspace_apply(
+                {"operation": "write", "path": "note.txt", "content": "identical"}
+            )
+        assert one.workspace_state_sha256() == two.workspace_state_sha256()
+        assert one.state_sha256() != two.state_sha256()
+        one.close()
+        two.close()

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
@@ -1575,6 +1575,250 @@ evidence the bound held, and it is still not accepted, because it does not say
 death as containment. The first run's six-of-seven stands in the record as a
 failed run.
 
+###### The host is stopped, and this is what it ran for
+
+C2 and C3 were the only work scheduled on `gdpval-devhost-vm`, and both are done,
+so it is deallocated. Idleness was checked before stopping it rather than
+assumed: nobody logged in, no `firecracker` or `jailer` process, nothing outside
+kernel threads.
+
+| | |
+|---|---|
+| Started | `2026-09-10T19:33:33.115Z` requested, `19:34:03.528Z` succeeded |
+| Deallocated | `2026-09-10T20:52:57.917Z` requested, `20:53:10.886Z` succeeded |
+| Outer window | **4,777.8 s — 79.63 min — 1.3272 h** |
+| Size / region | `Standard_D8as_v5`, `koreacentral` |
+| Published Linux rate | 0.424 USD/h pay-as-you-go, from the public retail price API |
+| Rate × window | 0.5627 USD |
+| Price status | **`partial`** |
+
+The two timestamps come from the subscription's own activity log, so the
+**duration is measured, not estimated**. The dollar figure is not. 0.424 USD/h is
+the *published list rate* for this size in this region; what the subscription is
+actually billed depends on agreement terms this session cannot read. So the
+arithmetic is recorded as arithmetic and the price stays `partial`.
+
+**`partial` is not zero.** Something was spent for 79.63 minutes of an 8-vCPU
+machine, and the number simply is not verifiable from here.
+
+Two smaller things worth keeping:
+
+- **`az monitor activity-log` does not run on this box** — the installed CLI
+  raises `TypeError: ord() expected string of length 1, but int found` out of a
+  bundled antlr4 that disagrees with its own generated lexer. That is a local
+  packaging fault, not an access one; the same query answers through
+  `az rest` against `Microsoft.Insights/eventtypes/management/values`.
+- **The artefacts survive the deallocation.** They are on `/var/tmp`, which on
+  this VM is the OS disk, and both are committed to the repository anyway.
+
 ### Stage D — not yet run
+
+#### The plan, written before any of it is built
+
+Stage C proved a machine that boots with the rules applied and stops seven ways
+of getting out of them. What it did **not** build is the thing on the other side
+of the tool contract. The gap is worth naming precisely, because it is not
+"wire two finished pieces together".
+
+**C boots a machine to run one command and then destroys it.** The tool
+contract's `exec_run` is a call made repeatedly inside a session that holds
+state: the model writes a file with `workspace_apply`, runs something with
+`exec_run`, reads what came out, and runs something else. Between those calls
+the workspace has to still be there. A one-shot boot has nowhere to keep it.
+
+##### One machine per call, not one machine per session
+
+Two ways to close that gap, and the choice matters enough to write down.
+
+**A long-lived machine per task.** Boot once when the session starts, keep it
+running, send each `exec_run` to an agent inside it over vsock, tear it down at
+`finalize`. Fewer boots, so less latency per call. It needs a guest agent, a
+channel protocol, and a way to bound a call without killing the machine — none
+of which stage C looked at, so none of which has evidence behind it.
+
+**A fresh machine per call, with the work disk carried across.** The workspace
+lives on the host between calls. Each `exec_run` builds a work disk out of it,
+boots, runs, and the machine is destroyed; the results and the changed workspace
+are read back out of the disk image afterwards. **This is exactly the sequence
+stage C measured** — `build_launch_plan`, boot, collect, teardown with
+`all_gone: true` — repeated.
+
+**Taking the second.** The cost is real: C2's guest ran for 1.269 s but the
+orchestration around it is seconds, and 220 tasks at ten calls each is thousands
+of boots. That is hours, and it is affordable. What is bought for it is that
+every `exec_run` inherits stage C's evidence instead of needing its own, and
+that nothing whatever survives a call except a disk image the host controls —
+so a call that gets compromised has no resident machine to stay in.
+
+This does not weaken `workdir: ephemeral`. Carrying the disk between calls
+*within* one task is the workspace working; what `ephemeral` forbids is carrying
+it between tasks. That is a runner property, and stage E is where it is kept.
+
+##### What gets built, and in what order
+
+**D1 — the pure part, testable on a box that cannot boot.** A module that turns
+a validated `exec_run` request into the guest command, and turns what a boot
+returned into the tool contract's result. No subprocess, no Firecracker, no
+network. Same shape as C3: pure data and pure judging, with the boot injected.
+
+**D2 — the backend.** A real `AgenticV2Backend` whose `workspace_apply` reads
+and writes a host-side session directory, whose `exec_run` calls D1 and boots,
+and whose `finalize` collects the produced files with their hashes. Guards
+untouched.
+
+**D3 — the model's voice.** `real_model_voice` currently refuses, and its stated
+reason — *"reaching one costs money that has not been approved"* — **is now out
+of date**, because the calls have been approved. It will keep refusing, on the
+reason that is still true, and the docstring gets corrected rather than quietly
+left saying something false.
+
+**D4 — the guards, each in its own change.** Only after D1–D3 exist, run, and
+have artefacts. Nothing is flipped before then.
+
+##### The one judging rule that decides whether any of this is honest
+
+A guest that panicked on boot and a guest whose command returned 0 leave
+**different** evidence, and the difference is the whole thing:
+
+- `/out/exit_status` **present** — the command ran and this is its returncode,
+  whatever the number is. A non-zero returncode is a *successful tool call*
+  reporting a failed command, and the model is shown it.
+- `/out/exit_status` **absent** — the command did not run to completion, and
+  there is no returncode to report. This is `compute_backend_error`. It is
+  **never** `returncode: 0`, and never a made-up non-zero either.
+
+Getting this backwards is how a run of 220 tasks reports a wall of clean
+failures that were really a broken launcher. Stage C's first run was this exact
+mistake in the other direction, and the discipline is the same: **absent
+evidence is not a result.**
+
+##### The bound a model asks for, and the bound it gets
+
+`exec_run`'s schema allows `timeout_seconds` up to 2700. The containment policy
+allows 1200. A model asking for more than the policy permits is not an error and
+is not a refusal — it gets the policy's bound, and **the result says which
+number was actually applied**, so nobody later reads a 1200 s kill as the model's
+own 2700 s choice having been honoured.
+
+##### D1 — the pure part, built and green
+
+`core/agentic_v2_exec_boot.py` and `tests/test_agentic_v2_exec_boot.py`.
+**47 tests, 0.26 s, nothing booted.**
+
+The technique that made it worth doing first: the tests **run the wrapper they
+built**, under a real `/bin/sh`, with `/work` pointed at a temporary directory —
+the same way `GUEST_INIT` runs it, output redirected to files. That is not a
+microVM and does not pretend to be one; the containment is stage C's business
+and was measured there. What it proves is the part a microVM would not have
+helped with: that the wrapper is valid shell, that it enters the directory it
+was asked to, that the payload arrives byte for byte, and that a command reading
+standard input gets what the request said.
+
+It found a real bug on the first run, which is the entire argument for the
+technique. The reader downstream matches stderr **exactly** against a marker, and
+a shell that cannot enter a directory prints its own sentence first — worded
+differently in dash, ash and bash. The match would have fired on no real guest
+at all, and the fault would have surfaced once, expensively, on a booted machine.
+The fix is `2>/dev/null` on the `cd`, and the same treatment on `base64 -d`.
+
+Two decisions worth keeping written down:
+
+**The payload travels as base64, and that is not decoration.** It closes three
+things at once. The heredoc delimiter is `GDPVAL_SCRIPT_EOF`, containing `_`,
+which base64's alphabet — `A-Z a-z 0-9 + / =` — provably never emits, so a
+payload cannot end its own document early. A heredoc appends a newline the
+model's bytes may not have had. And a 256 KiB script as one `printf` argument
+would be past `MAX_ARG_STRLEN` and simply fail to execute.
+
+**A setup failure and a command's own status are told apart by a marker, not by
+a number.** The wrapper exits 125 when its own setup failed, but 125 is a number
+a real command can return, so it counts as a setup failure only alongside the
+matching marker on stderr — and there are two markers, not one. A path it could
+not enter is something the model can fix by asking for another; a guest with no
+working `base64` is a fault in the image, and telling the model to correct its
+path would send it chasing something it cannot reach.
+
+##### D2 — the backend, built and green
+
+`core/agentic_v2_microvm_backend.py` and `tests/test_agentic_v2_microvm_backend.py`.
+**36 tests.** Wider selection re-run afterwards: **1,971 passed, 3 skipped** —
+no fingerprint regression from adding a `core/` module.
+
+It subclasses `AgenticV2FixtureBackend`, and the reason is specific. Most of that
+class is not a stub: it is roughly four hundred lines of workspace path safety —
+a directory descriptor pinned by device and inode, every open relative to it with
+`O_NOFOLLOW`, every resulting descriptor checked back against the root before a
+byte moves, and quotas on entries, file size and total size. That is the code
+that stops a model writing through a symlink into the host, and it is identical
+whether the command afterwards runs in a fixture or in a machine. Two copies of
+it would mean two versions of the part that must never drift.
+
+What makes the fixture a fixture is overridden away: its identity, its
+`fixture-upper` command, its demonstration package catalogue. **A test pins the
+exact set of inherited public methods**, so a convenience added to the fixture
+years from now cannot become a production capability while nothing fails.
+
+###### The guard I did not touch, and where it is
+
+`core/agentic_v2_runner.py:466` compares the startup identity against the
+foundation fixture's and fails **anything else** with `compute_start_failed`.
+This backend does not satisfy that check, and this change does not alter it.
+That is not an oversight — it is the guard that has to be opened as its own
+reviewable change, once the pieces under it have evidence, and opening it quietly
+from inside the backend would make every other honest thing in the file
+worthless. So the backend is proven directly by its tests, and **the runner still
+refuses it.** There is now a line number for D4 to argue about.
+
+###### Two capability gaps, named as gaps
+
+`environment_resolve` and `environment_activate` refuse. Resolving a requirement
+needs an index and the machine has no route to one — that is stage C's fourth
+attack, the containment working, and the refusal is its consequence rather than
+a missing feature.
+
+`browser_run` refuses **including `open_local`**, and the two reasons differ.
+`search` and `open_url` need a network. `open_local` needs none — the image has
+chromium and the file is on the work disk — but nothing here starts it, collects
+what it rendered, or bounds how long it runs. Returning a hash of the file the
+model already handed over would read as a browser having run, which is worse than
+an error. **Both gaps will change the outcome of some tasks, and a task that
+failed for want of a browser has to read as that and not as a model that could
+not do the work.**
+
+###### Identity is the image, because the image is the behaviour
+
+The fixture hashes its own source, which is right for something whose behaviour
+is entirely its own code. Here the code decides very little: the same wrapper in
+a different guest is a different machine with different programs in it. So the
+implementation hash covers the image reference and digest, the kernel and root
+filesystem hashes, the manifest, the pinned interpreter binaries and the policy.
+`state_sha256` carries it too — an identical workspace under a different guest is
+not the same state, and a resume that treated it as one would carry a run across
+a change it should have noticed.
+
+Two digests the runner insists on are derived rather than invented, and both are
+described for what they are. `package_snapshot_sha256` is the hash of an **empty**
+inventory — a real digest of a real state, since nothing can be installed.
+`browser_build_sha256` identifies the browser *in this image*, from the image
+digest and the manifest's own record of the command. **It is not a build
+attestation from whoever built chromium**, and calling it one would be a claim
+nobody here can support.
+
+With no manifest, `start` returns `substrate_manifest_missing` rather than
+describing itself. The tempting alternative is a placeholder digest, which would
+put a hash into the run record that no file on disk corresponds to.
+
+###### One thing found that has to be settled by probing, not by reasoning
+
+The substrate manifest requires a command named **`python`**. D1 invokes
+**`python3`**. On a Debian image both normally exist — but *normally* is not
+evidence, and a guest with only one of them would fail every Python call with
+"not found" while the manifest went on reporting the capability as present.
+
+So the interpreter binaries are an **argument** to the backend rather than a
+constant, defaulting to D1's mapping. The capability probe runs both and records
+the answer, and the answer gets pinned here without editing D1 on the strength of
+what is usually true.
+
 ### Stage E — not yet run
 ### Stage F — not yet run


### PR DESCRIPTION
## What this is

Stage C proved a machine boots with the containment applied and that seven ways out of it are closed. It did **not** build the thing on the other side of the tool contract. This is the first half of that, plus the record of the stage B host being stopped.

## D1 — the pure part (`core/agentic_v2_exec_boot.py`, 47 tests)

Turns one `exec_run` request into the guest command, and one boot into a tool result. No subprocess, no socket, no file — the boot is injected, exactly as stage C's attacks were.

Because it is pure, **the tests run the wrapper they built**, under a real `/bin/sh`, with `/work` pointed at a tmpdir and output redirected to files — the same way `GUEST_INIT` runs it. That is not a microVM and does not pretend to be one; the containment is stage C's business and was measured there.

It caught a real bug on the first run. The reader matches stderr **exactly** against a marker, and a shell that cannot enter a directory prints its own sentence first, worded differently in dash, ash and bash — so the match would have fired on no real guest at all, and the fault would have surfaced once, expensively, on a booted machine. Fixed with `2>/dev/null`, applied to `base64 -d` as well.

Two things worth reviewing deliberately:

- **The payload travels as base64**, which closes three problems at once: the heredoc delimiter contains `_`, which base64's alphabet (`A-Z a-z 0-9 + / =`) provably never emits, so a payload cannot end its own document early; a heredoc appends a newline the model's bytes may not have had; and a 256 KiB script as one `printf` argument would be past `MAX_ARG_STRLEN`.
- **Setup failure vs. the command's own status** is told apart by a marker, not a number. 125 is a status a real command can return, so it counts as setup failure only alongside a marker — and there are two markers. A path the guest could not enter is something the model can fix; a guest with no working `base64` is a fault in the image, and telling the model to correct its path would send it chasing something it cannot reach.

## D2 — the backend (`core/agentic_v2_microvm_backend.py`, 36 tests)

The object the conversation loop holds: workspace on the host, one throwaway machine per `exec_run`.

It **subclasses `AgenticV2FixtureBackend`**, and the reason is specific. Most of that class is not a stub — it is ~400 lines of workspace path safety (root fd pinned by dev/ino, every open relative with `O_NOFOLLOW`, every descriptor re-checked against the root, quotas). That is what stops a model writing through a symlink into the host, and it is identical whether the command runs in a fixture or a machine. Two copies would mean two versions of the part that must never drift.

What makes the fixture a fixture is overridden away. **A test pins the exact inherited public surface**, so a convenience added to the fixture years from now cannot silently become a production capability.

### The guard this does not touch

`core/agentic_v2_runner.py:466` compares the startup identity against the foundation fixture's and fails **anything else** with `compute_start_failed`. This backend does not satisfy that check and this PR does not change it. That guard is its own reviewable change, once the pieces under it have evidence — opening it quietly from inside the backend would make every other honest thing in the file worthless. The backend is proven directly by its tests, and the runner still refuses it.

### Two capability gaps, named as gaps

- `environment_resolve` / `environment_activate` refuse: resolving needs an index and the machine has no route to one. That is stage C's fourth attack — the containment working — so this is its consequence, not a missing feature.
- `browser_run` refuses **including `open_local`**, and the reasons differ. `search`/`open_url` need a network. `open_local` needs none, but nothing here starts chromium, collects what it rendered, or bounds it — and returning a hash of the file the model already handed over would read as a browser having run.

Both will change the outcome of some tasks, and a task that failed for want of a browser has to read as that rather than as a model that could not do the work.

### Identity is the image

The implementation hash covers the image reference and digest, the kernel and rootfs hashes, the manifest, the pinned interpreter binaries and the policy — because the same wrapper in a different guest is a different machine. `state_sha256` carries it too, so a resume cannot carry a run across a guest change it should have noticed.

The two derived digests are described for what they are: `package_snapshot_sha256` is the hash of an **empty** inventory (nothing can be installed), and `browser_build_sha256` identifies the browser *in this image* — **not** a build attestation from whoever built chromium. With no manifest, `start` returns `substrate_manifest_missing` rather than inventing a placeholder digest that no file on disk corresponds to.

### Found, and to be settled by probing rather than reasoning

The substrate manifest requires a command named **`python`**; D1 invokes **`python3`**. Both normally exist on a Debian image — but *normally* is not evidence, and a guest with only one would fail every Python call with "not found" while the manifest reported the capability present. So the interpreter binaries are an argument defaulting to D1's mapping, for the capability probe to pin.

## Also in here

The stage B host is stopped. Idleness was verified first (nobody logged in, no firecracker/jailer). Duration is **measured** from the subscription's own activity log — 4,777.8 s — and the price status is **`partial`, explicitly not $0**, because the billed amount cannot be read from here.

## Tests

- `tests/test_agentic_v2_exec_boot.py` — 47 passed
- `tests/test_agentic_v2_microvm_backend.py` — 36 passed
- agentic/substrate/licence/fingerprint/provenance/contract selection — **1,971 passed, 3 skipped**, no fingerprint regression from adding a `core/` module