### PR TITLE
feat(agentic-v2): D3 — the carriage, the one-call machine, and stage D's probe

### DIFF
--- a/batch-runner/core/agentic_v2_conversation.py
+++ b/batch-runner/core/agentic_v2_conversation.py
@@ -182,8 +182,17 @@ def real_model_voice(
     Kept as a function that can refuse rather than left absent, so the refusal
     can be *run* by the free check instead of inferred from a file not
     existing. Called with nothing — which is how the free check calls it — it
-    still raises, because nothing has been approved and there is nothing to
-    charge against.
+    still raises.
+
+    **The reason it raises is not that nothing has been approved.** It was that
+    once; stage A has since been approved, run and paid for, so leaving the old
+    sentence here would make this docstring say something false. What is still
+    true is narrower and does not expire: an approval is a number in a document,
+    and a document cannot stop the next call. :class:`StageOneBudget` is the
+    object that knows what has already gone out and refuses before the turn that
+    would pass the ceiling. A caller holding an approval and no budget has
+    permission to spend and no way to stop, which is the case this refusal is
+    for.
 
     Given a client and a budget, it hands back a voice that really asks a
     Microsoft Foundry deployment. Building the client is somebody else's job:

--- a/batch-runner/core/agentic_v2_one_call_machine.py
+++ b/batch-runner/core/agentic_v2_one_call_machine.py
@@ -1,0 +1,226 @@
+"""One ``exec_run``, one machine: staging, boot, read-back, and nothing left.
+
+D2's backend holds a workspace and calls ``boot_one_command`` once per
+``exec_run``. This is the thing that satisfies that call on a host that can
+really boot — it is the only place where the carriage
+(:mod:`core.agentic_v2_work_disk`), the launcher
+(:mod:`core.agentic_v2_microvm_launch`) and the boot
+(:mod:`core.agentic_v2_first_boot`) meet.
+
+**Every rule stays where it was written.** The launch plan is built by C1's
+builder from :data:`REQUIRED_MICROVM_POLICY`, and exactly one key is changed on
+the way past: ``wall_clock_seconds``, set to the deadline D1 already reconciled
+between what the model asked for and what the policy allows. Tightening a bound
+is the one adjustment a per-call launcher can make without becoming a second
+place where containment is decided; a test here asserts that no other rule
+differs, so a loosening cannot arrive disguised as a deadline.
+
+**Where the changed workspace actually is after a boot.** Not in the jail —
+:func:`first_boot` destroys the chroot as the last thing it does, because
+``workdir: ephemeral-quota`` says so. Just before that it copies the work disk
+to ``<work_disk>.returned``, and that copy is the only surviving record of what
+the guest wrote. Reading from anywhere else finds an empty directory and reports
+a model that did nothing.
+
+**A command that finished and a workspace that came back are two facts, and the
+model needs both.** If the command exits 0 and its files cannot be carried out,
+handing back ``returncode: 0`` would tell the model its work is on disk when it
+is not, and every later turn would be reasoning about files that are not there.
+So the call is reported as an infrastructure failure, and the exit status the
+guest really wrote is kept in the record under its own name rather than thrown
+away.
+
+The outcome used for that case is ``workspace_did_not_come_back``.
+:func:`core.agentic_v2_exec_boot.read_the_boot` has no branch naming it, so it
+falls to the last one and becomes ``compute_backend_error`` — the right answer,
+reached by the right route. Its *wording* there ("wrote no exit status") is not
+quite right for this case, and sharpening it is a small change to D1 that is
+deliberately not made from here while D1's own tests are in flight.
+
+Nothing in this module opens ``exec_run`` in the product path, changes
+``foundation_only`` or ``production_activation``, or touches the runner's
+backend-identity check. Those are D4, each on its own.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from core.agentic_v2_substrate import REQUIRED_MICROVM_POLICY
+from core.agentic_v2_work_disk import (
+    carry_the_workspace_back,
+    stage_the_work_disk,
+    work_disk_fingerprint,
+)
+
+
+THE_ONE_RULE_A_CALL_MAY_TIGHTEN = "wall_clock_seconds"
+
+WORKSPACE_DID_NOT_COME_BACK = "workspace_did_not_come_back"
+"""The command ran and its files could not be carried off the disk.
+
+Kept distinct from ``booted_but_wrote_nothing``, which means the guest produced
+no exit status at all. Collapsing the two would lose the difference between a
+machine that failed and a carriage that failed, and those get fixed in different
+places.
+"""
+
+
+class MachineRefused(RuntimeError):
+    """The call cannot be made as asked, so nothing was started."""
+
+
+def policy_for_this_call(deadline_seconds: int) -> dict[str, Any]:
+    """The containment rules with one bound tightened, and nothing else moved.
+
+    Returns a full policy rather than a patch, because
+    :func:`build_launch_plan` refuses a policy that is missing a rule or has
+    gained one — which is what makes "nothing else moved" checkable rather than
+    promised.
+    """
+    if (
+        not isinstance(deadline_seconds, int)
+        or isinstance(deadline_seconds, bool)
+        or deadline_seconds <= 0
+    ):
+        raise MachineRefused(
+            f"a deadline of {deadline_seconds!r} is not a bound, and a call with "
+            "no bound is not a call this will make"
+        )
+    allowed = int(REQUIRED_MICROVM_POLICY[THE_ONE_RULE_A_CALL_MAY_TIGHTEN])
+    if deadline_seconds > allowed:
+        raise MachineRefused(
+            f"{deadline_seconds} seconds is longer than the policy's {allowed}. "
+            "A call may tighten this bound and may not loosen it, and D1 is "
+            "where the model's request is reconciled with the policy"
+        )
+    return {**REQUIRED_MICROVM_POLICY, THE_ONE_RULE_A_CALL_MAY_TIGHTEN: deadline_seconds}
+
+
+@dataclass
+class OneCallMachine:
+    """A host that can boot, holding everything that is fixed for the session.
+
+    The image paths, the account to jail to and the processor count are facts
+    about the host and are settled once. What arrives per call is the command,
+    the workspace and the deadline — which is exactly D2's ``boot_one_command``
+    signature, so an instance of this *is* that callable.
+    """
+
+    kernel: str | Path
+    rootfs: str | Path
+    firecracker_binary: str | Path
+    uid: int
+    gid: int
+    vcpu_count: int
+    cgroup_version: int
+    scratch: str | Path
+    session: str = "call"
+    jailer_binary: str = "jailer"
+    build_plan: Callable[..., Mapping[str, Any]] | None = None
+    boot: Callable[..., Mapping[str, Any]] | None = None
+    calls: int = 0
+    record: list[dict[str, Any]] = field(default_factory=list)
+
+    def name_the_machine(self) -> str:
+        """A per-call identity the jailer will accept, and two calls never share.
+
+        The jailer takes at most 64 alphanumerics and hyphens and turns the id
+        into a directory under the chroot base, so a repeated id would be a
+        second call building its jail on top of a first one's.
+        """
+        clean = "".join(ch for ch in self.session if ch.isalnum() or ch == "-")
+        stem = (clean.strip("-") or "call")[:48]
+        if not stem[0].isalnum():
+            stem = f"c{stem}"
+        return f"{stem}-{self.calls:04d}"
+
+    def __call__(
+        self,
+        *,
+        command_sh: str,
+        workspace: str | Path,
+        deadline_seconds: int,
+    ) -> dict[str, Any]:
+        from core.agentic_v2_first_boot import first_boot
+        from core.agentic_v2_microvm_launch import build_launch_plan
+
+        build_plan = self.build_plan or build_launch_plan
+        boot = self.boot or first_boot
+
+        call = self.calls
+        # Named before the counter moves, and once, so the jail directory and
+        # the plan's vm_id are the same string rather than two calls to a
+        # function whose answer changed in between.
+        name = self.name_the_machine()
+        self.calls += 1
+        here = Path(self.scratch) / name
+        here.mkdir(parents=True, exist_ok=True)
+
+        staged = stage_the_work_disk(
+            workspace=workspace, command_sh=command_sh, into=here
+        )
+        plan = build_plan(
+            vm_id=name,
+            firecracker_binary=self.firecracker_binary,
+            kernel_path=self.kernel,
+            rootfs_path=self.rootfs,
+            work_disk_path=staged["image"],
+            uid=self.uid,
+            gid=self.gid,
+            vcpu_count=self.vcpu_count,
+            cgroup_version=self.cgroup_version,
+            policy=policy_for_this_call(deadline_seconds),
+        )
+        booted = dict(
+            boot(
+                plan,
+                jailer_binary=self.jailer_binary,
+                kernel=self.kernel,
+                rootfs=self.rootfs,
+                work_disk=staged["image"],
+                uid=self.uid,
+                gid=self.gid,
+            )
+        )
+
+        # first_boot leaves the disk it took out of the jail beside the one that
+        # went in, and then removes the jail. This copy is the only place the
+        # guest's writes still exist.
+        returned = Path(str(staged["image"]) + ".returned")
+        carried = carry_the_workspace_back(
+            image=returned, workspace=workspace, scratch=here / "back"
+        )
+        booted["workspace_carriage"] = carried
+        booted["work_disk"] = {
+            "staged_sha256": staged["sha256"],
+            "returned_sha256": work_disk_fingerprint(returned),
+            "carried_in": staged["carried"],
+        }
+
+        if booted.get("command_exit_status") is not None and not carried["replaced"]:
+            # The command finished and its files did not come out. Reporting the
+            # returncode here would tell the model its work is on disk.
+            booted["command_exit_status_before_the_carriage_failed"] = booted[
+                "command_exit_status"
+            ]
+            booted["command_exit_status"] = None
+            booted["outcome"] = WORKSPACE_DID_NOT_COME_BACK
+
+        self.record.append(
+            {
+                "call": call,
+                "vm_id": plan["vm_id"],
+                "deadline_seconds": deadline_seconds,
+                "outcome": booted.get("outcome"),
+                "carriage": {
+                    "replaced": carried["replaced"],
+                    "files": carried["files"],
+                    "refused_symlinks": carried["refused_symlinks"],
+                },
+                "teardown": booted.get("teardown"),
+            }
+        )
+        return booted

--- a/batch-runner/core/agentic_v2_stage_d_probe.py
+++ b/batch-runner/core/agentic_v2_stage_d_probe.py
@@ -1,0 +1,491 @@
+"""Stage D's one question, asked once, of a real model and a real machine.
+
+Stage A asked whether a Foundry deployment shown a set of tools *chooses* one,
+and whether the turn after that arrives holding the first turn's answer. It was
+answered: yes, on ``gpt-5.4``, over four turns, for $0.0063. It also produced a
+finding that shapes this module — the model spent three of its four turns on
+``capabilities_query``, asking what it was allowed to do, before doing anything.
+A stage sized for four turns would spend all of them establishing the ground.
+
+Stage D asks the next question, and it is a different kind of question because
+the tool it turns on is not a tool that answers — it is a tool that *boots*:
+
+    Does a real model, offered a command runner, use it; does the command run
+    inside a machine that is destroyed afterwards; do the files it wrote come
+    back; and does the turn after that build on them?
+
+Every clause is separately falsifiable and all four have to hold. A model that
+calls ``exec_run`` and gets nothing back has been reached and has learnt
+nothing. A command that runs and whose files are lost is worse than one that
+never ran, because the model is told its work exists.
+
+**Why this can offer ``exec_run`` when stage A could not.** Stage A left it out
+because it was shut: :class:`AgenticV2FixtureBackend` accepts one fixed argument
+list and answers ``capability_unavailable`` to everything else, so offering it
+would have spent a paid turn to be told no. It is not shut here. The backend is
+:class:`AgenticV2MicroVMBackend`, whose ``exec_run`` boots one machine per call,
+and the launcher under it really stages a disk, boots, and carries the workspace
+back. Nothing was unblocked to make that true — this probe builds its own
+dispatcher, exactly as stage A's did, and the runner's backend-identity check at
+``core/agentic_v2_runner.py`` is untouched and still refuses this backend. That
+guard is D4's to open, as its own reviewable change, and opening it from here
+would make everything else in this file worthless.
+
+**What is still left out, and why.** ``finalize`` commits deliverables to the
+grader, and marking is nearly the whole of stage one's cost; a probe that could
+reach it is the stage-one run wearing a smaller name. ``environment_resolve``,
+``environment_activate`` and ``browser_run`` are refused by this backend by
+design — the machine has no route off itself — and offering a tool that always
+refuses spends a paid turn to be told no. Both exclusions are enforced by
+:func:`check_probe_tools` rather than promised by this docstring.
+
+**Nothing is graded, and nothing is kept from the model's own words.** As in
+stage A: fingerprints, token counts, a trimmed stated reason. No request body,
+no reply body, no reasoning. What is added here is the boot record — what ran,
+under which machine name, for how long it was allowed, and whether the workspace
+came back — because a run whose commands cannot be accounted for is not evidence
+of anything.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass, field
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional, Sequence
+
+from core.agentic_v2_contract import AgenticV2Lifecycle, AgenticV2Profile, LifecycleState
+from core.agentic_v2_conversation import (
+    ConversationOutcome,
+    DispatcherToolDesk,
+    LoopLimits,
+    real_model_voice,
+    run_model_conversation,
+)
+from core.agentic_v2_microvm_backend import AgenticV2MicroVMBackend, GuestImage
+from core.agentic_v2_one_call_machine import WORKSPACE_DID_NOT_COME_BACK
+from core.agentic_v2_stage_one_budget import StageOneBudget
+from core.agentic_v2_substrate import AgenticV2SubstrateManifest
+from core.agentic_v2_tools import AgenticV2ToolDispatcher
+from core.execution_envelope_cost import ModelPrice
+
+
+#: The tools stage D puts on offer, and the only ones.
+#:
+#: ``exec_run`` is the one the stage exists for. The other two are what make a
+#: sensible sequence possible: ``capabilities_query`` is how a model finds out
+#: what it may do — measured in stage A as the first thing it wants — and
+#: ``workspace_apply`` is how it writes a script to run and reads back what the
+#: command printed, since ``exec_run``'s result carries a returncode and nothing
+#: else.
+PROBE_TOOLS: tuple[str, ...] = (
+    "capabilities_query",
+    "workspace_apply",
+    "exec_run",
+)
+
+#: Tools this backend answers by refusing, whatever is asked of them.
+#:
+#: Not a policy decision taken here — the machine has no route off itself, which
+#: is stage C's fourth attack, so there is no index to resolve a requirement
+#: against and nothing to drive a browser with. Offering one would spend a paid
+#: turn to be told no, and would teach the model to ask again.
+TOOLS_THIS_BACKEND_REFUSES: tuple[str, ...] = (
+    "environment_resolve",
+    "environment_activate",
+    "browser_run",
+)
+
+#: Turns to allow, sized off what stage A measured rather than off a round number.
+#:
+#: Stage A spent three of four turns on ``capabilities_query`` before doing any
+#: work. A stage D run has strictly more to do — ask what it may do, write a
+#: script, run it, read what it printed, act on that — and a limit that stops it
+#: mid-sequence answers nothing while still costing what it spent. Eight is that
+#: sequence with room for one wrong guess.
+TURNS_STAGE_D_NEEDS = 8
+
+#: What the model is told it is doing.
+#:
+#: Says a command runner exists and does not say to call it, for the same reason
+#: stage A's did not name a tool: a probe that instructs the model to call
+#: ``exec_run`` and then reports that it called ``exec_run`` has established that
+#: models follow instructions.
+PROBE_INSTRUCTIONS = (
+    "You are working inside an isolated task workspace. You have a small set of "
+    "tools, including one that runs a command in a sandbox and returns its exit "
+    "status. Commands do not return their output directly — anything a command "
+    "prints is written into the workspace for you to read back. Use the tools to "
+    "make progress on the task you are given. Ask for one tool at a time and use "
+    "what comes back before deciding what to do next. If a tool answers that "
+    "something is unavailable, do not ask for it again."
+)
+
+
+class ProbeToolsAreWrong(RuntimeError):
+    """The probe's tool list would make it something other than stage D.
+
+    A hard failure rather than a filter, on the same reasoning as stage A's: a
+    list that has gained ``finalize`` or lost ``exec_run`` means someone changed
+    what this run is, and quietly correcting it would hide that from them.
+    """
+
+
+class ProbeCannotDescribeItself(RuntimeError):
+    """The backend could not say what it is, so no model call is worth making.
+
+    Raised before spending. A run whose substrate manifest is missing produces a
+    record with no verified image behind it — the numbers would be real and
+    would refer to nothing checkable, which is worse than not having them.
+    """
+
+
+def check_probe_tools(tools: Sequence[str] = PROBE_TOOLS) -> list[str]:
+    """Everything wrong with a stage D tool list, read from the list itself."""
+    problems: list[str] = []
+    offered = tuple(tools)
+    if "exec_run" not in offered:
+        problems.append(
+            "the stage D probe does not offer exec_run, which is the only thing "
+            "it exists to find out about. Without it this is stage A again, at "
+            "stage A's price and stage D's name"
+        )
+    if "finalize" in offered:
+        problems.append(
+            "the stage D probe offers finalize, which commits deliverables and "
+            "sends them to the grader. Stage D marks nothing, and marking is "
+            "almost the whole of stage one's cost, so a probe that can reach it "
+            "is the stage-one run under another name"
+        )
+    refused = [name for name in offered if name in TOOLS_THIS_BACKEND_REFUSES]
+    if refused:
+        problems.append(
+            f"the stage D probe offers {sorted(refused)}, which this backend "
+            "refuses whatever is asked of them — the machine has no route off "
+            "itself. Offering one spends a paid turn to be told no"
+        )
+    unknown = [name for name in offered if name not in _known_tools()]
+    if unknown:
+        problems.append(
+            f"the stage D probe offers {sorted(unknown)}, which the published "
+            "tool contract does not define"
+        )
+    return problems
+
+
+def _known_tools() -> frozenset[str]:
+    from core.agentic_v2_contract import TOOL_NAMES
+
+    return frozenset(TOOL_NAMES)
+
+
+@dataclass(frozen=True)
+class StageDProbeOutcome:
+    """What the one paid question answered, and what ran while it was asked.
+
+    Kept deliberately parallel to :class:`StageAProbeOutcome` so the two can be
+    read side by side, and extended with the boot record — which is the half
+    stage A had no equivalent of.
+
+    ``reached_a_model`` is about the connection, not the result, as in stage A. A
+    model that was asked, answered, and chose never to run a command has been
+    reached; that is a finding about the model, and this records findings rather
+    than requiring successes.
+    """
+
+    reached_a_model: bool
+    resolved_model: Optional[str]
+    requested_deployment: str
+    resource: str
+    tools_offered: tuple[str, ...]
+    tools_asked_for: tuple[str, ...]
+    turns_taken: int
+    stop_reason: str
+    detail: str
+    guest_image: Mapping[str, str]
+    substrate_manifest_sha256: Optional[str] = None
+    boots: tuple[Mapping[str, Any], ...] = ()
+    machines: tuple[Mapping[str, Any], ...] = ()
+    collected: Mapping[str, Any] = field(default_factory=dict)
+    ledger: tuple[Mapping[str, Any], ...] = ()
+    spent_usd: Optional[Decimal] = None
+    conversation: Optional[ConversationOutcome] = field(
+        default=None, repr=False, compare=False
+    )
+
+    @property
+    def carried_the_first_result(self) -> bool:
+        """Whether a later call went out holding an earlier tool's answer."""
+        return any(
+            int(row.get("history_entries_sent") or 0) > 0 for row in self.ledger
+        )
+
+    @property
+    def asked_to_run_something(self) -> bool:
+        """Whether the model chose the command runner at all.
+
+        False is a real answer and not a failure of the harness: it says a model
+        shown this tool did not reach for it, which is a finding about the model
+        and about how the tool is described to it.
+        """
+        return "exec_run" in self.tools_asked_for
+
+    @property
+    def a_command_really_ran(self) -> bool:
+        """Whether a machine came back carrying an exit status the guest wrote.
+
+        Keyed on the returncode rather than on ``boot_outcome`` because those
+        two answer different questions. A command that exits 37 ran; a machine
+        that overran its shutdown after the command finished also ran; a machine
+        that started cleanly and whose guest wrote no status did not. Only the
+        returncode separates them, and it is the guest's own file.
+        """
+        return any(
+            row.get("booted")
+            and isinstance(
+                (row.get("result") or {}).get("data", {}).get("returncode"), int
+            )
+            for row in self.boots
+        )
+
+    @property
+    def worked_on_after_running_something(self) -> bool:
+        """Whether the model did anything *after* its first command came back.
+
+        This is stage D's version of stage A's carried-the-first-result: a run
+        that boots a machine on its last turn has proved the machine and nothing
+        about the loop closing. The turn afterwards is what closes it.
+        """
+        asked = list(self.tools_asked_for)
+        if "exec_run" not in asked:
+            return False
+        return len(asked) > asked.index("exec_run") + 1
+
+    @property
+    def carriage_failures(self) -> int:
+        """Boots whose command finished and whose files did not come back.
+
+        Counted separately from every other failure because it is the one that
+        would otherwise be read as a model that produced nothing.
+        """
+        return sum(
+            1 for row in self.boots
+            if row.get("boot_outcome") == WORKSPACE_DID_NOT_COME_BACK
+        )
+
+    @property
+    def price_missing(self) -> bool:
+        """Whether any call was made whose price nobody has committed."""
+        return any(row.get("price_missing") for row in self.ledger)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "reached_a_model": self.reached_a_model,
+            "resolved_model": self.resolved_model,
+            "requested_deployment": self.requested_deployment,
+            "resource": self.resource,
+            "tools_offered": list(self.tools_offered),
+            "tools_asked_for": list(self.tools_asked_for),
+            "turns_taken": self.turns_taken,
+            "carried_the_first_result": self.carried_the_first_result,
+            "asked_to_run_something": self.asked_to_run_something,
+            "a_command_really_ran": self.a_command_really_ran,
+            "worked_on_after_running_something": self.worked_on_after_running_something,
+            "carriage_failures": self.carriage_failures,
+            "stop_reason": self.stop_reason,
+            "detail": self.detail,
+            "guest_image": dict(self.guest_image),
+            "substrate_manifest_sha256": self.substrate_manifest_sha256,
+            "boots": [dict(row) for row in self.boots],
+            "machines": [dict(row) for row in self.machines],
+            "collected": dict(self.collected),
+            "model_calls": [dict(row) for row in self.ledger],
+            "spent_usd": (
+                str(self.spent_usd) if self.spent_usd is not None else None
+            ),
+            "price_missing": self.price_missing,
+        }
+
+
+def run_stage_d_probe(
+    *,
+    client: Any,
+    deployment: str,
+    resource: str,
+    budget: StageOneBudget,
+    task_prompt: str,
+    workspace_root: str | Path,
+    image: GuestImage,
+    boot_one_command: Callable[..., Mapping[str, Any]],
+    substrate_manifest: Optional[AgenticV2SubstrateManifest],
+    max_output_tokens_per_turn: int,
+    max_seconds: float,
+    max_tool_calls: int = TURNS_STAGE_D_NEEDS,
+    collect_outputs_into: str | Path | None = None,
+    policy_profile_id: str = "offline-full-v1",
+    prices: Mapping[str, ModelPrice] | None = None,
+    tools: Sequence[str] = PROBE_TOOLS,
+    request_timeout_seconds: float = 120.0,
+) -> StageDProbeOutcome:
+    """Ask a real deployment one task's worth of questions, over a real machine.
+
+    The client and the launcher are both taken rather than built, for the same
+    reason: each involves choices — an endpoint and a credential on one side, a
+    kernel, a rootfs and an account to jail to on the other — that the
+    repository already has one reviewed place for. A second place to make them
+    is a second place to keep right. Build them with
+    :class:`core.azure_ai_clients.AzureAIClientFactory` and
+    :class:`core.agentic_v2_one_call_machine.OneCallMachine`.
+
+    Refuses before spending anything if the tool list is wrong or the backend
+    cannot describe itself. Both are cheap to establish and neither is cheaper
+    later: the first would let a probe reach the grader, and the second would
+    produce a paid record with no verified image behind it.
+
+    **The workspace is collected before it is destroyed.** ``close()`` purges
+    the work directory, which is the ``workdir: ephemeral-quota`` rule doing its
+    job — a task must not inherit the previous task's files. But the files are
+    also the entire product of the run, so they are copied out first, to
+    ``collect_outputs_into`` or to ``<workspace_root>/collected`` beside the
+    work directory. Without that step a run that succeeded would leave a boot
+    record describing deliverables that no longer exist.
+    """
+    wrong = check_probe_tools(tools)
+    if wrong:
+        raise ProbeToolsAreWrong("; ".join(wrong))
+
+    profile = AgenticV2Profile(
+        tool_contract_version="2.0",
+        policy_profile_id=policy_profile_id,
+        foundation_only=True,
+    )
+    backend = AgenticV2MicroVMBackend(
+        root=workspace_root,
+        profile=profile,
+        image=image,
+        boot_one_command=boot_one_command,
+        substrate_manifest=substrate_manifest,
+    )
+    started = backend.start(request_timeout_seconds)
+    if not started.get("ok"):
+        backend.close()
+        raise ProbeCannotDescribeItself(
+            "the backend would not describe itself — "
+            f"{started.get('error_type')!r} — so a model call made now would be "
+            "paid for and would refer to an image nothing on disk corresponds to"
+        )
+
+    voice = real_model_voice(
+        client=client,
+        deployment=deployment,
+        resource=resource,
+        budget=budget,
+        instructions=PROBE_INSTRUCTIONS,
+        max_output_tokens_per_turn=max_output_tokens_per_turn,
+        prices=dict(prices or {}),
+        request_timeout_seconds=request_timeout_seconds,
+    )
+
+    lifecycle = AgenticV2Lifecycle()
+    lifecycle.transition(LifecycleState.STARTED)
+    lifecycle.transition(LifecycleState.ACTIVE)
+    dispatcher = AgenticV2ToolDispatcher(
+        backend=backend,
+        lifecycle=lifecycle,
+        max_total_calls=max_tool_calls,
+    )
+
+    try:
+        outcome = run_model_conversation(
+            task_prompt=task_prompt,
+            voice=voice,
+            desk=DispatcherToolDesk(dispatcher=dispatcher),
+            limits=LoopLimits(
+                max_model_turns=max_tool_calls,
+                max_written_tokens_per_turn=max_output_tokens_per_turn,
+                max_seconds=max_seconds,
+                budget=budget,
+                # Same reasoning as stage A: two identical requests in a row is
+                # a model going in circles, and here each circuit can also cost
+                # a boot rather than only a turn.
+                max_repeats_of_one_request=2,
+            ),
+            tools_available=tuple(tools),
+        )
+        kept = _collect_the_workspace(
+            backend.work,
+            into=collect_outputs_into or Path(workspace_root) / "collected",
+        )
+        return StageDProbeOutcome(
+            reached_a_model=bool(voice.calls),
+            resolved_model=voice.resolved_model,
+            requested_deployment=deployment,
+            resource=resource,
+            tools_offered=tuple(tools),
+            tools_asked_for=tuple(record.tool_name for record in outcome.turns),
+            turns_taken=len(voice.calls),
+            stop_reason=outcome.stop_reason.value,
+            detail=outcome.detail,
+            guest_image=image.as_record(),
+            substrate_manifest_sha256=(
+                substrate_manifest.sha256 if substrate_manifest is not None else None
+            ),
+            boots=tuple(dict(row) for row in backend.boots),
+            machines=tuple(
+                dict(row) for row in getattr(boot_one_command, "record", ())
+            ),
+            collected=kept,
+            ledger=tuple(voice.ledger()),
+            spent_usd=voice.spent_usd(),
+            conversation=outcome,
+        )
+    finally:
+        # The workspace is ephemeral by policy and the run's whole product at
+        # the same time, so it is copied out above and destroyed here. Both, in
+        # that order -- keeping it would let the next task inherit these files,
+        # and destroying it without collecting would leave a record of
+        # deliverables that no longer exist.
+        backend.close()
+
+
+def _collect_the_workspace(work: str | Path, *, into: str | Path) -> dict[str, Any]:
+    """Copy the work directory somewhere the teardown will not reach.
+
+    Links are copied as links rather than followed. The carriage already
+    refuses one pointing out of the workspace on the way back off the disk, so
+    what survives to here points inside it — but following even those would
+    duplicate content and turn a self-referential tree into an infinite one.
+
+    Never raises. A collection that failed is recorded as one; letting it throw
+    would lose the model calls, the boot record and the price alongside the
+    files, and those are still true and still worth having.
+    """
+    work = Path(work)
+    into = Path(into)
+    try:
+        if into.exists():
+            shutil.rmtree(into)
+        shutil.copytree(work, into, symlinks=True)
+    except OSError as failure:
+        return {
+            "kept": False,
+            "root": None,
+            "files": 0,
+            "bytes": 0,
+            "grounds": f"the workspace could not be copied out: {failure}",
+        }
+    files = 0
+    total = 0
+    for path in into.rglob("*"):
+        if path.is_symlink() or path.is_file():
+            files += 1
+            if not path.is_symlink():
+                total += path.stat().st_size
+    return {
+        "kept": True,
+        "root": into.as_posix(),
+        "files": files,
+        "bytes": total,
+        "grounds": f"{files} files were copied out before the workspace was purged",
+    }

--- a/batch-runner/core/agentic_v2_work_disk.py
+++ b/batch-runner/core/agentic_v2_work_disk.py
@@ -1,0 +1,402 @@
+"""Carrying a workspace into one machine and back out again.
+
+D1 builds the command and reads the boot. D2 is the backend that holds the
+workspace on the host between calls. Between them sits the thing neither of them
+is: the *carriage*. Each ``exec_run`` has to put the session's files onto a work
+disk, boot, and take back whatever the command changed — and it has to do that
+without a mount, without privilege, and without quietly altering a byte.
+
+**Why this is its own module rather than three lines in the backend.** Every
+failure here looks like something else. A workspace that did not arrive looks
+like a model that wrote to the wrong path. A read-back that produced nothing
+looks like a command that printed nothing. Bytes mangled in transit look like a
+model that produced a corrupt spreadsheet. Across 220 tasks each of those reads
+as a finding about the model, and none of them would be. So the carriage is
+written where it can be tested on its own, on a box that cannot boot a machine
+at all, using the same ``mke2fs`` and ``debugfs`` that will do the work in
+production.
+
+Three facts were measured with those tools rather than assumed, and each one
+changed the code:
+
+**``debugfs -R`` exits 0 when it fails.** A missing directory in the image, a
+destination that does not exist, and a superblock that is not one all produce
+the complaint on stderr and a returncode of zero. So the returncode is not
+evidence of anything, and the read-back is judged by what actually landed on the
+host. This is the same rule D1 reads boots by: *absent evidence is not a
+result*, and the reason it matters more here is that the failure is silent and
+the wrong conclusion is plausible.
+
+**``rdump`` is byte-exact and ``cat`` is not.** ``debugfs -R "cat …"`` comes
+back through a text pipe, which is fine for an exit status and destroys an
+``.xlsx``. The workspace comes back with ``rdump``, which writes the files
+directly and preserved a byte sequence containing NUL, ``0xff`` and ``0xfe``
+unchanged in the measurement.
+
+**Symlinks survive the round trip in both directions.** ``mke2fs -d`` copies a
+symlink into the image as a symlink rather than following it, and ``rdump``
+recreates one on the host — including an absolute one pointing at
+``/etc/passwd``. Inside the guest that is harmless: the root filesystem is
+read-only and it resolves to the guest's own file. On the *host* it is a link
+into the host that a later step might follow. D2's inherited workspace code
+opens everything with ``O_NOFOLLOW`` and would refuse it, but the carriage must
+not depend on the other end being careful — a deliverable collector, a report
+step or an operator's ``cp -r`` would all follow it. So a link that leaves the
+workspace is not carried, and is recorded as having been refused.
+
+What is deliberately not here: booting. This module stages a disk and reads one
+back. :func:`core.agentic_v2_first_boot.first_boot` is what runs in between, and
+it is the caller's to supply, exactly as it was for stage C's attacks.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+from core.agentic_v2_guest_image import build_ext4, sha256_file
+from core.agentic_v2_substrate import REQUIRED_MICROVM_POLICY
+
+
+SCRATCH_ON_DISK = "in"
+RESULTS_ON_DISK = "out"
+WORKSPACE_ON_DISK = "ws"
+"""The three directories on the work disk, and the guest's view of them.
+
+``GUEST_INIT`` mounts the disk at ``/work`` and runs ``/work/in/command.sh``, so
+these are ``/work/in``, ``/work/out`` and ``/work/ws`` in the machine. The last
+one is D1's :data:`~core.agentic_v2_exec_boot.WORKSPACE_IN_GUEST`, which is why
+it is spelled here rather than derived: the two have to agree, and a test says
+so out loud instead of leaving it to whoever edits one of them next.
+"""
+
+COMMAND_ON_DISK = f"{SCRATCH_ON_DISK}/command.sh"
+
+BYTES_A_QUOTA_ACTUALLY_HOLDS = 234_557_440
+"""How much content fits in the policy's 256 MiB disk, measured rather than guessed.
+
+``mke2fs -q -F -t ext4 -b 4096`` on a 256 MiB image leaves 57,265 free 4 KiB
+blocks — the rest goes to the journal, the inode tables and the reserved block
+count. Sizing a refusal off the nominal 268,435,456 would let a workspace 32 MiB
+too large through, and it would fail during ``mke2fs`` with a message about
+blocks that reads like a broken toolchain rather than like a full disk.
+
+The arithmetic is still not trusted. :func:`stage_the_work_disk` checks what
+landed after building, because a formula that is right today is a formula that
+is wrong the first time a filesystem option changes.
+"""
+
+INODES_A_QUOTA_ACTUALLY_HOLDS = 65_522
+"""And how many files, which is the limit a directory of small outputs hits first."""
+
+_QUOTA_MIB = int(REQUIRED_MICROVM_POLICY["workdir_quota_mib"])
+
+
+class WorkDiskRefused(RuntimeError):
+    """The workspace cannot be carried, so no disk was built and nothing booted.
+
+    Distinct from a command that failed and from a machine that would not start.
+    This is the host declining before either could happen, which is the cheapest
+    place to decline and the only place where the reason is still legible.
+    """
+
+
+def _walk(root: Path) -> Iterable[tuple[Path, os.stat_result]]:
+    for current, directories, files in os.walk(root, followlinks=False):
+        here = Path(current)
+        for name in list(directories) + files:
+            path = here / name
+            yield path, path.lstat()
+
+
+def _leaves_the_tree(link: Path, root: Path) -> bool:
+    """Whether a symlink points anywhere but inside ``root``.
+
+    Resolved without touching the filesystem — ``os.path.realpath`` would follow
+    the link, and following a link that points at something slow, absent or
+    privileged is the thing being avoided. An absolute target is out by
+    definition; a relative one is joined to the link's own directory and
+    normalised.
+    """
+    target = os.readlink(link)
+    if os.path.isabs(target):
+        return True
+    landing = os.path.normpath(os.path.join(link.parent, target))
+    return not (landing == str(root) or landing.startswith(f"{root}{os.sep}"))
+
+
+def what_would_be_carried_in(
+    workspace: str | Path, *, quota_mib: int = _QUOTA_MIB
+) -> dict[str, Any]:
+    """Measure a host workspace against the disk it has to fit on.
+
+    Returns a description and raises nothing; :func:`stage_the_work_disk` is
+    what refuses. Separated so the measurement can be taken — and reported —
+    without committing to building anything, which is what a caller sizing a
+    task wants.
+    """
+    root = Path(workspace).resolve()
+    files = 0
+    directories = 0
+    links_out: list[str] = []
+    total = 0
+    for path, stats in _walk(root):
+        if os.path.islink(path):
+            files += 1
+            if _leaves_the_tree(path, root):
+                links_out.append(path.relative_to(root).as_posix())
+            continue
+        if os.path.isdir(path):
+            directories += 1
+            continue
+        files += 1
+        total += stats.st_size
+    room = min(BYTES_A_QUOTA_ACTUALLY_HOLDS, quota_mib * 1024 * 1024)
+    return {
+        "workspace": root.as_posix(),
+        "files": files,
+        "directories": directories,
+        "bytes": total,
+        "room_bytes": room,
+        "fits": total <= room,
+        "inode_room": INODES_A_QUOTA_ACTUALLY_HOLDS,
+        "entries": files + directories,
+        "symlinks_leaving_the_workspace": sorted(links_out),
+    }
+
+
+def stage_the_work_disk(
+    *,
+    workspace: str | Path,
+    command_sh: str,
+    into: str | Path,
+    quota_mib: int = _QUOTA_MIB,
+    build: Callable[..., Mapping[str, Any]] = build_ext4,
+) -> dict[str, Any]:
+    """Build one call's work disk: the command, an empty result tray, the workspace.
+
+    The workspace is *copied* rather than moved. If the boot goes wrong, the
+    host still holds what the session had before it, and a call that failed
+    leaves the model exactly where it was rather than one directory poorer.
+
+    Refuses before building when the workspace cannot fit or holds a link out of
+    itself. Both are cheap to see here and expensive to see later: the first
+    fails inside ``mke2fs`` with a message about blocks, and the second puts a
+    path into the guest that means something different on each side of the wall.
+    """
+    measured = what_would_be_carried_in(workspace, quota_mib=quota_mib)
+    if measured["symlinks_leaving_the_workspace"]:
+        raise WorkDiskRefused(
+            "the workspace holds symbolic links pointing out of itself — "
+            f"{measured['symlinks_leaving_the_workspace']} — and a link means a "
+            "different thing on each side of the wall, so none of it is carried"
+        )
+    payload = len(command_sh.encode("utf-8"))
+    if measured["bytes"] + payload > measured["room_bytes"]:
+        raise WorkDiskRefused(
+            f"the workspace is {measured['bytes']} bytes and the command is "
+            f"{payload}, against {measured['room_bytes']} a "
+            f"{quota_mib} MiB disk actually holds. Building it would fail inside "
+            "mke2fs with a message about blocks, which is not the reason"
+        )
+    if measured["entries"] >= measured["inode_room"]:
+        raise WorkDiskRefused(
+            f"the workspace has {measured['entries']} entries against "
+            f"{measured['inode_room']} inodes on the disk"
+        )
+
+    into = Path(into)
+    staging = into / "staging"
+    if staging.exists():
+        shutil.rmtree(staging)
+    (staging / SCRATCH_ON_DISK).mkdir(parents=True)
+    (staging / RESULTS_ON_DISK).mkdir(parents=True)
+    # symlinks=True keeps a link a link. Following one would copy whatever it
+    # points at into the guest, and the links that could do harm were refused
+    # above -- this is about the ones that are ordinary and should survive.
+    shutil.copytree(
+        Path(workspace), staging / WORKSPACE_ON_DISK, symlinks=True, dirs_exist_ok=True
+    )
+    (staging / COMMAND_ON_DISK).write_text(command_sh, encoding="utf-8")
+
+    image = into / "work.ext4"
+    built = build(image, size_mib=quota_mib, populate_from=staging)
+
+    landed = _what_the_image_holds(image)
+    if landed.get("command_bytes") != payload:
+        raise WorkDiskRefused(
+            "the command did not land on the disk at the size it was written — "
+            f"{landed.get('command_bytes')!r} against {payload}. The disk was "
+            "built and is not usable, and booting it would run something else"
+        )
+    return {
+        "image": image.as_posix(),
+        "sha256": built.get("sha256"),
+        "size_mib": quota_mib,
+        "carried": measured,
+        "staging": staging.as_posix(),
+        "checked": landed,
+    }
+
+
+def _what_the_image_holds(
+    image: str | Path, *, run: Callable[[Sequence[str]], Any] | None = None
+) -> dict[str, Any]:
+    """Read back the one fact that says the staging worked: the command's size.
+
+    ``mke2fs -d`` reports a full disk on stderr and can still produce an image,
+    so the arithmetic above is checked against the filesystem rather than
+    believed. One ``stat`` is enough — if the command is whole, the disk was not
+    truncated under it.
+    """
+    runner = run or _debugfs_runner
+    result = runner(["debugfs", "-R", f"stat {COMMAND_ON_DISK}", Path(image).as_posix()])
+    text = getattr(result, "stdout", "") or ""
+    size: int | None = None
+    for line in text.splitlines():
+        # The size sits on the ownership line -- "User: 1026 Group: 100
+        # Project: 0 Size: 18". Anchoring on "User:" rather than on "Size:"
+        # alone matters: two lines below it there is a "Fragment: Address: 0
+        # Number: 0 Size: 0", and reading that one would report every command
+        # as empty.
+        if "User:" not in line or "Size:" not in line:
+            continue
+        try:
+            size = int(line.split("Size:")[1].split()[0])
+        except (IndexError, ValueError):
+            size = None
+    return {"command_bytes": size, "said": (getattr(result, "stderr", "") or "").strip()}
+
+
+def _debugfs_runner(command: Sequence[str]) -> Any:
+    return subprocess.run(  # noqa: S603
+        list(command), check=False, capture_output=True, text=True, timeout=300
+    )
+
+
+def rdump_arguments(
+    image: str | Path, *, inside: str, destination: str | Path
+) -> list[str]:
+    """The ``debugfs`` call that takes a whole directory out of an image.
+
+    Built where a test can read it, for the same reason
+    :func:`core.agentic_v2_guest_image.ext4_image_arguments` is: these arguments
+    decide whether the host mounts a filesystem the guest was writing, and that
+    decision should be visible without running anything. ``rdump`` walks the
+    structures in userspace — no loop device, no privilege, and the host
+    kernel's ext4 driver never sees the image.
+    """
+    return [
+        "debugfs",
+        "-R",
+        f"rdump {inside} {Path(destination).as_posix()}",
+        Path(image).as_posix(),
+    ]
+
+
+def workspace_out_of_work_disk(
+    *,
+    image: str | Path,
+    into: str | Path,
+    run: Callable[[Sequence[str]], Any] | None = None,
+) -> dict[str, Any]:
+    """Take the workspace off a work disk, and say what came back.
+
+    The returncode is ignored on purpose: ``debugfs -R`` exits 0 whether it
+    dumped a tree, could not find one, could not write one, or could not read
+    the superblock. What is trusted instead is the directory on the host
+    afterwards — it either exists with something in it or it does not, and
+    ``read_back`` is that answer rather than the tool's.
+
+    Links pointing out of the workspace are **not** carried. They are deleted
+    from what landed and named in ``refused_symlinks``, because a guest can
+    create one and the host is where it would mean something.
+    """
+    runner = run or _debugfs_runner
+    into = Path(into)
+    into.mkdir(parents=True, exist_ok=True)
+    result = runner(rdump_arguments(image, inside=f"/{WORKSPACE_ON_DISK}", destination=into))
+    said = (getattr(result, "stderr", "") or "").strip()
+
+    landed = into / WORKSPACE_ON_DISK
+    if not landed.is_dir():
+        return {
+            "read_back": False,
+            "root": None,
+            "files": 0,
+            "bytes": 0,
+            "refused_symlinks": [],
+            "said": said,
+            "grounds": (
+                "debugfs left no /ws directory on the host, so nothing came back "
+                "off the disk. That is not the same as a command that wrote "
+                "nothing, and it is never reported as one"
+            ),
+        }
+
+    refused: list[str] = []
+    files = 0
+    total = 0
+    for path, stats in list(_walk(landed)):
+        if os.path.islink(path):
+            if _leaves_the_tree(path, landed):
+                refused.append(path.relative_to(landed).as_posix())
+                path.unlink()
+            else:
+                files += 1
+            continue
+        if path.is_dir():
+            continue
+        files += 1
+        total += stats.st_size
+    return {
+        "read_back": True,
+        "root": landed.as_posix(),
+        "files": files,
+        "bytes": total,
+        "refused_symlinks": sorted(refused),
+        "said": said,
+        "grounds": f"{files} files came back off the disk",
+    }
+
+
+def carry_the_workspace_back(
+    *,
+    image: str | Path,
+    workspace: str | Path,
+    scratch: str | Path,
+    run: Callable[[Sequence[str]], Any] | None = None,
+) -> dict[str, Any]:
+    """Replace the host workspace with what the machine left on the disk.
+
+    **Only if something came back.** A read-back that produced nothing leaves
+    the host workspace exactly as it was: the alternative is deleting a
+    session's accumulated work because *this* call's carriage broke, which
+    converts an infrastructure fault into the permanent loss of a model's
+    output. The result says which happened, and the caller reports it as an
+    infrastructure failure rather than as an empty answer.
+
+    The replacement is a rename, so there is no window in which the workspace is
+    half of each. The old one is removed after the new one is in place.
+    """
+    read = workspace_out_of_work_disk(image=image, into=scratch, run=run)
+    workspace = Path(workspace)
+    if not read["read_back"]:
+        return {**read, "replaced": False}
+
+    previous = workspace.with_name(workspace.name + ".previous")
+    if previous.exists():
+        shutil.rmtree(previous)
+    workspace.rename(previous)
+    Path(read["root"]).rename(workspace)
+    shutil.rmtree(previous, ignore_errors=True)
+    return {**read, "replaced": True}
+
+
+def work_disk_fingerprint(image: str | Path) -> str | None:
+    """The disk as it stands, for a record that has to distinguish two calls."""
+    path = Path(image)
+    return sha256_file(path) if path.exists() else None

--- a/batch-runner/core/agentic_v2_work_disk.py
+++ b/batch-runner/core/agentic_v2_work_disk.py
@@ -16,7 +16,7 @@ written where it can be tested on its own, on a box that cannot boot a machine
 at all, using the same ``mke2fs`` and ``debugfs`` that will do the work in
 production.
 
-Three facts were measured with those tools rather than assumed, and each one
+Four facts were measured with those tools rather than assumed, and each one
 changed the code:
 
 **``debugfs -R`` exits 0 when it fails.** A missing directory in the image, a
@@ -43,6 +43,16 @@ opens everything with ``O_NOFOLLOW`` and would refuse it, but the carriage must
 not depend on the other end being careful — a deliverable collector, a report
 step or an operator's ``cp -r`` would all follow it. So a link that leaves the
 workspace is not carried, and is recorded as having been refused.
+
+**A renamed workspace is a broken workspace.** The obvious way to install what
+came back is to rename the old directory aside and the new one into its place,
+which is atomic. It also destroys the session: the backend holding the workspace
+pins ``(st_dev, st_ino)`` at construction and keeps the descriptor, so after a
+rename its own re-check refuses and a write through that descriptor raises
+``FileNotFoundError``. Measured here, not reasoned about. The children are moved
+instead and the directory keeps its identity; :func:`carry_the_workspace_back`
+says what that costs. The failure this avoids would have appeared on the second
+``exec_run`` of a session, after the first looked fine.
 
 What is deliberately not here: booting. This module stages a disk and reads one
 back. :func:`core.agentic_v2_first_boot.first_boot` is what runs in between, and
@@ -370,7 +380,7 @@ def carry_the_workspace_back(
     scratch: str | Path,
     run: Callable[[Sequence[str]], Any] | None = None,
 ) -> dict[str, Any]:
-    """Replace the host workspace with what the machine left on the disk.
+    """Replace the *contents* of the host workspace with what the disk holds.
 
     **Only if something came back.** A read-back that produced nothing leaves
     the host workspace exactly as it was: the alternative is deleting a
@@ -379,20 +389,51 @@ def carry_the_workspace_back(
     output. The result says which happened, and the caller reports it as an
     infrastructure failure rather than as an empty answer.
 
-    The replacement is a rename, so there is no window in which the workspace is
-    half of each. The old one is removed after the new one is in place.
+    **The directory itself is never replaced, and that is not a style choice.**
+    The obvious implementation renames the old workspace aside and renames the
+    new one into its place, which is atomic and would be better in every way
+    except the one that matters: the object holding this workspace opens it once
+    and keeps the descriptor. ``AgenticV2FixtureBackend.__init__`` pins
+    ``(st_dev, st_ino)`` and re-checks it before later work. Measured on this
+    box, a rename-swap leaves that descriptor pointing at the renamed-away
+    directory, so the backend's re-check refuses and a write through the pinned
+    descriptor raises ``FileNotFoundError`` once the old directory is removed.
+    The failure would arrive on the *second* ``exec_run`` of a session, after
+    the first had already looked like it worked.
+
+    So the children are moved instead and the directory stays the one it was.
+    The cost is a window in which the workspace holds neither set whole; it is
+    inside one synchronous call with no other reader, and it is a far smaller
+    thing than losing the inode. If the move in fails partway, what was moved
+    aside is put back, so a half-carriage does not become an empty workspace.
+
+    ``shutil.move`` rather than ``rename`` because the read-back lands in the
+    caller's scratch and the workspace need not be on the same filesystem.
     """
     read = workspace_out_of_work_disk(image=image, into=scratch, run=run)
     workspace = Path(workspace)
     if not read["read_back"]:
         return {**read, "replaced": False}
 
-    previous = workspace.with_name(workspace.name + ".previous")
-    if previous.exists():
-        shutil.rmtree(previous)
-    workspace.rename(previous)
-    Path(read["root"]).rename(workspace)
-    shutil.rmtree(previous, ignore_errors=True)
+    landed = Path(read["root"])
+    held = Path(scratch) / "previous"
+    if held.exists():
+        shutil.rmtree(held)
+    held.mkdir(parents=True)
+
+    moved_aside = []
+    for child in sorted(workspace.iterdir()):
+        shutil.move(str(child), str(held / child.name))
+        moved_aside.append(child.name)
+    try:
+        for child in sorted(landed.iterdir()):
+            shutil.move(str(child), str(workspace / child.name))
+    except OSError:
+        for name in moved_aside:
+            if not (workspace / name).exists():
+                shutil.move(str(held / name), str(workspace / name))
+        raise
+    shutil.rmtree(held, ignore_errors=True)
     return {**read, "replaced": True}
 
 

--- a/batch-runner/tests/test_agentic_v2_one_call_machine.py
+++ b/batch-runner/tests/test_agentic_v2_one_call_machine.py
@@ -1,0 +1,293 @@
+"""One call, one machine — everything about it except the machine.
+
+The boot is injected, exactly as stage C injected it: this box runs kernel 3.10
+and cannot start a microVM. What is real here is the rest, and the rest is what
+would otherwise be discovered expensively on a booted host — that the plan a
+call builds is the policy with one bound tightened and nothing else moved, that
+the workspace is on the disk the boot is handed, that what the guest wrote gets
+back to the host, and that a command whose files did not survive the trip is not
+reported to the model as a command that succeeded.
+
+The stand-in boot writes a *real ext4 image* where ``first_boot`` would leave
+one, so the read-back is exercised rather than simulated.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from core.agentic_v2_exec_boot import read_the_boot
+from core.agentic_v2_one_call_machine import (
+    THE_ONE_RULE_A_CALL_MAY_TIGHTEN,
+    WORKSPACE_DID_NOT_COME_BACK,
+    MachineRefused,
+    OneCallMachine,
+    policy_for_this_call,
+)
+from core.agentic_v2_substrate import REQUIRED_MICROVM_POLICY
+from core.agentic_v2_work_disk import SCRATCH_ON_DISK, WORKSPACE_ON_DISK
+
+
+needs_ext4_tools = pytest.mark.skipif(
+    shutil.which("mke2fs") is None or shutil.which("debugfs") is None,
+    reason="e2fsprogs is what builds and reads the work disk",
+)
+
+A_COMMAND = "#!/bin/sh\ncd /work/ws/job\necho ran\n"
+
+
+class Guest:
+    """A stand-in for a booted machine, which really writes a work disk back.
+
+    ``first_boot`` copies the disk out of the jail to ``<work_disk>.returned``
+    before destroying the chroot, so that is where this leaves one too. What it
+    puts on it is whatever the test asked for, which is how "the guest wrote a
+    file" is expressed without a guest.
+    """
+
+    def __init__(self, *, wrote=None, status=0, outcome="booted", returns_a_disk=True):
+        self.wrote = wrote or {}
+        self.status = status
+        self.outcome = outcome
+        self.returns_a_disk = returns_a_disk
+        self.plans: list[dict] = []
+        self.disks: list[str] = []
+
+    def __call__(self, plan, *, jailer_binary, kernel, rootfs, work_disk, uid, gid):
+        self.plans.append(dict(plan))
+        self.disks.append(str(work_disk))
+        if self.returns_a_disk:
+            self._leave_a_disk(Path(str(work_disk) + ".returned"))
+        return {
+            "outcome": self.outcome,
+            "command_exit_status": self.status,
+            "results": {"/out/stdout": "ran\n", "/out/stderr": ""},
+            "teardown": {"all_gone": True},
+            "vm_id": plan["vm_id"],
+        }
+
+    def _leave_a_disk(self, at: Path) -> None:
+        staging = at.parent / f"{at.name}-staging"
+        (staging / WORKSPACE_ON_DISK / "job").mkdir(parents=True, exist_ok=True)
+        (staging / SCRATCH_ON_DISK).mkdir(parents=True, exist_ok=True)
+        for name, text in self.wrote.items():
+            target = staging / WORKSPACE_ON_DISK / name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(text, encoding="utf-8")
+        subprocess.run(
+            [
+                "mke2fs", "-q", "-F", "-t", "ext4", "-b", "4096",
+                "-d", staging.as_posix(), at.as_posix(), "4096",
+            ],
+            check=True,
+            capture_output=True,
+        )
+
+
+def _workspace(root: Path) -> Path:
+    work = root / "session" / "ws"
+    (work / "job").mkdir(parents=True)
+    (work / "job" / "started_with.txt").write_text("turn one\n", encoding="utf-8")
+    return work
+
+
+def _machine(tmp_path, guest) -> OneCallMachine:
+    # The kernel and rootfs are real files with real bytes because
+    # build_launch_plan reads and hashes both, and refuses a plan whose images
+    # are not there. Stand-ins for the images, not for the check.
+    images = tmp_path / "images"
+    images.mkdir(exist_ok=True)
+    (images / "vmlinux").write_bytes(b"not a kernel, but a file that is here\n")
+    (images / "rootfs.ext4").write_bytes(b"not a rootfs, but a file that is here\n")
+    return OneCallMachine(
+        kernel=images / "vmlinux",
+        rootfs=images / "rootfs.ext4",
+        firecracker_binary=images / "firecracker",
+        uid=1200,
+        gid=1200,
+        vcpu_count=2,
+        cgroup_version=2,
+        scratch=tmp_path / "scratch",
+        session="task-abc",
+        boot=guest,
+    )
+
+
+class TestOneBoundMovesAndTheRestDoNot:
+    def test_exactly_one_rule_differs_from_the_policy(self):
+        tightened = policy_for_this_call(60)
+        differs = [
+            name
+            for name in REQUIRED_MICROVM_POLICY
+            if tightened[name] != REQUIRED_MICROVM_POLICY[name]
+        ]
+        assert differs == [THE_ONE_RULE_A_CALL_MAY_TIGHTEN]
+
+    def test_it_is_a_whole_policy_and_not_a_patch(self):
+        # build_launch_plan refuses a policy missing a rule or holding an extra
+        # one, which is what makes "nothing else moved" checkable.
+        assert set(policy_for_this_call(60)) == set(REQUIRED_MICROVM_POLICY)
+
+    def test_a_call_cannot_ask_for_longer_than_the_policy_allows(self):
+        allowed = int(REQUIRED_MICROVM_POLICY[THE_ONE_RULE_A_CALL_MAY_TIGHTEN])
+        with pytest.raises(MachineRefused) as refusal:
+            policy_for_this_call(allowed + 1)
+        assert "may not loosen" in str(refusal.value)
+
+    @pytest.mark.parametrize("bad", [0, -5, None, True, 12.5, "60"])
+    def test_a_deadline_that_is_not_a_bound_is_refused(self, bad):
+        with pytest.raises(MachineRefused):
+            policy_for_this_call(bad)
+
+
+@needs_ext4_tools
+class TestWhatOneCallHandsToTheBoot:
+    def test_the_tightened_deadline_reaches_the_plan_the_boot_runs(self, tmp_path):
+        guest = Guest()
+        _machine(tmp_path, guest)(
+            command_sh=A_COMMAND, workspace=_workspace(tmp_path), deadline_seconds=45
+        )
+        assert guest.plans[0]["host_side"]["deadline_seconds"] == 45
+
+    def test_the_workspace_is_on_the_disk_the_boot_is_given(self, tmp_path):
+        guest = Guest()
+        _machine(tmp_path, guest)(
+            command_sh=A_COMMAND, workspace=_workspace(tmp_path), deadline_seconds=45
+        )
+        listed = subprocess.run(
+            ["debugfs", "-R", f"ls /{WORKSPACE_ON_DISK}/job", guest.disks[0]],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert "started_with.txt" in listed.stdout
+
+    def test_the_command_is_on_the_disk_where_the_guest_init_looks(self, tmp_path):
+        guest = Guest()
+        _machine(tmp_path, guest)(
+            command_sh=A_COMMAND, workspace=_workspace(tmp_path), deadline_seconds=45
+        )
+        read = subprocess.run(
+            ["debugfs", "-R", f"cat {SCRATCH_ON_DISK}/command.sh", guest.disks[0]],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert "cd /work/ws/job" in read.stdout
+
+    def test_two_calls_are_two_machines_with_different_names(self, tmp_path):
+        guest = Guest()
+        machine = _machine(tmp_path, guest)
+        workspace = _workspace(tmp_path)
+        machine(command_sh=A_COMMAND, workspace=workspace, deadline_seconds=45)
+        machine(command_sh=A_COMMAND, workspace=workspace, deadline_seconds=45)
+        names = [plan["vm_id"] for plan in guest.plans]
+        assert names == ["task-abc-0000", "task-abc-0001"]
+
+    def test_the_name_is_one_the_jailer_would_accept(self, tmp_path):
+        machine = _machine(tmp_path, Guest())
+        machine.session = "task/with bad..chars"
+        name = machine.name_the_machine()
+        assert len(name) <= 64 and name.isascii() and name[0].isalnum()
+        assert all(part.isalnum() for part in name.split("-") if part)
+
+
+@needs_ext4_tools
+class TestWhatTheGuestWroteReachesTheHost:
+    def test_a_file_the_guest_made_is_in_the_workspace_afterwards(self, tmp_path):
+        workspace = _workspace(tmp_path)
+        guest = Guest(wrote={"job/made_by_the_guest.txt": "from inside\n"})
+        booted = _machine(tmp_path, guest)(
+            command_sh=A_COMMAND, workspace=workspace, deadline_seconds=45
+        )
+        assert booted["workspace_carriage"]["replaced"] is True
+        assert (workspace / "job" / "made_by_the_guest.txt").read_text() == "from inside\n"
+
+    def test_the_workspace_is_what_came_back_and_not_what_went_in(self, tmp_path):
+        # The guest's disk does not carry started_with.txt, so a workspace that
+        # still has it was never replaced -- it was merged, which would let a
+        # deleted file come back from the dead every call.
+        workspace = _workspace(tmp_path)
+        guest = Guest(wrote={"job/only_this.txt": "replaced\n"})
+        _machine(tmp_path, guest)(
+            command_sh=A_COMMAND, workspace=workspace, deadline_seconds=45
+        )
+        assert (workspace / "job" / "only_this.txt").exists()
+        assert not (workspace / "job" / "started_with.txt").exists()
+
+    def test_the_record_holds_one_row_per_call_with_what_it_carried(self, tmp_path):
+        workspace = _workspace(tmp_path)
+        machine = _machine(tmp_path, Guest(wrote={"job/a.txt": "a\n"}))
+        machine(command_sh=A_COMMAND, workspace=workspace, deadline_seconds=45)
+        machine(command_sh=A_COMMAND, workspace=workspace, deadline_seconds=45)
+        assert [row["call"] for row in machine.record] == [0, 1]
+        assert machine.record[0]["deadline_seconds"] == 45
+        assert machine.record[0]["carriage"]["replaced"] is True
+
+
+@needs_ext4_tools
+class TestACommandWhoseFilesDidNotSurviveIsNotASuccess:
+    def _call_with_no_disk_coming_back(self, tmp_path):
+        workspace = _workspace(tmp_path)
+        guest = Guest(status=0, returns_a_disk=False)
+        booted = _machine(tmp_path, guest)(
+            command_sh=A_COMMAND, workspace=workspace, deadline_seconds=45
+        )
+        return workspace, booted
+
+    def test_the_returncode_is_withheld_rather_than_handed_over(self, tmp_path):
+        _workspace_, booted = self._call_with_no_disk_coming_back(tmp_path)
+        assert booted["command_exit_status"] is None
+        assert booted["outcome"] == WORKSPACE_DID_NOT_COME_BACK
+
+    def test_the_status_the_guest_really_wrote_is_kept_not_discarded(self, tmp_path):
+        _workspace_, booted = self._call_with_no_disk_coming_back(tmp_path)
+        assert booted["command_exit_status_before_the_carriage_failed"] == 0
+
+    def test_the_model_is_told_the_backend_failed(self, tmp_path):
+        # Read through D1, because what the model sees is read_the_boot's answer
+        # and not this dictionary.
+        _workspace_, booted = self._call_with_no_disk_coming_back(tmp_path)
+        result = read_the_boot(booted, deadline={"applied_seconds": 45})["result"]
+        assert result["ok"] is False
+        assert result["error_type"] == "compute_backend_error"
+
+    def test_the_session_keeps_the_files_it_already_had(self, tmp_path):
+        # The failure this exists for: losing a session's accumulated work
+        # because one call's carriage broke.
+        workspace, _booted = self._call_with_no_disk_coming_back(tmp_path)
+        assert (workspace / "job" / "started_with.txt").read_text() == "turn one\n"
+
+    def test_a_machine_that_never_started_keeps_its_own_outcome(self, tmp_path):
+        # No exit status, so there is nothing for the carriage to override, and
+        # calling this a carriage fault would hide a launcher fault.
+        guest = Guest(status=None, outcome="never_started", returns_a_disk=False)
+        booted = _machine(tmp_path, guest)(
+            command_sh=A_COMMAND, workspace=_workspace(tmp_path), deadline_seconds=45
+        )
+        assert booted["outcome"] == "never_started"
+        result = read_the_boot(booted, deadline={"applied_seconds": 45})["result"]
+        assert result["error_type"] == "compute_start_failed"
+
+
+@needs_ext4_tools
+class TestTheRecordSaysWhatWasBootedAndWhatWasLeft:
+    def test_both_disks_are_fingerprinted(self, tmp_path):
+        booted = _machine(tmp_path, Guest(wrote={"job/a.txt": "a\n"}))(
+            command_sh=A_COMMAND, workspace=_workspace(tmp_path), deadline_seconds=45
+        )
+        disks = booted["work_disk"]
+        assert len(disks["staged_sha256"]) == 64
+        assert len(disks["returned_sha256"]) == 64
+        assert disks["staged_sha256"] != disks["returned_sha256"]
+
+    def test_the_teardown_the_boot_reported_is_carried_into_the_record(self, tmp_path):
+        machine = _machine(tmp_path, Guest(wrote={"job/a.txt": "a\n"}))
+        machine(
+            command_sh=A_COMMAND, workspace=_workspace(tmp_path), deadline_seconds=45
+        )
+        assert machine.record[0]["teardown"] == {"all_gone": True}

--- a/batch-runner/tests/test_agentic_v2_stage_d_probe.py
+++ b/batch-runner/tests/test_agentic_v2_stage_d_probe.py
@@ -1,0 +1,601 @@
+"""Stage D's paid probe, run end to end without paying for it and without a boot.
+
+Stage A's probe could be proved free because the only real thing under it was a
+backend that writes bytes. Stage D has a second real thing under it — a machine
+— and this box cannot start one. So the boot is injected, exactly as it is in
+:mod:`tests.test_agentic_v2_stage_d_session`, and *everything else runs*: the
+real dispatcher, the real microVM backend, the real work disk built with
+``mke2fs``, the real carriage, read back with ``debugfs``.
+
+That leaves one test in this file doing something no other test in the tree
+does, and it is the one the whole stage is for:
+
+    a model asks to run a command → a work disk is built from the session's
+    workspace → the injected guest writes a file onto it → the disk comes back →
+    the carriage installs it → and the *next* model turn reads that file through
+    ``workspace_apply`` and gets its contents.
+
+Five modules and a filesystem, in one sequence, with only the network and the
+hypervisor standing in. If that passes, what a paid run adds is the model's own
+judgement and a real kernel — not any of the wiring.
+
+The tool list is checked here too, for stage A's reason and one more: this probe
+offers a tool that *boots*, so a list that has drifted does not merely waste a
+turn, it spends a machine.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.agentic_v2_microvm_backend import GuestImage  # noqa: E402
+from core.agentic_v2_one_call_machine import OneCallMachine  # noqa: E402
+from core.agentic_v2_stage_a_probe import (  # noqa: E402
+    PROBE_TOOLS as STAGE_A_TOOLS,
+)
+from core.agentic_v2_stage_d_probe import (  # noqa: E402
+    PROBE_INSTRUCTIONS,
+    PROBE_TOOLS,
+    TOOLS_THIS_BACKEND_REFUSES,
+    TURNS_STAGE_D_NEEDS,
+    ProbeCannotDescribeItself,
+    ProbeToolsAreWrong,
+    StageDProbeOutcome,
+    check_probe_tools,
+    run_stage_d_probe,
+)
+from core.agentic_v2_stage_one_budget import StageOneBudget  # noqa: E402
+from core.agentic_v2_substrate import AgenticV2SubstrateManifest  # noqa: E402
+from core.agentic_v2_work_disk import (  # noqa: E402
+    SCRATCH_ON_DISK,
+    WORKSPACE_ON_DISK,
+    workspace_out_of_work_disk,
+)
+from core.execution_envelope_cost import ModelPrice  # noqa: E402
+
+
+needs_ext4_tools = pytest.mark.skipif(
+    shutil.which("mke2fs") is None or shutil.which("debugfs") is None,
+    reason="e2fsprogs is what builds and reads the work disk",
+)
+
+MODEL = "gpt-5.4"
+
+AN_IMAGE = GuestImage(
+    reference="ghcr.io/hyeonsangjeon/gdpval-sandbox",
+    digest="sha256:ee6ef798631d3c3aeaed28658c640e6f5d021677449852bf2e1f18be5bd24edb",
+    kernel_sha256="a" * 64,
+    rootfs_sha256="b" * 64,
+)
+
+
+# ── stand-ins: one for the network, one for the hypervisor ────────────────
+
+
+class FakeResponses:
+    def __init__(self, answers):
+        self.answers = list(answers)
+        self.calls: list[dict] = []
+
+    def create(self, **payload):
+        self.calls.append(payload)
+        if not self.answers:
+            raise AssertionError("the probe asked more times than it was told to")
+        answer = self.answers.pop(0)
+        if isinstance(answer, Exception):
+            raise answer
+        return answer
+
+
+class FakeClient:
+    def __init__(self, answers):
+        self.responses = FakeResponses(answers)
+
+
+class AGuestThatReallyWritesADisk:
+    """The injected boot: reads the staged disk, changes it, leaves a new one.
+
+    The same stand-in the joint session tests use, for the same reason — it is
+    the only thing here that is not the production object, and it does exactly
+    what a booted machine does to the work disk and nothing else.
+    """
+
+    def __init__(self, *, writes=None, status=0, outcome="booted", returns_a_disk=True):
+        self.writes = dict(writes or {})
+        self.status = status
+        self.outcome = outcome
+        self.returns_a_disk = returns_a_disk
+        self.commands: list[str] = []
+
+    def __call__(self, plan, *, jailer_binary, kernel, rootfs, work_disk, uid, gid):
+        staged = Path(work_disk)
+        self.commands.append(
+            subprocess.run(
+                ["debugfs", "-R", f"cat {SCRATCH_ON_DISK}/command.sh", staged.as_posix()],
+                capture_output=True,
+                text=True,
+                check=False,
+            ).stdout
+        )
+        if self.returns_a_disk:
+            self._rebuild(staged, Path(str(staged) + ".returned"))
+        return {
+            "outcome": self.outcome,
+            "command_exit_status": self.status,
+            "results": {"/out/stdout": "", "/out/stderr": ""},
+            "teardown": {"all_gone": True},
+        }
+
+    def _rebuild(self, staged: Path, rebuilt: Path) -> None:
+        scratch = staged.parent / "guest"
+        if scratch.exists():
+            shutil.rmtree(scratch)
+        read = workspace_out_of_work_disk(image=staged, into=scratch)
+        assert read["read_back"], read["said"]
+
+        tree = staged.parent / "guest-tree"
+        if tree.exists():
+            shutil.rmtree(tree)
+        (tree / SCRATCH_ON_DISK).mkdir(parents=True)
+        shutil.move(read["root"], str(tree / WORKSPACE_ON_DISK))
+        for relative, content in self.writes.items():
+            target = tree / WORKSPACE_ON_DISK / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+        subprocess.run(
+            [
+                "mke2fs", "-q", "-F", "-t", "ext4", "-b", "4096",
+                "-d", tree.as_posix(), rebuilt.as_posix(), "8192",
+            ],
+            check=True,
+            capture_output=True,
+        )
+
+
+def _machine(tmp_path, guest) -> OneCallMachine:
+    images = tmp_path / "images"
+    images.mkdir(exist_ok=True)
+    (images / "vmlinux").write_bytes(b"stands in for a kernel\n")
+    (images / "rootfs.ext4").write_bytes(b"stands in for a rootfs\n")
+    return OneCallMachine(
+        kernel=images / "vmlinux",
+        rootfs=images / "rootfs.ext4",
+        firecracker_binary=images / "firecracker",
+        uid=1200,
+        gid=1200,
+        vcpu_count=2,
+        cgroup_version=2,
+        scratch=tmp_path / "scratch",
+        session="gdpval-stage-d",
+        boot=guest,
+    )
+
+
+def _manifest() -> AgenticV2SubstrateManifest:
+    return AgenticV2SubstrateManifest.load(Path("sandbox/agentic_v2_capabilities.json"))
+
+
+def asks_for(name: str, arguments: dict, *, call_id: str = "call-1") -> dict:
+    return {
+        "model": MODEL,
+        "usage": {"input_tokens": 120, "output_tokens": 30},
+        "output_text": "",
+        "output": [
+            {
+                "type": "function_call",
+                "call_id": call_id,
+                "name": name,
+                "arguments": json.dumps(arguments),
+            }
+        ],
+    }
+
+
+def says_nothing_useful(text: str = "I have finished thinking") -> dict:
+    return {
+        "model": MODEL,
+        "usage": {"input_tokens": 140, "output_tokens": 12},
+        "output_text": text,
+        "output": [],
+    }
+
+
+def runs(argv, *, cwd=".", timeout_seconds=60, call_id="call-1") -> dict:
+    return asks_for(
+        "exec_run",
+        {"argv": list(argv), "cwd": cwd, "timeout_seconds": timeout_seconds},
+        call_id=call_id,
+    )
+
+
+def a_budget(**changes) -> StageOneBudget:
+    settings = {
+        "max_model_calls": 12,
+        "max_input_tokens": 300_000,
+        "max_output_tokens": 16_384,
+    }
+    settings.update(changes)
+    return StageOneBudget(**settings)
+
+
+def prices_for(model: str = MODEL) -> dict[str, ModelPrice]:
+    return {
+        model: ModelPrice(
+            model=model,
+            input_usd_per_million=Decimal("1.25"),
+            output_usd_per_million=Decimal("10"),
+        )
+    }
+
+
+def run_probe(answers, tmp_path, *, guest=None, **changes):
+    guest = guest if guest is not None else AGuestThatReallyWritesADisk()
+    settings = {
+        "client": FakeClient(answers),
+        "deployment": "gpt-5.4",
+        "resource": "a-foundry-resource",
+        "budget": a_budget(),
+        "task_prompt": "count the rows in the attached sheet and write the total",
+        "workspace_root": tmp_path / "probe",
+        "image": AN_IMAGE,
+        "boot_one_command": _machine(tmp_path, guest),
+        "substrate_manifest": _manifest(),
+        "max_output_tokens_per_turn": 2_048,
+        "max_seconds": 120.0,
+        "prices": prices_for(),
+    }
+    settings.update(changes)
+    return run_stage_d_probe(**settings)
+
+
+# ── the tool list, which here guards machines and not only turns ──────────
+
+
+def test_the_offered_tools_are_the_three_a_command_run_needs():
+    """Written down so widening the list is a change somebody has to make."""
+    assert PROBE_TOOLS == ("capabilities_query", "workspace_apply", "exec_run")
+
+
+def test_the_shipped_list_is_acceptable_to_the_check_that_guards_it():
+    assert check_probe_tools() == []
+
+
+def test_stage_d_is_stage_a_plus_the_one_tool_it_exists_to_test():
+    """The difference between the two stages is one tool, and it is exec_run."""
+    assert set(PROBE_TOOLS) - set(STAGE_A_TOOLS) == {"exec_run"}
+
+
+def test_a_list_without_exec_run_is_refused_because_that_is_the_question():
+    problems = check_probe_tools(("capabilities_query", "workspace_apply"))
+
+    assert len(problems) == 1
+    assert "exec_run" in problems[0]
+    assert "stage A again" in problems[0]
+
+
+def test_offering_finalize_is_refused_because_it_reaches_the_grader():
+    problems = check_probe_tools((*PROBE_TOOLS, "finalize"))
+
+    assert len(problems) == 1
+    assert "finalize" in problems[0]
+    assert "marking" in problems[0]
+
+
+@pytest.mark.parametrize("shut", TOOLS_THIS_BACKEND_REFUSES)
+def test_offering_a_tool_this_backend_always_refuses_is_refused(shut):
+    """A tool that can only answer no spends a paid turn to say so."""
+    problems = check_probe_tools((*PROBE_TOOLS, shut))
+
+    assert len(problems) == 1
+    assert shut in problems[0]
+
+
+def test_a_tool_the_contract_does_not_define_is_refused():
+    problems = check_probe_tools((*PROBE_TOOLS, "make_it_work"))
+
+    assert len(problems) == 1
+    assert "make_it_work" in problems[0]
+
+
+def test_a_wrong_list_stops_the_probe_before_it_spends_or_boots(tmp_path):
+    client = FakeClient([runs(["true"])])
+    guest = AGuestThatReallyWritesADisk()
+
+    with pytest.raises(ProbeToolsAreWrong, match="finalize"):
+        run_probe(
+            [], tmp_path, client=client, guest=guest, tools=(*PROBE_TOOLS, "finalize")
+        )
+
+    assert client.responses.calls == []
+    assert guest.commands == []
+
+
+def test_a_backend_that_cannot_say_what_it_is_stops_before_spending(tmp_path):
+    """A paid record naming an unverified image is worse than no record.
+
+    The numbers would be real and would refer to nothing anyone can check
+    afterwards, which is exactly the shape of evidence this whole stage exists
+    to avoid producing.
+    """
+    client = FakeClient([runs(["true"])])
+
+    with pytest.raises(ProbeCannotDescribeItself, match="substrate_manifest_missing"):
+        run_probe([], tmp_path, client=client, substrate_manifest=None)
+
+    assert client.responses.calls == []
+
+
+def test_the_turn_budget_is_sized_off_what_stage_a_measured(tmp_path):
+    """Stage A spent three of four turns asking what it was allowed to do.
+
+    A stage D run has more to do than that and the same habit to pay for, so a
+    four-turn limit would stop it mid-sequence — having spent the money and
+    answered nothing.
+    """
+    assert TURNS_STAGE_D_NEEDS > 4
+
+
+# ── the whole loop, with only the network and the hypervisor standing in ──
+
+
+@needs_ext4_tools
+def test_a_command_runs_and_the_next_turn_reads_the_file_it_wrote(tmp_path):
+    """The one sequence stage D exists to establish, start to finish.
+
+    Model asks to run a command; a disk is built from the workspace; the guest
+    writes onto it; the disk comes back; the carriage installs it; the turn
+    after that reads the file through a different tool; and the bytes reach the
+    model. Nothing here is mocked except the socket and the hypervisor.
+
+    The last leg is checked against what was *sent to the model*, not against
+    the turn record — the record keeps hashes and no bodies, which is the
+    property that makes these runs safe to store, and it means the record
+    cannot show that the contents arrived. The request can.
+    """
+    guest = AGuestThatReallyWritesADisk(writes={"total.txt": "1462 rows\n"})
+    client = FakeClient(
+        [
+            runs(["python3", "count.py"]),
+            asks_for(
+                "workspace_apply",
+                {"operation": "read", "path": "total.txt"},
+                call_id="call-2",
+            ),
+            says_nothing_useful(),
+        ]
+    )
+    outcome = run_probe([], tmp_path, client=client, guest=guest)
+
+    assert outcome.tools_asked_for == ("exec_run", "workspace_apply")
+    assert outcome.asked_to_run_something is True
+    assert outcome.a_command_really_ran is True
+    assert outcome.worked_on_after_running_something is True
+    assert outcome.carriage_failures == 0
+
+    # It came off the disk and onto the host, and was collected before the
+    # ephemeral workspace was purged -- which is the only reason it still
+    # exists to be read here.
+    assert outcome.collected["kept"] is True
+    kept = Path(outcome.collected["root"]) / "total.txt"
+    assert kept.read_text(encoding="utf-8") == "1462 rows\n"
+    # And out of the host into the model's own next request, which is the leg
+    # that makes this a loop rather than two things that both worked.
+    assert "1462 rows" in json.dumps(client.responses.calls[2]["input"])
+
+
+@needs_ext4_tools
+def test_the_files_survive_the_teardown_that_the_policy_requires(tmp_path):
+    """Both rules hold at once, and the order is what makes that possible.
+
+    ``workdir: ephemeral-quota`` means the next task must not inherit these
+    files, so the workspace is purged. The files are also the entire product of
+    the run. A probe that closed without collecting would leave a boot record
+    describing deliverables that no longer exist — which reads exactly like a
+    model that produced nothing.
+    """
+    outcome = run_probe(
+        [runs(["true"]), says_nothing_useful()],
+        tmp_path,
+        guest=AGuestThatReallyWritesADisk(writes={"report.md": "# done\n"}),
+    )
+
+    assert not (tmp_path / "probe" / "work").exists()
+    assert (Path(outcome.collected["root"]) / "report.md").read_text() == "# done\n"
+    assert outcome.collected["files"] >= 1
+
+
+@needs_ext4_tools
+def test_the_collection_can_be_sent_somewhere_the_caller_chose(tmp_path):
+    outcome = run_probe(
+        [runs(["true"]), says_nothing_useful()],
+        tmp_path,
+        guest=AGuestThatReallyWritesADisk(writes={"report.md": "# done\n"}),
+        collect_outputs_into=tmp_path / "deliverables",
+    )
+
+    assert outcome.collected["root"] == (tmp_path / "deliverables").as_posix()
+    assert (tmp_path / "deliverables" / "report.md").is_file()
+
+
+@needs_ext4_tools
+def test_the_command_the_model_asked_for_is_the_one_on_the_disk(tmp_path):
+    """A boot that ran something else would still look like a success."""
+    guest = AGuestThatReallyWritesADisk()
+    run_probe([runs(["echo", "hello"]), says_nothing_useful()], tmp_path, guest=guest)
+
+    assert "echo" in guest.commands[0]
+    assert "/work/ws" in guest.commands[0]
+
+
+@needs_ext4_tools
+def test_one_tool_call_is_one_machine(tmp_path):
+    machine = _machine(tmp_path, AGuestThatReallyWritesADisk())
+    outcome = run_probe(
+        [
+            runs(["true"], call_id="c1"),
+            runs(["true"], cwd=".", timeout_seconds=61, call_id="c2"),
+            says_nothing_useful(),
+        ],
+        tmp_path,
+        boot_one_command=machine,
+    )
+
+    assert [row["vm_id"] for row in outcome.machines] == [
+        "gdpval-stage-d-0000",
+        "gdpval-stage-d-0001",
+    ]
+    assert len(outcome.boots) == 2
+
+
+@needs_ext4_tools
+def test_a_carriage_that_broke_is_counted_and_not_read_as_an_empty_command(tmp_path):
+    """The failure mode that would otherwise read as a model producing nothing."""
+    guest = AGuestThatReallyWritesADisk(returns_a_disk=False)
+    outcome = run_probe(
+        [runs(["true"]), says_nothing_useful()], tmp_path, guest=guest
+    )
+
+    assert outcome.carriage_failures == 1
+    assert outcome.a_command_really_ran is False
+    assert outcome.boots[0]["result"]["error_type"] == "compute_backend_error"
+
+
+@needs_ext4_tools
+def test_a_run_that_booted_on_its_last_turn_has_not_closed_the_loop(tmp_path):
+    """Proving the machine is not the same as proving the model can build on it.
+
+    Reported as a finding rather than a failure: the command really ran, and
+    what is missing is the turn afterwards.
+    """
+    outcome = run_probe(
+        [runs(["true"]), says_nothing_useful()],
+        tmp_path,
+        guest=AGuestThatReallyWritesADisk(writes={"made.txt": "x\n"}),
+    )
+
+    assert outcome.a_command_really_ran is True
+    assert outcome.worked_on_after_running_something is False
+
+
+def test_a_model_that_never_reached_for_the_machine_is_a_finding_not_an_error(
+    tmp_path,
+):
+    """Stage D records what happened. "It did not use it" is an answer."""
+    guest = AGuestThatReallyWritesADisk()
+    outcome = run_probe(
+        [asks_for("capabilities_query", {"kind": "commands"}), says_nothing_useful()],
+        tmp_path,
+        guest=guest,
+    )
+
+    assert outcome.reached_a_model is True
+    assert outcome.asked_to_run_something is False
+    assert outcome.a_command_really_ran is False
+    assert outcome.worked_on_after_running_something is False
+    assert guest.commands == []
+
+
+def test_a_service_that_never_answered_is_not_reported_as_reached(tmp_path):
+    outcome = run_probe([RuntimeError("the route was refused")], tmp_path)
+
+    assert outcome.reached_a_model is False
+    assert outcome.resolved_model is None
+    assert outcome.turns_taken == 0
+    assert outcome.boots == ()
+
+
+# ── what is written down, and what is deliberately not ────────────────────
+
+
+def test_the_model_is_not_told_which_tool_to_call(tmp_path):
+    """Otherwise the probe proves models follow instructions, not that they choose."""
+    for name in PROBE_TOOLS:
+        assert name not in PROBE_INSTRUCTIONS
+
+    client = FakeClient([says_nothing_useful()])
+    run_probe([], tmp_path, client=client)
+
+    sent = client.responses.calls[0]
+    assert {tool["name"] for tool in sent["tools"]} == set(PROBE_TOOLS)
+
+
+@needs_ext4_tools
+def test_nothing_the_model_said_is_kept(tmp_path):
+    outcome = run_probe(
+        [
+            runs(["python3", "-c", "print('my private working out')"]),
+            says_nothing_useful("my private working out"),
+        ],
+        tmp_path,
+    )
+
+    written = json.dumps(outcome.as_dict()["model_calls"])
+    assert "private working out" not in written
+    for row in outcome.ledger:
+        assert set(row) == {
+            "turn",
+            "requested_deployment",
+            "resolved_model",
+            "input_tokens",
+            "output_tokens",
+            "history_entries_sent",
+            "price_usd",
+            "price_missing",
+        }
+
+
+@needs_ext4_tools
+def test_the_record_names_the_image_the_commands_actually_ran_in(tmp_path):
+    """A boot record with no image behind it cannot be checked afterwards."""
+    written = run_probe(
+        [runs(["true"]), says_nothing_useful()], tmp_path
+    ).as_dict()
+
+    assert written["guest_image"]["digest"] == AN_IMAGE.digest
+    assert len(written["substrate_manifest_sha256"]) == 64
+    assert json.loads(json.dumps(written))["a_command_really_ran"] is True
+
+
+def test_an_unpriced_call_makes_the_total_missing_rather_than_zero(tmp_path):
+    """Zero would make an unsettled bill look settled."""
+    outcome = run_probe([says_nothing_useful()], tmp_path, prices={})
+
+    assert outcome.spent_usd is None
+    assert outcome.price_missing is True
+    assert outcome.as_dict()["spent_usd"] is None
+
+
+def test_running_something_is_read_from_the_boots_not_from_the_tool_calls():
+    """A model that asked and was refused before launch has run nothing.
+
+    Kept apart on purpose: ``asked_to_run_something`` is about the model and
+    ``a_command_really_ran`` is about the machine, and a probe that conflated
+    them would report a refused argument list as a successful boot.
+    """
+    asked_but_refused = StageDProbeOutcome(
+        reached_a_model=True,
+        resolved_model=MODEL,
+        requested_deployment="gpt-5.4",
+        resource="a-foundry-resource",
+        tools_offered=PROBE_TOOLS,
+        tools_asked_for=("exec_run",),
+        turns_taken=1,
+        stop_reason="turn_limit_reached",
+        detail="",
+        guest_image=AN_IMAGE.as_record(),
+        boots=({"call": 0, "booted": False, "refused_before_launch": "bad argv"},),
+    )
+
+    assert asked_but_refused.asked_to_run_something is True
+    assert asked_but_refused.a_command_really_ran is False

--- a/batch-runner/tests/test_agentic_v2_stage_d_session.py
+++ b/batch-runner/tests/test_agentic_v2_stage_d_session.py
@@ -1,0 +1,339 @@
+"""Where the two halves of stage D meet: the backend, and the disk under it.
+
+Everything above this file has been proven on one side of a line. D2's tests
+hand the backend a launcher that writes into the host workspace directly, which
+proves the backend and says nothing about the disk. The carriage tests build and
+read real images, which proves the disk and says nothing about the object that
+holds the workspace between calls.
+
+The failure that lives in the gap is not hypothetical, and this file exists
+because it was found there. The carriage originally installed what came back by
+renaming the new directory over the old one — atomic, and correct in isolation.
+The backend pins ``(st_dev, st_ino)`` of its workspace once, in ``__init__``,
+and keeps the descriptor. After a rename the two no longer describe the same
+directory: the backend's re-check refuses, and a write through the pinned
+descriptor raises. **The first ``exec_run`` of a session still looks fine.** It
+is the second one that fails, and by then the model has been told the first
+one's work is on disk.
+
+So these tests run a *session* — several calls in a row, through the real
+backend, over a real ext4 image that is torn down and rebuilt between them, with
+only the boot itself injected. That is as close to a booted host as this box
+gets, and it is the part a booted host would not have made any clearer.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from core.agentic_v2_contract import TOOL_CONTRACT_VERSION, AgenticV2Profile
+from core.agentic_v2_exec_boot import EXEC_RECORD_DIR
+from core.agentic_v2_microvm_backend import (
+    AgenticV2MicroVMBackend,
+    GuestImage,
+)
+from core.agentic_v2_one_call_machine import (
+    WORKSPACE_DID_NOT_COME_BACK,
+    OneCallMachine,
+)
+from core.agentic_v2_substrate import AgenticV2SubstrateManifest
+from core.agentic_v2_work_disk import (
+    SCRATCH_ON_DISK,
+    WORKSPACE_ON_DISK,
+    workspace_out_of_work_disk,
+)
+
+
+needs_ext4_tools = pytest.mark.skipif(
+    shutil.which("mke2fs") is None or shutil.which("debugfs") is None,
+    reason="e2fsprogs is what builds and reads the work disk",
+)
+
+AN_IMAGE = GuestImage(
+    reference="ghcr.io/hyeonsangjeon/gdpval-sandbox",
+    digest="sha256:ee6ef798631d3c3aeaed28658c640e6f5d021677449852bf2e1f18be5bd24edb",
+    kernel_sha256="a" * 64,
+    rootfs_sha256="b" * 64,
+)
+
+
+class AGuestThatReallyWritesADisk:
+    """The injected boot, and the only injected thing in this file.
+
+    It does what a booted machine does to the work disk and nothing else: reads
+    the staged image, applies whatever the test said the command wrote, and
+    leaves a rebuilt image at ``<work_disk>.returned`` — which is where
+    ``first_boot`` leaves its copy, taken out of the jail immediately before the
+    chroot is destroyed.
+
+    ``writes`` are paths inside the workspace. ``deletes`` are too, because a
+    guest deleting a file is a case the carriage has to carry as faithfully as a
+    guest creating one.
+    """
+
+    def __init__(self, *, writes=None, deletes=(), status=0, outcome="booted",
+                 returns_a_disk=True):
+        self.writes = dict(writes or {})
+        self.deletes = list(deletes)
+        self.status = status
+        self.outcome = outcome
+        self.returns_a_disk = returns_a_disk
+        self.commands: list[str] = []
+
+    def __call__(self, plan, *, jailer_binary, kernel, rootfs, work_disk, uid, gid):
+        staged = Path(work_disk)
+        rebuilt = Path(str(staged) + ".returned")
+        self.commands.append(self._command_off_the_disk(staged))
+        if self.returns_a_disk:
+            self._rebuild(staged, rebuilt)
+        return {
+            "outcome": self.outcome,
+            "command_exit_status": self.status,
+            "results": {"/out/stdout": "", "/out/stderr": ""},
+            "teardown": {"all_gone": True},
+        }
+
+    def _command_off_the_disk(self, staged: Path) -> str:
+        read = subprocess.run(
+            ["debugfs", "-R", f"cat {SCRATCH_ON_DISK}/command.sh", staged.as_posix()],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return read.stdout
+
+    def _rebuild(self, staged: Path, rebuilt: Path) -> None:
+        scratch = staged.parent / "guest"
+        if scratch.exists():
+            shutil.rmtree(scratch)
+        read = workspace_out_of_work_disk(image=staged, into=scratch)
+        assert read["read_back"], read["said"]
+
+        tree = staged.parent / "guest-tree"
+        if tree.exists():
+            shutil.rmtree(tree)
+        (tree / SCRATCH_ON_DISK).mkdir(parents=True)
+        shutil.move(read["root"], str(tree / WORKSPACE_ON_DISK))
+
+        for relative in self.deletes:
+            (tree / WORKSPACE_ON_DISK / relative).unlink()
+        for relative, content in self.writes.items():
+            target = tree / WORKSPACE_ON_DISK / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+
+        subprocess.run(
+            [
+                "mke2fs", "-q", "-F", "-t", "ext4", "-b", "4096",
+                "-d", tree.as_posix(), rebuilt.as_posix(), "8192",
+            ],
+            check=True,
+            capture_output=True,
+        )
+
+
+def _machine(tmp_path, guest) -> OneCallMachine:
+    images = tmp_path / "images"
+    images.mkdir(exist_ok=True)
+    (images / "vmlinux").write_bytes(b"stands in for a kernel\n")
+    (images / "rootfs.ext4").write_bytes(b"stands in for a rootfs\n")
+    return OneCallMachine(
+        kernel=images / "vmlinux",
+        rootfs=images / "rootfs.ext4",
+        firecracker_binary=images / "firecracker",
+        uid=1200,
+        gid=1200,
+        vcpu_count=2,
+        cgroup_version=2,
+        scratch=tmp_path / "scratch",
+        session="gdpval-task",
+        boot=guest,
+    )
+
+
+def _backend(tmp_path, machine) -> AgenticV2MicroVMBackend:
+    return AgenticV2MicroVMBackend(
+        root=tmp_path / "session",
+        profile=AgenticV2Profile(
+            tool_contract_version=TOOL_CONTRACT_VERSION,
+            policy_profile_id="offline-full-v1",
+            foundation_only=True,
+        ),
+        image=AN_IMAGE,
+        boot_one_command=machine,
+        substrate_manifest=AgenticV2SubstrateManifest.load(
+            Path("sandbox/agentic_v2_capabilities.json")
+        ),
+    )
+
+
+def _call(argv=("true",), cwd=".", timeout_seconds=60):
+    return {"argv": list(argv), "cwd": cwd, "timeout_seconds": timeout_seconds}
+
+
+@needs_ext4_tools
+class TestASessionOfMoreThanOneCall:
+    def test_a_second_call_works_after_a_first_one_replaced_the_workspace(
+        self, tmp_path
+    ):
+        # The rename bug's exact signature: call one succeeds, call two fails
+        # because the workspace the backend pinned is no longer the workspace on
+        # disk. One call would never have shown it.
+        backend = _backend(tmp_path, _machine(tmp_path, AGuestThatReallyWritesADisk(
+            writes={"made_by_the_guest.txt": "here\n"}
+        )))
+        try:
+            first = backend.exec_run(_call())
+            second = backend.exec_run(_call())
+            assert first["ok"] is True, first
+            assert second["ok"] is True, second
+            assert [b["boot_outcome"] for b in backend.boots] == ["booted", "booted"]
+        finally:
+            backend.close()
+
+    def test_what_one_call_wrote_is_there_for_the_next_one(self, tmp_path):
+        # The whole point of holding a workspace between calls: turn two's guest
+        # has to see turn one's file, or the model cannot build on its own work.
+        guest = AGuestThatReallyWritesADisk(writes={"job/step1.txt": "from turn one\n"})
+        backend = _backend(tmp_path, _machine(tmp_path, guest))
+        try:
+            backend.exec_run(_call())
+            guest.writes = {"job/step2.txt": "from turn two\n"}
+            backend.exec_run(_call())
+            work = Path(backend.work)
+            assert (work / "job" / "step1.txt").read_text() == "from turn one\n"
+            assert (work / "job" / "step2.txt").read_text() == "from turn two\n"
+        finally:
+            backend.close()
+
+    def test_the_records_of_earlier_calls_survive_the_carriage(self, tmp_path):
+        # exec_run writes each call's streams into the workspace for the model to
+        # read back. A carriage that dropped them would leave the model unable to
+        # see what its own earlier commands printed.
+        guest = AGuestThatReallyWritesADisk()
+        backend = _backend(tmp_path, _machine(tmp_path, guest))
+        try:
+            backend.exec_run(_call())
+            backend.exec_run(_call())
+            records = Path(backend.work) / EXEC_RECORD_DIR
+            assert (records / "0000" / "meta.json").is_file()
+            assert (records / "0001" / "meta.json").is_file()
+        finally:
+            backend.close()
+
+    def test_a_file_the_guest_deleted_stays_deleted(self, tmp_path):
+        guest = AGuestThatReallyWritesADisk(writes={"job/temp.txt": "scratch\n"})
+        backend = _backend(tmp_path, _machine(tmp_path, guest))
+        try:
+            backend.exec_run(_call())
+            assert (Path(backend.work) / "job" / "temp.txt").exists()
+            guest.writes = {}
+            guest.deletes = ["job/temp.txt"]
+            backend.exec_run(_call())
+            assert not (Path(backend.work) / "job" / "temp.txt").exists()
+        finally:
+            backend.close()
+
+    def test_the_command_the_backend_built_is_the_one_on_the_disk(self, tmp_path):
+        # D1 builds the wrapper, the carriage puts it on the disk, the guest init
+        # runs it from there. Three modules, one string, checked once.
+        guest = AGuestThatReallyWritesADisk()
+        backend = _backend(tmp_path, _machine(tmp_path, guest))
+        try:
+            (Path(backend.work) / "job").mkdir()
+            backend.exec_run(_call(argv=["echo", "hello"], cwd="job"))
+            assert "/work/ws/job" in guest.commands[0]
+        finally:
+            backend.close()
+
+
+@needs_ext4_tools
+class TestWhenTheCarriageBreaksMidSession:
+    def test_the_model_is_told_the_backend_failed_not_that_it_succeeded(
+        self, tmp_path
+    ):
+        guest = AGuestThatReallyWritesADisk(status=0, returns_a_disk=False)
+        backend = _backend(tmp_path, _machine(tmp_path, guest))
+        try:
+            result = backend.exec_run(_call())
+            assert result["ok"] is False
+            assert result["error_type"] == "compute_backend_error"
+            assert backend.boots[0]["boot_outcome"] == WORKSPACE_DID_NOT_COME_BACK
+        finally:
+            backend.close()
+
+    def test_the_session_survives_a_broken_call_and_keeps_going(self, tmp_path):
+        # An infrastructure fault on one call must not cost the model the work it
+        # had already done, and must not end the session.
+        guest = AGuestThatReallyWritesADisk(writes={"job/kept.txt": "turn one\n"})
+        backend = _backend(tmp_path, _machine(tmp_path, guest))
+        try:
+            backend.exec_run(_call())
+            guest.returns_a_disk = False
+            assert backend.exec_run(_call())["ok"] is False
+            assert (Path(backend.work) / "job" / "kept.txt").read_text() == "turn one\n"
+
+            guest.returns_a_disk = True
+            guest.writes = {"job/after.txt": "turn three\n"}
+            assert backend.exec_run(_call())["ok"] is True
+            assert (Path(backend.work) / "job" / "after.txt").exists()
+            assert (Path(backend.work) / "job" / "kept.txt").exists()
+        finally:
+            backend.close()
+
+
+@needs_ext4_tools
+class TestOneCallIsOneMachine:
+    def test_each_call_gets_its_own_named_machine(self, tmp_path):
+        machine = _machine(tmp_path, AGuestThatReallyWritesADisk())
+        backend = _backend(tmp_path, machine)
+        try:
+            backend.exec_run(_call())
+            backend.exec_run(_call())
+            names = [row["vm_id"] for row in machine.record]
+            assert names == ["gdpval-task-0000", "gdpval-task-0001"]
+        finally:
+            backend.close()
+
+    def test_a_refused_call_never_reaches_the_machine(self, tmp_path):
+        # A bad path is established on the host. Spending a boot to discover it
+        # would be paying for an answer already in hand.
+        machine = _machine(tmp_path, AGuestThatReallyWritesADisk())
+        backend = _backend(tmp_path, machine)
+        try:
+            result = backend.exec_run(_call(cwd="does/not/exist"))
+            assert result == {"ok": False, "error_type": "path_not_directory"}
+            assert machine.record == []
+            assert machine.calls == 0
+        finally:
+            backend.close()
+
+    def test_nothing_of_a_finished_call_is_left_in_the_workspace(self, tmp_path):
+        # The disks and the read-back scratch live under the machine's own
+        # directory, never in the workspace the model reads.
+        backend = _backend(tmp_path, _machine(tmp_path, AGuestThatReallyWritesADisk()))
+        try:
+            backend.exec_run(_call())
+            present = {p.name for p in Path(backend.work).iterdir()}
+            assert not {name for name in present if name.endswith(".ext4")}
+            assert "staging" not in present and "previous" not in present
+        finally:
+            backend.close()
+
+    def test_the_workspace_the_backend_pinned_is_never_swapped_under_it(
+        self, tmp_path
+    ):
+        backend = _backend(tmp_path, _machine(tmp_path, AGuestThatReallyWritesADisk()))
+        try:
+            before = Path(backend.work).lstat()
+            backend.exec_run(_call())
+            backend.exec_run(_call())
+            after = Path(backend.work).lstat()
+            assert (after.st_dev, after.st_ino) == (before.st_dev, before.st_ino)
+        finally:
+            backend.close()

--- a/batch-runner/tests/test_agentic_v2_work_disk.py
+++ b/batch-runner/tests/test_agentic_v2_work_disk.py
@@ -352,6 +352,54 @@ class TestReplacingTheHostWorkspace:
             image=staged["image"], workspace=work, scratch=tmp_path / "scratch"
         )
         assert not work.with_name(work.name + ".previous").exists()
+        assert sorted(p.name for p in work.parent.iterdir()) == [work.name]
+
+    def test_the_directory_the_backend_pinned_is_still_the_one_it_pinned(
+        self, tmp_path
+    ):
+        # AgenticV2FixtureBackend opens the workspace once in __init__, keeps
+        # the descriptor, and re-checks (st_dev, st_ino) before later work. A
+        # carriage that renames the directory away leaves that descriptor on a
+        # directory nobody can reach -- and the session does not fail here, it
+        # fails on the *next* exec_run, after this one looked like it worked.
+        work = _workspace(tmp_path)
+        pinned = os.open(
+            work, os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_NOFOLLOW", 0)
+        )
+        try:
+            opened = os.fstat(pinned)
+            staged = self._staged(tmp_path, work)
+            (work / "job" / "plain.txt").write_text("stale\n", encoding="utf-8")
+            carry_the_workspace_back(
+                image=staged["image"], workspace=work, scratch=tmp_path / "scratch"
+            )
+            after = work.lstat()
+            assert (after.st_dev, after.st_ino) == (opened.st_dev, opened.st_ino)
+            # And the descriptor still reaches the workspace the model reads,
+            # which is what the backend does with it every call.
+            written = os.open(
+                "kept_by_the_backend.txt",
+                os.O_WRONLY | os.O_CREAT,
+                0o600,
+                dir_fd=pinned,
+            )
+            os.close(written)
+            assert (work / "kept_by_the_backend.txt").exists()
+        finally:
+            os.close(pinned)
+
+    def test_the_old_contents_are_gone_and_not_merged_with_the_new(self, tmp_path):
+        # Keeping the directory must not turn the replacement into a merge: a
+        # file the guest deleted would come back every call, and the model would
+        # be told its own delete did not take.
+        work = _workspace(tmp_path)
+        staged = self._staged(tmp_path, work)
+        (work / "job" / "deleted_by_the_guest.txt").write_text("gone\n")
+        carry_the_workspace_back(
+            image=staged["image"], workspace=work, scratch=tmp_path / "scratch"
+        )
+        assert not (work / "job" / "deleted_by_the_guest.txt").exists()
+        assert (work / "job" / "plain.txt").read_text() == "hello\n"
 
 
 class TestTheArgumentsAreReadableWithoutRunningThem:

--- a/batch-runner/tests/test_agentic_v2_work_disk.py
+++ b/batch-runner/tests/test_agentic_v2_work_disk.py
@@ -1,0 +1,367 @@
+"""The carriage between a host workspace and a guest work disk.
+
+These tests build **real ext4 images** with ``mke2fs`` and read them back with
+``debugfs``, on a box that cannot boot a microVM at all. That is not a
+compromise — the carriage is exactly the part a booted machine would not help
+prove, and the two tools here are the same two that will do the work in
+production. What a microVM adds is containment, and containment was measured in
+stage C.
+
+The tests that matter most are the ones about failure. ``debugfs -R`` exits 0
+when it cannot find the directory, cannot write the destination and cannot read
+the superblock, so every one of those has to be caught by looking at what landed
+rather than at what the tool said. A carriage that fails silently reports 220
+tasks' worth of models that wrote nothing.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from core.agentic_v2_exec_boot import WORKSPACE_IN_GUEST
+from core.agentic_v2_work_disk import (
+    BYTES_A_QUOTA_ACTUALLY_HOLDS,
+    COMMAND_ON_DISK,
+    RESULTS_ON_DISK,
+    SCRATCH_ON_DISK,
+    WORKSPACE_ON_DISK,
+    WorkDiskRefused,
+    carry_the_workspace_back,
+    rdump_arguments,
+    stage_the_work_disk,
+    what_would_be_carried_in,
+    workspace_out_of_work_disk,
+)
+
+
+needs_ext4_tools = pytest.mark.skipif(
+    shutil.which("mke2fs") is None or shutil.which("debugfs") is None,
+    reason="e2fsprogs is what builds and reads the work disk",
+)
+
+A_COMMAND = "#!/bin/sh\necho carried\n"
+
+# Small enough to build quickly, large enough to hold what these tests carry.
+A_SMALL_DISK = 16
+
+
+def _workspace(root: Path) -> Path:
+    work = root / "session" / "ws"
+    (work / "job").mkdir(parents=True)
+    (work / "job" / "plain.txt").write_text("hello\n", encoding="utf-8")
+    return work
+
+
+class TestTheTwoSidesAgreeOnWhereTheWorkspaceIs:
+    def test_the_disk_directory_is_the_one_the_guest_command_cds_into(self):
+        # D1 writes "cd /work/ws/<cwd>" into every command it builds. If these
+        # two ever disagree the command runs in a directory that exists and is
+        # empty, and the model is told its own files are not there.
+        assert WORKSPACE_IN_GUEST == f"/work/{WORKSPACE_ON_DISK}"
+
+    def test_the_command_lands_where_the_guest_init_runs_it_from(self):
+        # GUEST_INIT runs `sh /work/in/command.sh`.
+        assert COMMAND_ON_DISK == f"{SCRATCH_ON_DISK}/command.sh"
+        assert RESULTS_ON_DISK == "out"
+
+
+class TestMeasuringBeforeBuilding:
+    def test_it_counts_what_is_there(self, tmp_path):
+        work = _workspace(tmp_path)
+        (work / "job" / "second.txt").write_text("x" * 100, encoding="utf-8")
+        measured = what_would_be_carried_in(work)
+        assert measured["files"] == 2
+        assert measured["directories"] == 1
+        assert measured["bytes"] == 106
+        assert measured["fits"] is True
+
+    def test_a_link_out_of_the_workspace_is_named_not_followed(self, tmp_path):
+        work = _workspace(tmp_path)
+        (work / "job" / "escape").symlink_to("/etc/passwd")
+        measured = what_would_be_carried_in(work)
+        assert measured["symlinks_leaving_the_workspace"] == ["job/escape"]
+        # Named, and its target's size never read -- following it is the thing
+        # being avoided, so the total is still only the real file's bytes.
+        assert measured["bytes"] == 6
+
+    def test_a_link_inside_the_workspace_is_not_a_problem(self, tmp_path):
+        work = _workspace(tmp_path)
+        (work / "job" / "local").symlink_to("plain.txt")
+        assert what_would_be_carried_in(work)["symlinks_leaving_the_workspace"] == []
+
+    def test_a_link_climbing_out_by_dots_is_caught_like_an_absolute_one(
+        self, tmp_path
+    ):
+        work = _workspace(tmp_path)
+        (work / "job" / "sneaky").symlink_to("../../../../etc/passwd")
+        assert what_would_be_carried_in(work)["symlinks_leaving_the_workspace"] == [
+            "job/sneaky"
+        ]
+
+    def test_the_room_is_what_a_disk_holds_and_not_what_it_is_called(self, tmp_path):
+        # 256 MiB of image is 234,557,440 bytes of content. Sizing a refusal off
+        # the nominal figure lets a workspace 32 MiB too large through, and it
+        # then fails inside mke2fs with a message about blocks.
+        assert BYTES_A_QUOTA_ACTUALLY_HOLDS < 256 * 1024 * 1024
+        measured = what_would_be_carried_in(_workspace(tmp_path))
+        assert measured["room_bytes"] <= BYTES_A_QUOTA_ACTUALLY_HOLDS
+
+
+class TestRefusingBeforeADiskIsBuilt:
+    def test_a_workspace_that_cannot_fit_is_refused_by_name(self, tmp_path):
+        work = _workspace(tmp_path)
+        (work / "job" / "big.bin").write_bytes(b"\0" * (2 * 1024 * 1024))
+        with pytest.raises(WorkDiskRefused) as refusal:
+            stage_the_work_disk(
+                workspace=work,
+                command_sh=A_COMMAND,
+                into=tmp_path / "disk",
+                quota_mib=1,
+            )
+        assert "mke2fs" in str(refusal.value)
+        assert "2097158 bytes" in str(refusal.value)
+
+    def test_a_link_out_of_the_workspace_stops_the_whole_carriage(self, tmp_path):
+        work = _workspace(tmp_path)
+        (work / "job" / "escape").symlink_to("/etc/shadow")
+        with pytest.raises(WorkDiskRefused) as refusal:
+            stage_the_work_disk(
+                workspace=work, command_sh=A_COMMAND, into=tmp_path / "disk"
+            )
+        assert "job/escape" in str(refusal.value)
+
+    def test_nothing_is_built_when_it_refuses(self, tmp_path):
+        work = _workspace(tmp_path)
+        (work / "job" / "escape").symlink_to("/etc/shadow")
+        with pytest.raises(WorkDiskRefused):
+            stage_the_work_disk(
+                workspace=work, command_sh=A_COMMAND, into=tmp_path / "disk"
+            )
+        assert not (tmp_path / "disk" / "work.ext4").exists()
+
+
+@needs_ext4_tools
+class TestARealDiskWithARealWorkspaceOnIt:
+    def test_it_builds_and_the_command_is_whole(self, tmp_path):
+        work = _workspace(tmp_path)
+        staged = stage_the_work_disk(
+            workspace=work,
+            command_sh=A_COMMAND,
+            into=tmp_path / "disk",
+            quota_mib=A_SMALL_DISK,
+        )
+        assert Path(staged["image"]).is_file()
+        assert staged["checked"]["command_bytes"] == len(A_COMMAND.encode("utf-8"))
+        assert staged["sha256"]
+
+    def test_the_host_workspace_is_copied_not_moved(self, tmp_path):
+        # A boot that goes wrong must leave the session where it was, not one
+        # directory poorer.
+        work = _workspace(tmp_path)
+        stage_the_work_disk(
+            workspace=work,
+            command_sh=A_COMMAND,
+            into=tmp_path / "disk",
+            quota_mib=A_SMALL_DISK,
+        )
+        assert (work / "job" / "plain.txt").read_text() == "hello\n"
+
+    def test_the_workspace_is_on_the_disk_where_the_command_will_look(self, tmp_path):
+        work = _workspace(tmp_path)
+        staged = stage_the_work_disk(
+            workspace=work,
+            command_sh=A_COMMAND,
+            into=tmp_path / "disk",
+            quota_mib=A_SMALL_DISK,
+        )
+        listed = subprocess.run(
+            ["debugfs", "-R", f"ls -l /{WORKSPACE_ON_DISK}/job", staged["image"]],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert "plain.txt" in listed.stdout
+
+
+@needs_ext4_tools
+class TestWhatComesBackIsWhatWentIn:
+    def _round_trip(self, tmp_path, populate) -> Path:
+        work = _workspace(tmp_path)
+        populate(work)
+        staged = stage_the_work_disk(
+            workspace=work,
+            command_sh=A_COMMAND,
+            into=tmp_path / "disk",
+            quota_mib=A_SMALL_DISK,
+        )
+        read = workspace_out_of_work_disk(
+            image=staged["image"], into=tmp_path / "back"
+        )
+        assert read["read_back"] is True, read["said"]
+        return Path(read["root"])
+
+    def test_bytes_that_are_not_text_survive_exactly(self, tmp_path):
+        # debugfs's own "cat" comes back through a text pipe and would destroy
+        # this. rdump writes the file, so it does not.
+        awkward = bytes(range(256)) + b"\x00\xff\xfe" * 40
+        landed = self._round_trip(
+            tmp_path,
+            lambda work: (work / "job" / "sheet.bin").write_bytes(awkward),
+        )
+        assert (landed / "job" / "sheet.bin").read_bytes() == awkward
+
+    def test_a_nested_tree_comes_back_with_its_shape(self, tmp_path):
+        def populate(work):
+            deep = work / "job" / "a" / "b" / "c"
+            deep.mkdir(parents=True)
+            (deep / "deep.txt").write_text("down here\n", encoding="utf-8")
+
+        landed = self._round_trip(tmp_path, populate)
+        assert (landed / "job" / "a" / "b" / "c" / "deep.txt").read_text() == "down here\n"
+
+    def test_an_empty_file_comes_back_empty_rather_than_absent(self, tmp_path):
+        landed = self._round_trip(
+            tmp_path, lambda work: (work / "job" / "nothing.txt").touch()
+        )
+        assert (landed / "job" / "nothing.txt").is_file()
+        assert (landed / "job" / "nothing.txt").read_bytes() == b""
+
+    def test_a_file_the_size_of_a_real_deliverable_survives(self, tmp_path):
+        big = os.urandom(2 * 1024 * 1024)
+        landed = self._round_trip(
+            tmp_path, lambda work: (work / "job" / "report.bin").write_bytes(big)
+        )
+        assert (landed / "job" / "report.bin").read_bytes() == big
+
+
+@needs_ext4_tools
+class TestALinkTheGuestMadeDoesNotBecomeALinkOnTheHost:
+    def _disk_holding(self, tmp_path, link_target: str) -> str:
+        # Built directly rather than through stage_the_work_disk, because that
+        # refuses this on the way in. The case being tested is the guest
+        # creating one during the call, which no host-side refusal can prevent.
+        staging = tmp_path / "staging"
+        (staging / WORKSPACE_ON_DISK / "job").mkdir(parents=True)
+        (staging / SCRATCH_ON_DISK).mkdir()
+        (staging / WORKSPACE_ON_DISK / "job" / "real.txt").write_text("mine\n")
+        (staging / WORKSPACE_ON_DISK / "job" / "made").symlink_to(link_target)
+        image = tmp_path / "guest.ext4"
+        subprocess.run(
+            [
+                "mke2fs", "-q", "-F", "-t", "ext4", "-b", "4096",
+                "-d", staging.as_posix(), image.as_posix(), str(A_SMALL_DISK * 256),
+            ],
+            check=True,
+            capture_output=True,
+        )
+        return image.as_posix()
+
+    def test_a_link_pointing_into_the_host_is_dropped_and_recorded(self, tmp_path):
+        image = self._disk_holding(tmp_path, "/etc/passwd")
+        read = workspace_out_of_work_disk(image=image, into=tmp_path / "back")
+        assert read["refused_symlinks"] == ["job/made"]
+        assert not (Path(read["root"]) / "job" / "made").exists()
+        # The real file it sat next to still came back. Refusing the link is not
+        # refusing the call.
+        assert (Path(read["root"]) / "job" / "real.txt").read_text() == "mine\n"
+
+    def test_a_link_within_the_workspace_is_kept(self, tmp_path):
+        image = self._disk_holding(tmp_path, "real.txt")
+        read = workspace_out_of_work_disk(image=image, into=tmp_path / "back")
+        assert read["refused_symlinks"] == []
+        assert (Path(read["root"]) / "job" / "made").is_symlink()
+
+
+@needs_ext4_tools
+class TestFailuresThatDebugfsReportsAsSuccess:
+    def test_a_disk_with_no_workspace_on_it_is_not_a_model_that_wrote_nothing(
+        self, tmp_path
+    ):
+        empty = tmp_path / "empty.ext4"
+        subprocess.run(
+            ["mke2fs", "-q", "-F", "-t", "ext4", "-b", "4096", empty.as_posix(), "4096"],
+            check=True,
+            capture_output=True,
+        )
+        read = workspace_out_of_work_disk(image=empty, into=tmp_path / "back")
+        assert read["read_back"] is False
+        assert read["files"] == 0
+        assert "not the same as a command that wrote nothing" in read["grounds"]
+
+    def test_an_image_that_is_not_a_filesystem_reads_back_as_nothing(self, tmp_path):
+        broken = tmp_path / "broken.ext4"
+        broken.write_bytes(b"\0" * 8192)
+        read = workspace_out_of_work_disk(image=broken, into=tmp_path / "back")
+        # debugfs exits 0 here. If the returncode were trusted this would be a
+        # successful read of an empty workspace.
+        assert read["read_back"] is False
+        assert "super-block" in read["said"] or "Filesystem not open" in read["said"]
+
+    def test_an_image_that_is_not_there_at_all_reads_back_as_nothing(self, tmp_path):
+        read = workspace_out_of_work_disk(
+            image=tmp_path / "absent.ext4", into=tmp_path / "back"
+        )
+        assert read["read_back"] is False
+
+
+@needs_ext4_tools
+class TestReplacingTheHostWorkspace:
+    def _staged(self, tmp_path, work):
+        return stage_the_work_disk(
+            workspace=work,
+            command_sh=A_COMMAND,
+            into=tmp_path / "disk",
+            quota_mib=A_SMALL_DISK,
+        )
+
+    def test_what_the_machine_left_becomes_the_workspace(self, tmp_path):
+        work = _workspace(tmp_path)
+        staged = self._staged(tmp_path, work)
+        # Stand in for the guest: change the disk's copy, not the host's.
+        (work / "job" / "plain.txt").write_text("stale\n", encoding="utf-8")
+        carried = carry_the_workspace_back(
+            image=staged["image"], workspace=work, scratch=tmp_path / "scratch"
+        )
+        assert carried["replaced"] is True
+        assert (work / "job" / "plain.txt").read_text() == "hello\n"
+
+    def test_a_carriage_that_brought_nothing_leaves_the_session_alone(self, tmp_path):
+        # The failure this exists for: deleting a session's accumulated work
+        # because this one call's read-back broke would turn an infrastructure
+        # fault into the permanent loss of the model's output.
+        work = _workspace(tmp_path)
+        (work / "job" / "earlier.txt").write_text("from turn one\n", encoding="utf-8")
+        carried = carry_the_workspace_back(
+            image=tmp_path / "never-built.ext4",
+            workspace=work,
+            scratch=tmp_path / "scratch",
+        )
+        assert carried["replaced"] is False
+        assert carried["read_back"] is False
+        assert (work / "job" / "earlier.txt").read_text() == "from turn one\n"
+
+    def test_nothing_is_left_behind_beside_the_workspace(self, tmp_path):
+        work = _workspace(tmp_path)
+        staged = self._staged(tmp_path, work)
+        carry_the_workspace_back(
+            image=staged["image"], workspace=work, scratch=tmp_path / "scratch"
+        )
+        assert not work.with_name(work.name + ".previous").exists()
+
+
+class TestTheArgumentsAreReadableWithoutRunningThem:
+    def test_the_read_back_never_mounts_anything(self):
+        argv = rdump_arguments("/tmp/x.ext4", inside="/ws", destination="/tmp/out")
+        assert argv[0] == "debugfs"
+        assert "mount" not in " ".join(argv)
+        assert "-R" in argv
+
+    def test_it_names_the_directory_and_the_destination(self):
+        argv = rdump_arguments("/tmp/x.ext4", inside="/ws", destination="/tmp/out")
+        assert argv[2] == "rdump /ws /tmp/out"
+        assert argv[3] == "/tmp/x.ext4"


### PR DESCRIPTION
D1 built the command and read the boot. D2 built the backend that holds a
workspace between calls. This is what goes between them, and the probe that
uses it.

## The carriage (`core/agentic_v2_work_disk.py`)

Every `exec_run` has to put the session's files on a work disk, boot, and take
back whatever changed — with no mount, no privilege, and no altered byte. It is
its own module because **every failure here looks like something else**: a
workspace that did not arrive looks like a model writing to the wrong path; a
read-back that produced nothing looks like a command that printed nothing;
mangled bytes look like a model producing a corrupt spreadsheet. Across 220
tasks each of those reads as a finding about the model, and none of them would
be.

Four facts were measured with `mke2fs`/`debugfs` rather than assumed, and each
one changed the code:

| measured | consequence |
|---|---|
| `debugfs -R` exits **0** on a missing directory, an unwritable destination *and* an unreadable superblock | the returncode is not evidence; the read-back is judged by what landed on the host |
| `rdump` is byte-exact, `cat` is not | `cat` comes back through a text pipe — fine for an exit status, fatal for an `.xlsx` |
| symlinks survive **both** directions, including absolute ones | a link out of the workspace is not carried, and is recorded as refused |
| **a rename-swap breaks the pinned descriptor** | the workspace's contents are moved, and the directory keeps its identity |

That fourth one is a bug this PR found and fixes before it ever reached a paid
run. The obvious install is atomic — rename the old aside, the new into place.
`AgenticV2FixtureBackend.__init__` pins `(st_dev, st_ino)` and keeps the
descriptor, so after a rename its own re-check refuses and a write through that
descriptor raises `FileNotFoundError`. **The first `exec_run` of a session still
looks fine.** The second one fails, after the model has been told the first
one's work is on disk. Proved by probe, fixed, then mutation-verified: restoring
the rename fails 8 tests.

Measured capacity: a 256 MiB ext4 built this way holds **234,557,440 bytes** and
**65,522 inodes**, not the nominal 268,435,456. Sizing a refusal off the nominal
figure lets a workspace 32 MiB too large through, and it fails inside `mke2fs`
with a message about blocks that reads like a broken toolchain.

## The one-call machine (`core/agentic_v2_one_call_machine.py`)

One `exec_run`, one machine, destroyed afterwards. The plan it builds is
`REQUIRED_MICROVM_POLICY` with exactly one bound tightened — a test asserts the
diff against the policy is a one-element list — and a call may only tighten the
wall clock, never loosen it.

A command whose files did not survive the trip is **not** reported as a command
that succeeded: the returncode is withheld, the status the guest really wrote is
kept separately, and the model is told `compute_backend_error`.

## Stage D's probe (`core/agentic_v2_stage_d_probe.py`)

Stage A could not offer `exec_run` because it was shut. It is not shut now. The
probe asks whether a model offered a command runner uses it, whether the command
runs in a machine that is destroyed afterwards, whether the files come back, and
whether the turn after that builds on them — four separately falsifiable clauses,
recorded separately. A run that boots on its last turn is reported as having
proved the machine and not the loop.

`finalize` stays out (marking is nearly all of stage one's cost);
`environment_*`/`browser_run` stay out (this backend refuses them by design, and
offering one spends a paid turn to be told no). `check_probe_tools` enforces both
*and requires* `exec_run` — a stage D probe without it is stage A under stage D's
name.

Turn budget is 8, not 4: stage A measured the model spending three of its four
turns on `capabilities_query` before doing any work.

Writing it surfaced a second real defect: `close()` purges the work directory
— `workdir: ephemeral-quota` doing its job — and that directory is also the
entire product of the run. The first draft closed without collecting, which
would have left a boot record describing deliverables that no longer existed.
The workspace is now copied out first, so both rules hold.

## Nothing was activated

No guard flipped, no `foundation_only` or `production_activation` change, no
privilege escalation, no V1/Docker fallback. The probe builds its own
dispatcher, exactly as stage A's does; the runner's backend-identity check still
refuses this backend. Opening it is D4's, as its own reviewable change.

**Zero model calls and zero Azure execution.** All of this is local.

## Tests

64 new (24 one-call machine, 11 joint session, 26 probe, 3 carriage), and the
joint session file exists specifically because the rename bug lived in the gap
between two suites that each passed. It runs a real backend against a real
`OneCallMachine` over real ext4, torn down and rebuilt between calls, with only
the boot injected — as close to a booted host as kernel 3.10 gets, and precisely
the part a booted host would not have made clearer.

`1240 passed, 2 skipped` across the agentic_v2 subset; full backend suite green.