### PR TITLE
feat(exp034): the thirty-task stage of the Codex-against-Foundry sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,78 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Added
+- **The thirty-task stage of the Codex-against-Foundry sequence.**
+  `experiments/exp034_codex_foundry_trial30.yaml`. `exp033` is left exactly as
+  it is: a stage is a separate run with its own record, not an edit to the
+  stage before it.
+
+  The thirty tasks are not chosen here. `select_trial_run_tasks` produces them
+  from the committed score-free catalogue, and the same list is already written
+  into `experiments/execution_envelope/advance_check_plan.yaml` under
+  `run_sizes.trial_run`; the file was checked against both before it was
+  committed and matches element for element. Four of exp033's five carry
+  forward and `2ea2e5b5` does not — which is worth saying out loud, because
+  `2ea2e5b5` is one of the two tasks that succeeded in *both* runs of exp033.
+  A list assembled to protect a score would not drop it. Neither direction was
+  available: the rule predates every run and reads nothing but the catalogue.
+
+  Two settings change from exp033, and only one of them is an experimental
+  variable:
+
+  | | exp033 | exp034 |
+  |---|---|---|
+  | `execution.max_retries` | 2 | **3** |
+  | `execution.relay_max_runs` | (default 3) | **6** |
+
+  `relay_max_runs` decides how many times the workflow may hand an unfinished
+  run to a fresh leg. It cannot add an attempt and cannot change a result.
+
+  `max_retries` is a real change, made in the same run as the scale change, so
+  this file does **not** claim to isolate its effect against exp033 and says so
+  in its header. What the run can answer alone, because every attempt is
+  recorded with its index, is the question actually worth asking: *did a fourth
+  attempt ever convert a task that three attempts had not?* If no task in
+  thirty does, the extra budget bought nothing and the next stage drops it.
+  That answer needs no comparison run. The reason to try is that the fourth
+  attempt is the first to wait 240 s — in both exp033 runs the tasks refused
+  for rate were refused at 60 s and 120 s, so two minutes is the longest pause
+  ever tested against this deployment.
+
+  `resume_max_rounds: 0` is set explicitly, now for two reasons. The first is
+  exp033's: a resume round hands out uneven attempt counts. The second is the
+  finding recorded in the entry above — `_get_failed_task_ids` selects by
+  status and never by reason, so a resume round would re-run a task the
+  provider stopped for content. The default in `core/experiment_config.py` is
+  `3`, so an experiment file that merely omits the key does that quietly.
+
+  The wall clock is written into the header rather than discovered. Worst case
+  is 30 × (4 × 1800 + 420) = 228,600 s, 63.5 hours; seven legs at the 290-minute
+  `wall_timeout` ceiling supply 33.8. The worst case is therefore *not*
+  reachable inside the relay budget, and a run approaching it would stop with
+  tasks pending and need a leg started by hand. That is recorded so a stall
+  reads as this arithmetic rather than as a fault. It is nowhere near what is
+  expected: `34528903950` ran five tasks and nine turns end to end in 19 m 34 s.
+
+  A prediction is registered in the header *before* the run, so that it can be
+  wrong. In exp033 the two tasks that succeeded have the two longest task
+  statements — 2,902 and 3,632 characters against 1,589, 1,548 and 996. At five
+  points that is as likely coincidence as cause. Across the thirty, statements
+  run 801 to 6,029 characters, median 2,241.5, and eleven are shorter than
+  2,000 — so under the null any given failure lands short 11/30 of the time,
+  36.7%. Pile-up means the association is real; proportional scatter means it
+  was five points of noise. The header also states what a real association
+  would *not* mean: a shorter statement is a vaguer task, and a model given a
+  vaguer task wandering into content a filter stops is a benchmark result and
+  stays one.
+
+- **`test_the_silent_ones_are_still_silent` counts twenty, not nineteen.** The
+  number is a census of experiment files whose self-review budget carries no
+  comment, pinned so that adding a comment to all of them is a visible
+  decision. exp034 is a new file rather than a comment removed from an old one
+  — its self-review is off and its budget is zero, so there is nothing for a
+  comment to describe — and moving the number in the change that adds the file
+  is the decision the pin asks to see. Same reasoning as exp033's bump from
+  eighteen.
 - **A run record now says how many retries it made, and for which reason.**
   `REQUIRED_RUN_RECORD_FIELDS` has asked for `retry_counts_by_reason` since it
   was written, and no production code has ever produced it;

--- a/batch-runner/experiments/exp034_codex_foundry_trial30.yaml
+++ b/batch-runner/experiments/exp034_codex_foundry_trial30.yaml
@@ -1,0 +1,318 @@
+# Codex against Foundry — the thirty-task trial stage
+# ===================================================
+#
+# The second of three stages: five, then thirty, then two hundred and twenty.
+# `exp033_codex_foundry_fixed5.yaml` is the five and is left exactly as it was
+# — a stage is a separate run with its own record, not an edit to the stage
+# before it.
+#
+# Everything about how a task is run is the same as exp033: one fresh Codex
+# session per task, that task's reference files staged into an isolated working
+# directory, the agent's own tools, and whatever files it leaves behind
+# collected as the deliverables. Two settings change and both are named below.
+#
+# What the five tasks actually showed
+# -----------------------------------
+#
+# Two runs of exp033 with an identical configuration, `34500590783` and
+# `34528903950`. Both scored 2 of 5. The same two tasks succeeded both times
+# and the same three failed both times — and not one of the three failed for
+# the same reason twice:
+#
+#   task        34500590783                     34528903950
+#   02aa1805    exceeded rate limit, 3 tries    reason: content_filter
+#   3baa0009    exceeded rate limit, 3 tries    Transport error
+#   0818571f    reason: content_filter, 1 try   exceeded rate limit, 3 tries
+#
+# So *which* task fails reproduces and *why* it fails does not. Those are two
+# findings, not one, and they do not have the same remedy. A rate ceiling
+# cannot be why a task is refused for rate once and filtered for content the
+# next time; and something that reproduces per task is not explained by
+# contention alone. What all six sentences share is their opening —
+# `stream disconnected before completion:` — so what reproduces is that these
+# particular turns get cut, and the wording is whatever the server said on the
+# way out.
+#
+# On the contention half the five-task evidence is already conclusive, and it
+# is about the deployment rather than about this pipeline. `34528903950` was
+# refused on the first call of the run, before it had sent anything, and again
+# after a hundred and twenty seconds in which it sent nothing. The provider's
+# own sentence names the deployment and the region rather than a subscription
+# or a key: `Your requests to gpt-5.4 for gpt-5.4 in eastus2 have exceeded rate
+# limit.` The turn that spent 289,404 input tokens succeeded and a turn
+# spending 11,586 after an idle gap did not, so it is not what one turn spends
+# inside itself either. Sending less is not the lever; surviving the refusal
+# is.
+#
+# A prediction written down before this run starts
+# ------------------------------------------------
+#
+# On the per-task half, five tasks are too few to say why those three. Several
+# task properties separate the two groups perfectly at that size, and one of
+# them is worth writing down *before* the numbers arrive so that it can be
+# wrong: the two tasks that succeeded have the two longest task statements.
+#
+#   succeeded   0112fc9b  2,902 characters      2ea2e5b5  3,632
+#   failed      02aa1805  1,589                 0818571f  1,548
+#               3baa0009    996
+#
+# At five points that is as likely to be coincidence as cause. Thirty tasks can
+# test it. Their statements run from 801 to 6,029 characters with a median of
+# 2,241.5, and eleven of the thirty are shorter than 2,000 characters. So under
+# the null — failure having nothing to do with the length of the statement —
+# any given failure lands in that short group 11/30 of the time, 36.7%. If
+# failures instead pile up there, the association is real and worth chasing. If
+# they scatter in proportion, it was five points of noise and this comment is
+# the record of it having been checked rather than assumed.
+#
+# It has to be said plainly what a real association would and would not mean.
+# It would *not* automatically be a defect of this run place to engineer
+# around. A shorter statement is a vaguer task, and a model given a vaguer task
+# may well wander into content a filter stops — which is a benchmark result and
+# must stay one. The distinction is not settled by this run and nothing here
+# should be written up as if it were.
+#
+# The thirty tasks
+# ----------------
+#
+# Produced by `select_trial_run_tasks` in `core/execution_envelope_tasks.py`
+# from the committed score-free catalogue, and written into
+# `experiments/execution_envelope/advance_check_plan.yaml` under `trial_run`
+# before any of these runs existed. The rule walks the industries from the
+# largest down and takes the smallest-numbered task not yet taken from each in
+# turn until thirty are held. Re-deriving it needs the catalogue and nothing
+# else:
+#
+#   catalog_sha256    5f1eca853979b2b4efe6c6ba656545c3a416da920e3faf067d52f5d8ac4ae0eb
+#   dataset_revision  11e7900cdcac61bc4daf59e65feb238acda98fbf
+#
+# The mix that comes out is 4 tasks from each of three industries and 3 from
+# each of the other six, and it is worth being exact about why, because "the
+# three largest" would be wrong. Eight of the nine industries are the same size
+# — 25 tasks each — and only Retail Trade differs, at 20. So the walk hands
+# every industry three tasks and has three left over, and those three go to the
+# first three of the eight equals in name order: Finance and Insurance,
+# Government, Health Care and Social Assistance. Retail Trade gets three like
+# everyone else despite being the smallest. The remainder is settled by the
+# tie-break, not by size.
+#
+# Sixteen of the thirty ship no reference files at all and the thirty ship
+# twenty-one between them, which is ordinary for this benchmark rather than a
+# property of this selection.
+#
+# Four of exp033's five tasks are in this list and `2ea2e5b5` is not. That is
+# the rule's answer and not a choice made here: the rule predates every run and
+# reads nothing but the catalogue, so it cannot be following a score. It is
+# worth saying out loud because `2ea2e5b5` is one of the two that succeeded
+# twice, and dropping a task that passed is the direction nobody would suspect
+# of score-chasing — the point is that neither direction was available.
+#
+# What changes from exp033, and what that costs the comparison
+# -----------------------------------------------------------
+#
+# Two settings, and one of them is not an experimental variable:
+#
+#   execution.max_retries       2  ->  3     four attempts per task
+#   execution.relay_max_runs  (3) ->  6      more legs for six times the work
+#
+# `relay_max_runs` only decides how many times the workflow may hand the run to
+# a fresh leg after the previous one hits its wall clock. It cannot add
+# attempts and cannot change any result; it is raised because thirty tasks is
+# six times the work of five and the default of three legs was written for
+# five.
+#
+# `max_retries` is a real change and it is being made at the same time as the
+# scale change, so this run does not isolate its effect against exp033. That
+# is stated rather than glossed. What the run *can* answer on its own is the
+# question actually worth asking, because every attempt is recorded with its
+# index: **did a fourth attempt ever convert a task that three attempts had
+# not?** If no task in thirty succeeds on its fourth attempt, the extra budget
+# bought nothing and the next stage drops it. That answer needs no comparison
+# run.
+#
+# The reason to try at all is that the fourth attempt is the first one that
+# waits four minutes. In both five-task runs the tasks refused for rate were
+# refused three times each at 60 s and 120 s of waiting, so the longest pause
+# ever tested against this deployment is two minutes. Four is a different
+# question, and it is one the retry budget already allows for.
+#
+# The limits, fixed before the run
+# --------------------------------
+#
+#   30 tasks x at most 4 attempts each = 120 turns, worst case
+#   1 turn per attempt, 1800s wall clock each
+#   at most 1 task at a time (this pipeline does not run tasks concurrently)
+#   Self-QA off, so no second call per task
+#   at most 600s of waiting between a task's attempts — 60s, 120s then 240s at
+#     this setting, 420s in total, so the budget still binds nothing
+#
+# The arithmetic worth having written down is the wall clock. Worst case is
+# 30 x (4 x 1800 + 420) = 228,600 seconds, sixty-three and a half hours. What
+# the relay can supply is less: `relay_max_runs: 6` means leg zero plus six
+# more, seven legs, and a leg's step 2 runs under a watchdog of 290 minutes —
+# the `wall_timeout` dispatch input's default and its documented ceiling, below
+# the 350-minute step cap and the 360-minute job cap that sit outside it. Seven
+# legs of 290 minutes is 33.8 hours. So the worst case is not reachable inside
+# the relay budget: if the run ever approached it, it would stop with tasks
+# still pending and need a leg started by hand. That is the honest bound and it
+# is written here so a stall reads as this arithmetic rather than as a fault.
+#
+# It is nowhere near what is expected. `34528903950` ran five tasks and nine
+# turns — three of them refused, four of them retries — in a batch-run job of
+# 19 minutes 34 seconds end to end, image pull and upload included. Six times
+# that is around two hours, comfortably inside a single leg.
+#
+# Resume stays off, and now for two reasons
+# -----------------------------------------
+#
+# The first is exp033's: a resume round gives some tasks more attempts than
+# others depending on where their failures happened to fall.
+#
+# The second was found while reading the code for this file and is worse.
+# `_get_failed_task_ids` in `step2_run_inference.py` selects tasks to resume by
+# **status** — `{"error", "qa_failed", "pending"}` — and never looks at why the
+# task failed. A resume round would therefore re-run a task the provider
+# stopped for content, which is not recovering a lost result: it replaces a
+# benchmark outcome with a different one and raises the score by the
+# difference. The default in `core/experiment_config.py` is 3, so an experiment
+# file that simply omits this key retries filtered tasks quietly. This one does
+# not omit it.
+
+experiment:
+  id: "exp034_codex_foundry_trial30"
+  name: "Codex command-line tool against Foundry — thirty tasks"
+  description: >-
+    The trial stage of the Codex-against-Foundry sequence: the thirty tasks the
+    committed selection rule holds, run one fresh session at a time against the
+    confirmed deployment, with a fourth attempt allowed for the first time. The
+    second stage of five, then thirty, then two hundred and twenty.
+  author: "Hyeonsang Jeon"
+  created_at: "2026-09-10"
+
+control:
+  fixed:
+    - model
+    - temperature
+    - self_qa
+    - execution_environment
+  changed:
+    # Both named in the header. `tasks` is the stage moving from five to thirty;
+    # `retry_budget` is a real second change made in the same run, which is why
+    # this file does not claim to isolate it.
+    - tasks
+    - retry_budget
+
+data:
+  source: "HyeonSang/exp034_codex_foundry_trial30"
+  filter:
+    sector: null
+    occupation: null
+    sample_size: null
+    # Produced by select_trial_run_tasks in core/execution_envelope_tasks.py
+    # and identical to the `trial_run.task_ids` list committed in
+    # experiments/execution_envelope/advance_check_plan.yaml. Written out here
+    # in full rather than described, so the list cannot quietly change.
+    task_ids:
+      - "0ed38524-a4ad-405f-9dee-7b2252659aad"
+      - "01d7e53e-0513-4109-a242-8ccaf442cd21"
+      - "0112fc9b-c3b2-4084-8993-5a4abb1f54f1"
+      - "38889c3b-e3d4-49c8-816a-3cc8e5313aba"
+      - "05389f78-589a-473c-a4ae-67c61050bfca"
+      - "02aa1805-c658-4069-8a6a-02dec146063a"
+      - "0419f1c3-d669-45d0-81cd-f4d5923b06a5"
+      - "105f8ad0-8dd2-422f-9e88-2be5fbd2b215"
+      - "02314fc6-a24e-42f4-a8cd-362cae0f0ec1"
+      - "1d4672c8-b0a7-488f-905f-9ab4e25a19f7"
+      - "11e1b169-5fb6-4d79-8a83-82ddf4987a85"
+      - "0353ee0c-18b5-4ad3-88e8-e001d223e1d7"
+      - "3a4c347c-4aec-43c7-9a54-eb1f816ab1f9"
+      - "11dcc268-cb07-4d3a-a184-c6d7a19349bc"
+      - "0e386e32-df20-4d1f-b536-7159bc409ad5"
+      - "0818571f-5ff7-4d39-9d2c-ced5ae44299e"
+      - "1137e2bb-bdf9-4876-b572-f29b7de5e595"
+      - "045aba2e-4093-42aa-ab7f-159cc538278c"
+      - "3600de06-3f71-4e48-9480-e4828c579924"
+      - "17111c03-aac7-45c2-857d-c06d8223d6ad"
+      - "0ec25916-1b5c-4bfe-93d3-4e103d860f3a"
+      - "3baa0009-5a60-4ae8-ae99-4955cb328ff3"
+      - "15ddd28d-8445-4baa-ac7f-f41372e1344e"
+      - "2c249e0f-4a8c-4f8e-b4f4-6508ba29b34f"
+      - "0e4fe8cd-16d0-4f41-8247-6385b4762582"
+      - "15d37511-75c5-4c7f-81f1-16e00c0d95f3"
+      - "0fad6023-767b-42c1-a1b3-027cd4f583cb"
+      - "4520f882-715a-482d-8e87-1cb3cbdfe975"
+      - "1bff4551-1d54-4e37-b2e0-d5c3f2ea4a45"
+      - "116e791e-890c-42b1-ba90-1db02e8bfd45"
+
+condition_a:
+  name: "Codex command-line tool, Foundry deployment"
+  model:
+    provider: "azure"
+    # The deployment Codex is pointed at. `execution.codex.model` below must
+    # name the same one: `CodexAgentRunner.run` refuses a mismatch rather than
+    # calling one deployment and recording another.
+    deployment: "gpt-5.4"
+    # Codex owns the request. It sets its own sampling and does not take a
+    # temperature or a seed from here, so these are the inherited defaults and
+    # are not claims about what was sent.
+    temperature: 0.0
+    seed: 42
+    reasoning_effort: null
+  prompt:
+    # Byte-for-byte exp033's. The whole point of a stage is that the thing
+    # being scaled up is the thing that was tried at five, and a reworded
+    # instruction would make the prompt the variable instead of the scale.
+    system: |
+      You are completing a professional work task. You have a terminal and a
+      working directory. Do the task and leave the finished deliverables in
+      the working directory as real files.
+    prefix: null
+    body: null
+    suffix: null
+
+  # Off, for the reason exp033 gives: the reviewer would be an Azure client
+  # built here, a second sign-in beside the one Codex performs through its
+  # provider auth command, on a run whose point is that the model reaches the
+  # deployment exactly one documented way.
+  qa:
+    enabled: false
+    max_retries: 0
+    model: null
+    min_score: 6
+    prompt: ""
+
+execution:
+  mode: "codex_foundry"
+
+  codex:
+    # No address here and no variable name either. The address comes from this
+    # run's Azure route, derived by `AzureAIRouteSettings.from_env`.
+    endpoint_from_route: true
+    model: "gpt-5.4"
+    # Both 0 on purpose. Retries live in `max_retries` below, where they are
+    # counted. These two numbers are in the settings fingerprint, so the record
+    # says which run had them.
+    request_max_retries: 0
+    stream_max_retries: 0
+
+  # Wall clock for one turn. Unchanged from exp033.
+  timeout: 1800
+  # Attempts after an infrastructure failure, per task: four at most, each a
+  # fresh session, each counted in the record. Raised from exp033's 2 so that a
+  # task refused for rate waits 240s once before being given up on — the
+  # longest pause ever tested against this deployment is 120s. The model's own
+  # judgement never causes an attempt: Self-QA is off.
+  max_retries: 3
+  # Off. Two reasons, both in the header: it hands out uneven attempt counts,
+  # and it selects by status rather than by reason, so it would re-run a task
+  # the provider stopped for content.
+  resume_max_rounds: 0
+  # Legs, not attempts. Leg zero plus six relays, each running step 2 under the
+  # 290-minute watchdog: 33.8 hours of wall clock against the default three
+  # legs' 14.5, which was written for five tasks. This cannot change a result —
+  # a leg picks up the same task list where the last one left it.
+  relay_max_runs: 6
+
+output:
+  publish_to_hf: false
+  submit_to_evals: false

--- a/batch-runner/tests/test_the_self_qa_comment_says_what_the_value_buys.py
+++ b/batch-runner/tests/test_the_self_qa_comment_says_what_the_value_buys.py
@@ -131,19 +131,20 @@ def test_the_corrected_comment_says_what_the_value_buys(qa_budgets):
 
 
 def test_the_silent_ones_are_still_silent(qa_budgets):
-    """Nineteen say nothing, which is not a claim and so not a defect.
+    """Twenty say nothing, which is not a claim and so not a defect.
 
     Pinned so that a later sweep adding a comment to all of them is a visible
     decision rather than a side effect.
 
-    It was eighteen. exp033 is the nineteenth and it is a new file, not a
-    comment removed from an old one: its self-review is off and its budget is
-    zero, so there is nothing for a comment to describe. The number counts
-    files, so adding one moves it, and moving it here in the same change that
-    adds the file is the visible decision this pin asks for.
+    It was eighteen, then nineteen for exp033. exp034 is the twentieth, and it
+    is a new file for the same reason exp033 was: the thirty-task stage of the
+    same sequence, self-review off and budget zero, so there is nothing for a
+    comment to describe. The number counts files, so adding one moves it, and
+    moving it here in the same change that adds the file is the visible
+    decision this pin asks for.
     """
     silent = [c for _, _, v, c in qa_budgets if v <= 1 and not c.strip()]
-    assert len(silent) == 19
+    assert len(silent) == 20
 
 
 def test_the_infra_retry_comment_was_not_swept_up():


### PR DESCRIPTION
The thirty-task stage of the Codex-against-Foundry sequence: five, then
thirty, then two hundred and twenty. `exp033_codex_foundry_fixed5.yaml` is
untouched — a stage is a separate run with its own record, not an edit to the
stage before it.

## The list is not chosen here

`select_trial_run_tasks` in `core/execution_envelope_tasks.py` produces the
thirty from the committed score-free catalogue, and the same list was written
into `experiments/execution_envelope/advance_check_plan.yaml` under
`run_sizes.trial_run` before any of these runs existed. Checked three ways
before committing:

```
catalog_sha256 : 5f1eca853979b2b4efe6c6ba656545c3a416da920e3faf067d52f5d8ac4ae0eb
file == rule   : True
file == plan30 : True
the 5 inside the 30 : 4 of 5
dropped from the 5  : ['2ea2e5b5']
30 inside 220  : True
```

The dropped one is worth naming. `2ea2e5b5` succeeded in **both** runs of
exp033 — a list assembled to protect a score would not drop a task that passes
twice. Neither direction was available: the rule predates every run and reads
nothing but the catalogue.

The header also corrects something it would have been easy to state loosely.
The mix is 4/4/4 and then 3 each, and that is **not** "the three largest
industries": eight of the nine are the same size, 25 tasks, and only Retail
Trade differs at 20. Thirty over nine is three each with three left over, and
the three go to the first of the eight equals in name order. Retail Trade gets
three like everyone else despite being smallest. The remainder is settled by
the tie-break, not by size.

## What changes, and what that costs the comparison

| | exp033 | exp034 |
|---|---|---|
| `execution.max_retries` | 2 | **3** |
| `execution.relay_max_runs` | (default 3) | **6** |

`relay_max_runs` decides how many times the workflow may hand an unfinished run
to a fresh leg. It cannot add an attempt and cannot change a result.

`max_retries` is a real change made in the same run as the scale change, so
this file does **not** claim to isolate its effect and says so in its header
rather than glossing it. What the run can answer alone, because every attempt
carries its index, is the question worth asking:

> **did a fourth attempt ever convert a task that three attempts had not?**

If no task in thirty does, the extra budget bought nothing and the next stage
drops it. That answer needs no comparison run. The reason to try is that the
fourth attempt is the first to wait 240 s — in both exp033 runs the tasks
refused for rate were refused at 60 s and 120 s, so two minutes is the longest
pause ever tested against this deployment.

## Resume stays off, now for two reasons

The first is exp033's: a resume round hands out uneven attempt counts. The
second is the defect recorded in the release that precedes this one —
`_get_failed_task_ids` selects by **status**, never by reason, so a resume
round would re-run a task the provider stopped for content. That does not
recover a lost result; it replaces a benchmark outcome and raises the score by
the difference. The default in `core/experiment_config.py` is `3`, so a file
that merely omits the key does this quietly. This one does not omit it.

## The wall clock, written down before the run rather than discovered

Worst case is 30 × (4 × 1800 + 420) = 228,600 s — **63.5 hours**. What the
relay supplies is less: `relay_max_runs: 6` means leg zero plus six, and a
leg's step 2 runs under a 290-minute watchdog (the `wall_timeout` input's
default and its documented ceiling, below the 350-minute step cap and the
360-minute job cap outside it). Seven legs × 290 min = **33.8 hours**.

So the worst case is **not reachable** inside the relay budget. A run
approaching it would stop with tasks pending and need a leg started by hand.
That is recorded in the header so a stall reads as this arithmetic rather than
as a fault. It is nowhere near what is expected — `34528903950` ran five tasks
and nine turns end to end in 19 m 34 s.

## A prediction registered before the spend

In exp033 the two tasks that succeeded have the two longest task statements:
2,902 and 3,632 characters against 1,589, 1,548 and 996. At five points that is
as likely coincidence as cause, so the test is written down now, where it can
be wrong:

```
chars  min/max: 801 6029  | median: 2241.5
below 2000     : 11 of 30 -> 36.7 %
```

Under the null — failure having nothing to do with statement length — any given
failure lands in the short group 36.7% of the time. Pile-up means the
association is real. Proportional scatter means it was five points of noise,
and this comment is the record of its having been checked rather than assumed.

The header states plainly what a real association would **not** mean. It would
not automatically be a defect of this run place to engineer around: a shorter
statement is a vaguer task, and a model given a vaguer task wandering into
content a filter stops is a benchmark result and stays one. This run does not
settle that distinction and nothing should be written up as if it did.

## The census bump, and why it is in this PR

`test_the_silent_ones_are_still_silent` counts experiment files whose
self-review budget carries no comment. It goes 19 → 20. Verified by staging the
file and running the test rather than by reading it:

```
tests/test_the_self_qa_comment_says_what_the_value_buys.py:146
    assert len(silent) == 19
E   AssertionError: assert 20 == 19
```

The pin exists so that a sweep commenting all of them is a visible decision.
exp034 is a new file, not a comment removed from an old one — self-review off,
budget zero, nothing for a comment to describe — and the pin asks for the bump
to be made in the change that adds the file. Same reasoning as exp033's bump
from eighteen.

## Verification

`ExperimentConfig.from_yaml(...).validate()` returns `[]`, and the parsed values
are what the file says: 30 unique ids, `codex_foundry`, `timeout: 1800`,
`max_retries: 3`, `resume_max_rounds: 0`, `qa.enabled: False`, deployment
`gpt-5.4`.

The gates were checked against this file before it was written rather than
after it went red. `advance-check` reads `advance_check_plan.yaml` and exactly
three named paths under `experiments/execution_envelope/` (`exp030`, `exp031`,
`exp032`); it does not glob the experiments directory, so a fourth file is
outside what it inspects.

Full backend suite green with the file staged.

## Files and ownership

- `batch-runner/experiments/exp034_codex_foundry_trial30.yaml` — new, A's.
- `batch-runner/tests/test_the_self_qa_comment_says_what_the_value_buys.py` —
  one pinned number and its docstring.
- `CHANGELOG.md` — shared; additive under a dated heading.

No shared executor, config, ledger, CI or grading file is touched. No
credential is read, logged or stored, and no isolation is weakened.
