### PR TITLE
feat(agentic-v2): D3b — sweep the declared manifest, and the runner that spends stage D

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,13 @@ batch-runner/scripts/*
 # this box is not, so the host gets it by cloning the repository.
 !batch-runner/scripts/run_agentic_c3_attacks.py
 
+# Stage D's paid run. Both of the reasons above at once: it needs a federated
+# token, which only a workflow job holds, and it needs a host that boots, which
+# only the execution host is. Neither place is a working copy, and both reach
+# the repository by cloning it. Its --dry-run path runs in a pull request and is
+# held by tests/test_run_agentic_stage_d_probe.py.
+!batch-runner/scripts/run_agentic_stage_d_probe.py
+
 
 # Experiment report HTML (skews GitHub language stats)
 batch-runner/results/*/report/report.html

--- a/batch-runner/core/agentic_v2_stage_d_probe.py
+++ b/batch-runner/core/agentic_v2_stage_d_probe.py
@@ -45,10 +45,37 @@ no reply body, no reasoning. What is added here is the boot record — what ran,
 under which machine name, for how long it was allowed, and whether the workspace
 came back — because a run whose commands cannot be accounted for is not evidence
 of anything.
+
+**The substrate manifest is a declaration, and this module says so out loud.**
+``sandbox/agentic_v2_capabilities.json`` lists twenty commands as
+``{"name": "Rscript", "capability": "data-science", "probe": ["Rscript",
+"--version"]}`` — probe command *lines*, with no versions and no hashes — and a
+``supply_chain`` block naming policy profiles (``cosign-offline-v1``,
+``buildkit-max-v1``) rather than the result of applying them. It says what an
+image ought to contain and how to check. It is not the check. The repository
+already keeps that distinction: the measurement is a separate *capability
+receipt*, validated by
+:func:`core.agentic_v2_substrate.validate_capability_receipt` against the
+manifest, and it carries a status from ``{"verified", "failed", "not_run"}``.
+
+Which matters here for a specific and checkable reason. The receipt that reads
+``verified`` for those twenty commands was measured on a locally built candidate
+(``sandbox/v2/README.md``: image ID ``sha256:e47537b8…``, OCI manifest
+``sha256:0064ce70…``) which was never pushed anywhere. The digest this probe is
+handed in practice, ``sha256:ee6ef798…``, is the one ``sandbox/v2/parent.lock.json``
+pins, and that is the *parent* — the V1 image the candidate is built **from**.
+So the image stage D can actually fetch is not the image the capability evidence
+describes, and per the same README, signature and provenance are ``not_run`` for
+both. :func:`capability_evidence_for` reads that off the lock file rather than
+asserting it, and the answer travels in the record, so a stage D result can
+never be read as a claim that the image it booted was verified. Computing a
+sha256 of a file this repository built is an identity check on that file. It is
+not a supplier signature, and nothing here presents it as one.
 """
 
 from __future__ import annotations
 
+import json
 import shutil
 from dataclasses import dataclass, field
 from decimal import Decimal
@@ -135,10 +162,71 @@ class ProbeToolsAreWrong(RuntimeError):
 class ProbeCannotDescribeItself(RuntimeError):
     """The backend could not say what it is, so no model call is worth making.
 
-    Raised before spending. A run whose substrate manifest is missing produces a
-    record with no verified image behind it — the numbers would be real and
-    would refer to nothing checkable, which is worse than not having them.
+    Raised before spending. Without the substrate manifest the run cannot name
+    the declaration its image was built against, so the numbers would be real
+    and would refer to nothing nameable — which is worse than not having them.
+    Naming it is not verifying it: see :func:`capability_evidence_for` for what
+    is actually known about the image being booted, which is usually
+    ``not_run``.
     """
+
+
+#: Where the digest of the image this repository can actually fetch is pinned.
+PARENT_LOCK = Path("sandbox/v2/parent.lock.json")
+
+
+def capability_evidence_for(
+    image: GuestImage, *, lock_path: str | Path = PARENT_LOCK
+) -> dict[str, Any]:
+    """What is known — measured, not declared — about the image being booted.
+
+    Returns a status in the vocabulary
+    :mod:`core.agentic_v2_supply_chain` already uses for evidence items:
+    ``verified``, ``failed``, ``not_run``, plus ``unknown`` for a digest this
+    repository has no record of at all.
+
+    The only answer this can currently return for a real run is ``not_run``, and
+    that is the point of having it. The capability receipt that reads
+    ``verified`` was measured on a candidate image that was never pushed; the
+    digest ``parent.lock.json`` pins is the parent it was built from. A record
+    that named an image and said nothing else would be read as though the
+    evidence followed the name. This makes the gap a field.
+
+    Never raises. A missing or unreadable lock file is itself an answer, and
+    losing a whole probe run over it would be a poor trade.
+    """
+    digest = (image.digest or "").strip()
+    try:
+        pinned = json.loads(Path(lock_path).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as unreadable:
+        return {
+            "status": "unknown",
+            "subject": digest,
+            "grounds": (
+                f"{Path(lock_path).as_posix()} could not be read ({unreadable}), "
+                "so nothing is known about this digest"
+            ),
+        }
+    if digest and digest == pinned.get("manifest_digest"):
+        return {
+            "status": "not_run",
+            "subject": digest,
+            "grounds": (
+                "this is the parent image parent.lock.json pins, not the "
+                "candidate the capability receipt was measured on, and the "
+                "receipt was never measured against this digest. Signature and "
+                "provenance are not_run for it either"
+            ),
+            "source_revision": pinned.get("source_revision"),
+        }
+    return {
+        "status": "unknown",
+        "subject": digest,
+        "grounds": (
+            "this digest is neither the pinned parent nor anything this "
+            "repository holds a receipt for"
+        ),
+    }
 
 
 def check_probe_tools(tools: Sequence[str] = PROBE_TOOLS) -> list[str]:
@@ -205,6 +293,7 @@ class StageDProbeOutcome:
     detail: str
     guest_image: Mapping[str, str]
     substrate_manifest_sha256: Optional[str] = None
+    image_evidence: Mapping[str, Any] = field(default_factory=dict)
     boots: tuple[Mapping[str, Any], ...] = ()
     machines: tuple[Mapping[str, Any], ...] = ()
     collected: Mapping[str, Any] = field(default_factory=dict)
@@ -297,6 +386,7 @@ class StageDProbeOutcome:
             "detail": self.detail,
             "guest_image": dict(self.guest_image),
             "substrate_manifest_sha256": self.substrate_manifest_sha256,
+            "image_evidence": dict(self.image_evidence),
             "boots": [dict(row) for row in self.boots],
             "machines": [dict(row) for row in self.machines],
             "collected": dict(self.collected),
@@ -341,7 +431,10 @@ def run_stage_d_probe(
     Refuses before spending anything if the tool list is wrong or the backend
     cannot describe itself. Both are cheap to establish and neither is cheaper
     later: the first would let a probe reach the grader, and the second would
-    produce a paid record with no verified image behind it.
+    produce a paid record that cannot name the declaration its image was built
+    against. What is *known* about that image — as opposed to declared about it —
+    is recorded separately by :func:`capability_evidence_for`, and for the
+    digest this repository can fetch the answer is ``not_run``.
 
     **The workspace is collected before it is destroyed.** ``close()`` purges
     the work directory, which is the ``workdir: ephemeral-quota`` rule doing its
@@ -431,6 +524,7 @@ def run_stage_d_probe(
             substrate_manifest_sha256=(
                 substrate_manifest.sha256 if substrate_manifest is not None else None
             ),
+            image_evidence=capability_evidence_for(image),
             boots=tuple(dict(row) for row in backend.boots),
             machines=tuple(
                 dict(row) for row in getattr(boot_one_command, "record", ())

--- a/batch-runner/sandbox/v2/declared-command-sweep.json
+++ b/batch-runner/sandbox/v2/declared-command-sweep.json
@@ -1,0 +1,1368 @@
+{
+  "artifact": "agentic-v2-declared-command-sweep-record",
+  "artifact_version": "1.0",
+  "candidate": {
+    "absent": 0,
+    "artifact": "agentic-v2-declared-command-sweep",
+    "artifact_version": "1.0",
+    "declared": {
+      "commands": 20,
+      "font_families": 3,
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux",
+        "python": "3.11"
+      },
+      "python_modules": 13
+    },
+    "host": {
+      "cgroup_version": 1,
+      "kernel": "3.10.102",
+      "machine": "x86_64",
+      "runtime": "docker",
+      "runtime_version": "20.10.3",
+      "system": "Linux"
+    },
+    "image": "sha256:94ea6cb4379ea2537be7875248dad5dc304bbf17f7c99682570b2844156ba1c7",
+    "is_not": [
+      "a capability receipt",
+      "a signature or provenance verification",
+      "a vulnerability scan",
+      "an isolation or containment measurement"
+    ],
+    "manifest_path": "/tmp/wtB485/batch-runner/sandbox/agentic_v2_capabilities.json",
+    "manifest_sha256": "fa76625f3fc9bb46c595f7c542132facb91c824bb5e51c7db9ea2d4fcb345a1f",
+    "present": 40,
+    "probes_answered": 40,
+    "probes_declared": 40,
+    "records": [
+      {
+        "answered": true,
+        "argv": [
+          "python",
+          "--version"
+        ],
+        "capability": "runtime",
+        "first_line": "Python 3.11.15",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "python",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "--version"
+        ],
+        "capability": "runtime",
+        "first_line": "Python 3.11.15",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "python3",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "sh",
+          "-c",
+          "echo ok"
+        ],
+        "capability": "runtime",
+        "first_line": "ok",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "sh",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "uname",
+          "-srm"
+        ],
+        "capability": "runtime",
+        "first_line": "Linux 3.10.102 x86_64",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "uname",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "Rscript",
+          "--version"
+        ],
+        "capability": "data-science",
+        "first_line": "Rscript (R) version 4.2.2 Patched (2022-11-10 r83330)",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "Rscript",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "bash",
+          "--version"
+        ],
+        "capability": "shell",
+        "first_line": "GNU bash, version 5.2.15(1)-release (x86_64-pc-linux-gnu)",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "bash",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "chromium",
+          "--version"
+        ],
+        "capability": "browser-local",
+        "first_line": "Chromium 150.0.7871.181 built on Debian GNU/Linux 12 (bookworm)",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "chromium",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "cmake",
+          "--version"
+        ],
+        "capability": "compilers",
+        "first_line": "cmake version 3.25.1",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "cmake",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "ffmpeg",
+          "-version"
+        ],
+        "capability": "media",
+        "first_line": "ffmpeg version 5.1.9-0+deb12u1 Copyright (c) 2000-2026 the FFmpeg developers",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "ffmpeg",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "ffprobe",
+          "-version"
+        ],
+        "capability": "media",
+        "first_line": "ffprobe version 5.1.9-0+deb12u1 Copyright (c) 2007-2026 the FFmpeg developers",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "ffprobe",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "g++",
+          "--version"
+        ],
+        "capability": "compilers",
+        "first_line": "g++ (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "g++",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "gcc",
+          "--version"
+        ],
+        "capability": "compilers",
+        "first_line": "gcc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "gcc",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "gdalinfo",
+          "--version"
+        ],
+        "capability": "gis",
+        "first_line": "GDAL 3.6.2, released 2023/01/02",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "gdalinfo",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "gfortran",
+          "--version"
+        ],
+        "capability": "compilers",
+        "first_line": "GNU Fortran (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "gfortran",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "libreoffice",
+          "--version"
+        ],
+        "capability": "documents",
+        "first_line": "LibreOffice 7.4.7.2 40(Build:2)",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "libreoffice",
+        "present": true,
+        "returncode": 0,
+        "stderr": "(process:75): dconf-CRITICAL **: 22:32:23.278: unable to create directory '/work/.cache/dconf': Read-only file system.  dconf will not work properly."
+      },
+      {
+        "answered": true,
+        "argv": [
+          "make",
+          "--version"
+        ],
+        "capability": "compilers",
+        "first_line": "GNU Make 4.3",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "make",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "node",
+          "--version"
+        ],
+        "capability": "programming",
+        "first_line": "v18.20.4",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "node",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "npm",
+          "--version"
+        ],
+        "capability": "programming",
+        "first_line": "9.2.0",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "npm",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "ogr2ogr",
+          "--version"
+        ],
+        "capability": "gis",
+        "first_line": "GDAL 3.6.2, released 2023/01/02",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "ogr2ogr",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "pandoc",
+          "--version"
+        ],
+        "capability": "documents",
+        "first_line": "pandoc 2.17.1.1",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "pandoc",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "pdftoppm",
+          "-v"
+        ],
+        "capability": "pdf",
+        "first_line": "pdftoppm version 22.12.0",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "pdftoppm",
+        "present": true,
+        "returncode": 0,
+        "stderr": "pdftoppm version 22.12.0\nCopyright 2005-2022 The Poppler Developers - http://poppler.freedesktop.org\nCopyright 1996-2011, 2022 Glyph & Cog, LLC"
+      },
+      {
+        "answered": true,
+        "argv": [
+          "pdftotext",
+          "-v"
+        ],
+        "capability": "pdf",
+        "first_line": "pdftotext version 22.12.0",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "pdftotext",
+        "present": true,
+        "returncode": 0,
+        "stderr": "pdftotext version 22.12.0\nCopyright 2005-2022 The Poppler Developers - http://poppler.freedesktop.org\nCopyright 1996-2011, 2022 Glyph & Cog, LLC"
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python",
+          "--version"
+        ],
+        "capability": "programming",
+        "first_line": "Python 3.11.15",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "python",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "tesseract",
+          "--version"
+        ],
+        "capability": "ocr",
+        "first_line": "tesseract 5.3.0",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "tesseract",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import PIL as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "documents",
+        "first_line": "12.3.0",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:PIL",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import av as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "media",
+        "first_line": "18.0.0",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:av",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import ezdxf as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "cad-dxf",
+        "first_line": "1.4.3",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:ezdxf",
+        "present": true,
+        "returncode": 0,
+        "stderr": "Cannot create cache home directory: '/work/.cache/ezdxf', cache files will not be saved.\nSee also issue https://github.com/mozman/ezdxf/issues/923."
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import geopandas as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "gis",
+        "first_line": "1.1.4",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:geopandas",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import matplotlib as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "data-science",
+        "first_line": "3.11.0",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:matplotlib",
+        "present": true,
+        "returncode": 0,
+        "stderr": "mkdir -p failed for path /work/.cache/matplotlib: [Errno 30] Read-only file system: '/work/.cache/matplotlib'\nMatplotlib created a temporary cache directory at /tmp/matplotlib-g9ot3ayn because there was an issue with the default path ({configdir}); it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and t"
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import numpy as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "data-science",
+        "first_line": "2.4.6",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:numpy",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import openpyxl as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "spreadsheets",
+        "first_line": "3.1.5",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:openpyxl",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import pandas as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "data-science",
+        "first_line": "3.0.3",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:pandas",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import pptx as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "presentations",
+        "first_line": "1.0.2",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:pptx",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import reportlab as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "pdf",
+        "first_line": "5.0.0",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:reportlab",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import scipy as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "data-science",
+        "first_line": "1.17.1",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:scipy",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import sklearn as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "machine-learning",
+        "first_line": "1.9.0",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:sklearn",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import weasyprint as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "documents",
+        "first_line": "69.0",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:weasyprint",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "fc-match",
+          "-f",
+          "%{family}|%{file}",
+          "DejaVu Sans"
+        ],
+        "capability": "fonts",
+        "first_line": "DejaVu Sans|/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        "grounds": "the probe exited 0",
+        "kind": "font_family",
+        "name": "font:DejaVu Sans",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "fc-match",
+          "-f",
+          "%{family}|%{file}",
+          "Liberation Sans"
+        ],
+        "capability": "fonts",
+        "first_line": "Liberation Sans|/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+        "grounds": "the probe exited 0",
+        "kind": "font_family",
+        "name": "font:Liberation Sans",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "fc-match",
+          "-f",
+          "%{family}|%{file}",
+          "Noto Sans CJK KR"
+        ],
+        "capability": "fonts",
+        "first_line": "Noto Sans CJK KR|/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+        "grounds": "the probe exited 0",
+        "kind": "font_family",
+        "name": "font:Noto Sans CJK KR",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      }
+    ],
+    "runtime_argv": [
+      "docker",
+      "run",
+      "--rm",
+      "--network",
+      "none",
+      "--read-only",
+      "--tmpfs",
+      "/tmp",
+      "--entrypoint",
+      "/bin/sh",
+      "sha256:94ea6cb4379ea2537be7875248dad5dc304bbf17f7c99682570b2844156ba1c7",
+      "-c",
+      "<driver>"
+    ],
+    "sweep_returncode": 0,
+    "sweep_seconds": 23.89,
+    "sweep_stderr": ""
+  },
+  "capability_receipt_status": "not_run",
+  "host_caveat": "Both sweeps were taken on a cgroup v1, kernel 3.10.102 host. Command presence inside an image does not depend on that, but the isolation policy stage D runs under requires cgroup v2, so nothing here should be read as an isolation or containment result. Re-run on the Azure host before treating these as the numbers stage D executes against.",
+  "is_not": [
+    "a capability receipt",
+    "a signature or provenance verification",
+    "a vulnerability scan",
+    "an isolation or containment measurement"
+  ],
+  "parent": {
+    "absent": 6,
+    "artifact": "agentic-v2-declared-command-sweep",
+    "artifact_version": "1.0",
+    "declared": {
+      "commands": 20,
+      "font_families": 3,
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux",
+        "python": "3.11"
+      },
+      "python_modules": 13
+    },
+    "host": {
+      "cgroup_version": 1,
+      "kernel": "3.10.102",
+      "machine": "x86_64",
+      "runtime": "docker",
+      "runtime_version": "20.10.3",
+      "system": "Linux"
+    },
+    "image": "ghcr.io/hyeonsangjeon/gdpval-sandbox@sha256:ee6ef798631d3c3aeaed28658c640e6f5d021677449852bf2e1f18be5bd24edb",
+    "is_not": [
+      "a capability receipt",
+      "a signature or provenance verification",
+      "a vulnerability scan",
+      "an isolation or containment measurement"
+    ],
+    "manifest_path": "/tmp/wtB485/batch-runner/sandbox/agentic_v2_capabilities.json",
+    "manifest_sha256": "fa76625f3fc9bb46c595f7c542132facb91c824bb5e51c7db9ea2d4fcb345a1f",
+    "present": 34,
+    "probes_answered": 40,
+    "probes_declared": 40,
+    "records": [
+      {
+        "answered": true,
+        "argv": [
+          "python",
+          "--version"
+        ],
+        "capability": "runtime",
+        "first_line": "Python 3.11.15",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "python",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "--version"
+        ],
+        "capability": "runtime",
+        "first_line": "Python 3.11.15",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "python3",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "sh",
+          "-c",
+          "echo ok"
+        ],
+        "capability": "runtime",
+        "first_line": "ok",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "sh",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "uname",
+          "-srm"
+        ],
+        "capability": "runtime",
+        "first_line": "Linux 3.10.102 x86_64",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "uname",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "Rscript",
+          "--version"
+        ],
+        "capability": "data-science",
+        "first_line": "/bin/sh: 39: Rscript: not found",
+        "grounds": "the probe exited 127",
+        "kind": "command",
+        "name": "Rscript",
+        "present": false,
+        "returncode": 127,
+        "stderr": "/bin/sh: 39: Rscript: not found"
+      },
+      {
+        "answered": true,
+        "argv": [
+          "bash",
+          "--version"
+        ],
+        "capability": "shell",
+        "first_line": "GNU bash, version 5.2.15(1)-release (x86_64-pc-linux-gnu)",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "bash",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "chromium",
+          "--version"
+        ],
+        "capability": "browser-local",
+        "first_line": "/bin/sh: 57: chromium: not found",
+        "grounds": "the probe exited 127",
+        "kind": "command",
+        "name": "chromium",
+        "present": false,
+        "returncode": 127,
+        "stderr": "/bin/sh: 57: chromium: not found"
+      },
+      {
+        "answered": true,
+        "argv": [
+          "cmake",
+          "--version"
+        ],
+        "capability": "compilers",
+        "first_line": "/bin/sh: 66: cmake: not found",
+        "grounds": "the probe exited 127",
+        "kind": "command",
+        "name": "cmake",
+        "present": false,
+        "returncode": 127,
+        "stderr": "/bin/sh: 66: cmake: not found"
+      },
+      {
+        "answered": true,
+        "argv": [
+          "ffmpeg",
+          "-version"
+        ],
+        "capability": "media",
+        "first_line": "ffmpeg version 5.1.9-0+deb12u1 Copyright (c) 2000-2026 the FFmpeg developers",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "ffmpeg",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "ffprobe",
+          "-version"
+        ],
+        "capability": "media",
+        "first_line": "ffprobe version 5.1.9-0+deb12u1 Copyright (c) 2007-2026 the FFmpeg developers",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "ffprobe",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "g++",
+          "--version"
+        ],
+        "capability": "compilers",
+        "first_line": "g++ (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "g++",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "gcc",
+          "--version"
+        ],
+        "capability": "compilers",
+        "first_line": "gcc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "gcc",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "gdalinfo",
+          "--version"
+        ],
+        "capability": "gis",
+        "first_line": "GDAL 3.6.2, released 2023/01/02",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "gdalinfo",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "gfortran",
+          "--version"
+        ],
+        "capability": "compilers",
+        "first_line": "GNU Fortran (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "gfortran",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "libreoffice",
+          "--version"
+        ],
+        "capability": "documents",
+        "first_line": "LibreOffice 7.4.7.2 40(Build:2)",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "libreoffice",
+        "present": true,
+        "returncode": 0,
+        "stderr": "(process:59): dconf-CRITICAL **: 22:31:15.108: unable to create directory '/root/.cache/dconf': Read-only file system.  dconf will not work properly."
+      },
+      {
+        "answered": true,
+        "argv": [
+          "make",
+          "--version"
+        ],
+        "capability": "compilers",
+        "first_line": "GNU Make 4.3",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "make",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "node",
+          "--version"
+        ],
+        "capability": "programming",
+        "first_line": "/bin/sh: 147: node: not found",
+        "grounds": "the probe exited 127",
+        "kind": "command",
+        "name": "node",
+        "present": false,
+        "returncode": 127,
+        "stderr": "/bin/sh: 147: node: not found"
+      },
+      {
+        "answered": true,
+        "argv": [
+          "npm",
+          "--version"
+        ],
+        "capability": "programming",
+        "first_line": "/bin/sh: 156: npm: not found",
+        "grounds": "the probe exited 127",
+        "kind": "command",
+        "name": "npm",
+        "present": false,
+        "returncode": 127,
+        "stderr": "/bin/sh: 156: npm: not found"
+      },
+      {
+        "answered": true,
+        "argv": [
+          "ogr2ogr",
+          "--version"
+        ],
+        "capability": "gis",
+        "first_line": "GDAL 3.6.2, released 2023/01/02",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "ogr2ogr",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "pandoc",
+          "--version"
+        ],
+        "capability": "documents",
+        "first_line": "pandoc 2.17.1.1",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "pandoc",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "pdftoppm",
+          "-v"
+        ],
+        "capability": "pdf",
+        "first_line": "pdftoppm version 22.12.0",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "pdftoppm",
+        "present": true,
+        "returncode": 0,
+        "stderr": "pdftoppm version 22.12.0\nCopyright 2005-2022 The Poppler Developers - http://poppler.freedesktop.org\nCopyright 1996-2011, 2022 Glyph & Cog, LLC"
+      },
+      {
+        "answered": true,
+        "argv": [
+          "pdftotext",
+          "-v"
+        ],
+        "capability": "pdf",
+        "first_line": "pdftotext version 22.12.0",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "pdftotext",
+        "present": true,
+        "returncode": 0,
+        "stderr": "pdftotext version 22.12.0\nCopyright 2005-2022 The Poppler Developers - http://poppler.freedesktop.org\nCopyright 1996-2011, 2022 Glyph & Cog, LLC"
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python",
+          "--version"
+        ],
+        "capability": "programming",
+        "first_line": "Python 3.11.15",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "python",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "tesseract",
+          "--version"
+        ],
+        "capability": "ocr",
+        "first_line": "tesseract 5.3.0",
+        "grounds": "the probe exited 0",
+        "kind": "command",
+        "name": "tesseract",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import PIL as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "documents",
+        "first_line": "12.3.0",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:PIL",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import av as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "media",
+        "first_line": "18.0.0",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:av",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import ezdxf as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "cad-dxf",
+        "first_line": "Traceback (most recent call last):",
+        "grounds": "the probe exited 1",
+        "kind": "python_module",
+        "name": "python3:ezdxf",
+        "present": false,
+        "returncode": 1,
+        "stderr": "Traceback (most recent call last):\n  File \"<string>\", line 1, in <module>\nModuleNotFoundError: No module named 'ezdxf'"
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import geopandas as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "gis",
+        "first_line": "1.1.4",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:geopandas",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import matplotlib as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "data-science",
+        "first_line": "3.11.0",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:matplotlib",
+        "present": true,
+        "returncode": 0,
+        "stderr": "mkdir -p failed for path /root/.config/matplotlib: [Errno 30] Read-only file system: '/root/.config'\nMatplotlib created a temporary cache directory at /tmp/matplotlib-tlfun6nv because there was an issue with the default path ({configdir}); it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better "
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import numpy as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "data-science",
+        "first_line": "2.4.6",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:numpy",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import openpyxl as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "spreadsheets",
+        "first_line": "3.1.5",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:openpyxl",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import pandas as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "data-science",
+        "first_line": "3.0.3",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:pandas",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import pptx as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "presentations",
+        "first_line": "1.0.2",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:pptx",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import reportlab as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "pdf",
+        "first_line": "5.0.0",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:reportlab",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import scipy as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "data-science",
+        "first_line": "1.17.1",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:scipy",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import sklearn as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "machine-learning",
+        "first_line": "1.9.0",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:sklearn",
+        "present": true,
+        "returncode": 0,
+        "stderr": ""
+      },
+      {
+        "answered": true,
+        "argv": [
+          "python3",
+          "-c",
+          "import weasyprint as m; print(getattr(m, '__version__', 'no __version__'))"
+        ],
+        "capability": "documents",
+        "first_line": "69.0",
+        "grounds": "the probe exited 0",
+        "kind": "python_module",
+        "name": "python3:weasyprint",
+        "present": true,
+        "returncode": 0,
+        "stderr": "Fontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories"
+      },
+      {
+        "answered": true,
+        "argv": [
+          "fc-match",
+          "-f",
+          "%{family}|%{file}",
+          "DejaVu Sans"
+        ],
+        "capability": "fonts",
+        "first_line": "DejaVu Sans|/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        "grounds": "the probe exited 0",
+        "kind": "font_family",
+        "name": "font:DejaVu Sans",
+        "present": true,
+        "returncode": 0,
+        "stderr": "Fontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories"
+      },
+      {
+        "answered": true,
+        "argv": [
+          "fc-match",
+          "-f",
+          "%{family}|%{file}",
+          "Liberation Sans"
+        ],
+        "capability": "fonts",
+        "first_line": "Liberation Sans|/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+        "grounds": "the probe exited 0",
+        "kind": "font_family",
+        "name": "font:Liberation Sans",
+        "present": true,
+        "returncode": 0,
+        "stderr": "Fontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories"
+      },
+      {
+        "answered": true,
+        "argv": [
+          "fc-match",
+          "-f",
+          "%{family}|%{file}",
+          "Noto Sans CJK KR"
+        ],
+        "capability": "fonts",
+        "first_line": "Noto Sans CJK KR|/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+        "grounds": "the probe exited 0",
+        "kind": "font_family",
+        "name": "font:Noto Sans CJK KR",
+        "present": true,
+        "returncode": 0,
+        "stderr": "Fontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories\nFontconfig error: No writable cache directories"
+      }
+    ],
+    "runtime_argv": [
+      "docker",
+      "run",
+      "--rm",
+      "--network",
+      "none",
+      "--read-only",
+      "--tmpfs",
+      "/tmp",
+      "--entrypoint",
+      "/bin/sh",
+      "ghcr.io/hyeonsangjeon/gdpval-sandbox@sha256:ee6ef798631d3c3aeaed28658c640e6f5d021677449852bf2e1f18be5bd24edb",
+      "-c",
+      "<driver>"
+    ],
+    "sweep_returncode": 0,
+    "sweep_seconds": 48.02,
+    "sweep_stderr": ""
+  },
+  "provenance_status": "not_run",
+  "signature_status": "not_run",
+  "taken_on": "2026-09-10",
+  "the_gap_this_measures": "parent is the image parent.lock.json pins and the only one this repository can fetch. candidate is a local build carrying the professional-work layer and exists nowhere else. The difference between their two answer sets is that layer, measured rather than assumed.",
+  "what_this_is": "Two sweeps of the declared substrate manifest against two images that actually exist on this box. Each answers, per declared command, module and font family, whether the probe in the manifest exits 0 inside that image. That is the whole claim.",
+  "why_those_are_not_run": "The capability receipt that reads 'verified' in sandbox/v2/README.md was measured on candidate image sha256:e47537b8..., which was never pushed and is not present on this host. Neither image below has a receipt, a signature or a provenance attestation. A sha256 this repository computed over bytes it fetched is an identity for those bytes; it is not a supplier's assertion about what is in them."
+}

--- a/batch-runner/sandbox/v2/probe_declared_commands.py
+++ b/batch-runner/sandbox/v2/probe_declared_commands.py
@@ -1,0 +1,458 @@
+"""Check one exact image against what the substrate manifest declares.
+
+``sandbox/agentic_v2_capabilities.json`` is a **declaration**. It lists twenty
+commands as ``{"name": "Rscript", "capability": "data-science", "probe":
+["Rscript", "--version"]}`` — an argv to run, with no version and no hash — and
+thirteen Python modules by name alone. It says what an image ought to hold and
+how to find out. It is not the finding out.
+
+This script does the finding out, for one image, on one host, and writes down
+which host. That last part is not bookkeeping: a probe result belongs to the
+place it was taken, and a sweep run on a 3.10 kernel and a sweep run on the
+Azure host are two different measurements even when the image is the same
+bytes.
+
+**Why this exists separately from** :mod:`sandbox.v2.image_probe`. That module
+produces a *capability receipt* — the artifact
+:func:`core.agentic_v2_substrate.validate_capability_receipt` accepts — and it
+runs from inside the image, reading ``/opt/gdpval/v2/capabilities.json``, which
+only the built candidate carries. The candidate that receipt was measured on
+(``sandbox/v2/README.md``: image ID ``sha256:e47537b8…``) was never pushed
+anywhere. The image this repository can actually fetch is the one
+``parent.lock.json`` pins, and that is the *parent* the candidate is built from.
+So the receipt exists and does not describe the reachable image, and the
+reachable image has never been swept at all.
+
+This produces the narrower thing that is honestly available: a per-command
+answer about a reachable image. It is deliberately **not** a capability receipt,
+and it does not validate as one. Naming it one would be the same overclaim in a
+new place.
+
+**What a result here is not.** Not a signature check, not a provenance
+attestation, not a vulnerability scan, and not an isolation measurement. The
+digest is the registry's content address for the bytes fetched — an identity for
+what was pulled, not a supplier's assertion about what is in it. Signature and
+provenance remain ``not_run``.
+
+A command that is absent is recorded as absent. Nothing is skipped, because a
+skipped probe and a failed probe read the same in a summary and mean opposite
+things.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import re
+import shlex
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+
+BATCH_ROOT = Path(__file__).resolve().parents[2]
+if str(BATCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_ROOT))
+
+DEFAULT_MANIFEST = BATCH_ROOT / "sandbox" / "agentic_v2_capabilities.json"
+DEFAULT_LOCK = BATCH_ROOT / "sandbox" / "v2" / "parent.lock.json"
+
+#: Marks the driver's records apart from whatever a probe prints.
+#:
+#: Long and unlikely rather than short and tidy: one of the things being probed
+#: is a shell, and a delimiter a probe could plausibly emit would let its own
+#: output be read as the driver's framing.
+MARK = "###gdpval-probe-8f2a###"
+
+#: Bytes kept from each stream. A probe that prints a manual is still a probe
+#: that answered, and the answer is in the first line.
+KEEP_BYTES = 2000
+
+PROBE_TIMEOUT_SECONDS = 120
+
+#: Asked of every image regardless of the manifest.
+#:
+#: ``python`` versus ``python3`` is the specific unknown: the manifest declares
+#: ``platform.python == "3.11"`` and never says which name reaches it, and a
+#: command built around the wrong one fails in a way that reads as the model
+#: writing a broken command. Both are asked, always, and both answers are kept.
+ALWAYS_ASKED: tuple[dict[str, Any], ...] = (
+    {"name": "python", "capability": "runtime", "probe": ["python", "--version"]},
+    {"name": "python3", "capability": "runtime", "probe": ["python3", "--version"]},
+    {"name": "sh", "capability": "runtime", "probe": ["sh", "-c", "echo ok"]},
+    {"name": "uname", "capability": "runtime", "probe": ["uname", "-srm"]},
+)
+
+
+class SweepRefused(RuntimeError):
+    """The sweep cannot be run as asked, so no image was started."""
+
+
+_IMAGE_ID = re.compile(r"sha256:[0-9a-f]{64}\Z", re.ASCII)
+
+
+def _is_pinned(image: str) -> bool:
+    """Whether this reference names one exact set of bytes.
+
+    Two forms count. ``repo@sha256:…`` is a registry content address, which is
+    what a pushed image is pinned by. A bare ``sha256:…`` is a local image ID,
+    which is what an image that was *built* and never pushed has instead — and
+    that is the case that matters here, because the candidate carrying the
+    professional-work layer was never pushed anywhere. ``sandbox/v2/README.md``
+    identifies it the same way.
+
+    A tag is not pinning. It names whatever is behind it at the moment of the
+    run, which makes a result that cannot be checked afterwards.
+    """
+    return "@sha256:" in image or bool(_IMAGE_ID.fullmatch(image.strip()))
+
+
+def _shell_driver(probes: Sequence[Mapping[str, Any]]) -> str:
+    """One shell script that runs every probe and frames each answer.
+
+    One container rather than one per probe, because twenty container starts
+    measure the daemon more than the image. Each probe still gets its own
+    ``execve``, its own exit status and its own two streams — the saving is in
+    the starts, not in the isolation between answers.
+
+    ``shlex.quote`` on every argument: these come from a file in this repository
+    rather than from anywhere untrusted, which is a reason to expect them to be
+    ordinary, not a reason to concatenate them unquoted.
+    """
+    lines = ["exec 2>/dev/null"]
+    for probe in probes:
+        argv = " ".join(shlex.quote(str(part)) for part in probe["probe"])
+        name = probe["name"]
+        lines.extend(
+            [
+                f"printf '%s\\n' {shlex.quote(MARK + 'BEGIN ' + name)}",
+                f"{argv} >/tmp/probe.out 2>/tmp/probe.err",
+                "status=$?",
+                f"printf '%s%s\\n' {shlex.quote(MARK + 'RC ')} \"$status\"",
+                f"printf '%s\\n' {shlex.quote(MARK + 'OUT')}",
+                f"head -c {KEEP_BYTES} /tmp/probe.out 2>/dev/null || true",
+                f"printf '\\n%s\\n' {shlex.quote(MARK + 'ERR')}",
+                f"head -c {KEEP_BYTES} /tmp/probe.err 2>/dev/null || true",
+                f"printf '\\n%s\\n' {shlex.quote(MARK + 'END')}",
+            ]
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _module_probes(modules: Iterable[Mapping[str, Any]], interpreter: str) -> list[dict]:
+    """Import each declared module and print whatever version it admits to.
+
+    The import is the answer; the version is a courtesy. A module that imports
+    and has no ``__version__`` is present, and recording it as unknown-version
+    is right where recording it as absent would be wrong.
+    """
+    built = []
+    for module in modules:
+        name = str(module["name"])
+        built.append(
+            {
+                "name": f"{interpreter}:{name}",
+                "capability": module.get("capability", ""),
+                "kind": "python_module",
+                "module": name,
+                "interpreter": interpreter,
+                "probe": [
+                    interpreter,
+                    "-c",
+                    f"import {name} as m; "
+                    "print(getattr(m, '__version__', 'no __version__'))",
+                ],
+            }
+        )
+    return built
+
+
+def _font_probes(families: Iterable[str]) -> list[dict]:
+    """Ask ``fc-match`` what it would actually use for each declared family.
+
+    ``fc-list | grep`` answers whether a name appears. ``fc-match`` answers what
+    a document would be rendered with, and fontconfig substitutes silently — a
+    missing ``Noto Sans CJK KR`` resolves to something else and exits 0. So the
+    family it names back is kept, and comparing it to what was asked for is left
+    to whoever reads the artifact.
+    """
+    return [
+        {
+            "name": f"font:{family}",
+            "capability": "fonts",
+            "kind": "font_family",
+            "asked_for": family,
+            "probe": ["fc-match", "-f", "%{family}|%{file}", family],
+        }
+        for family in families
+    ]
+
+
+def _parse(transcript: str, probes: Sequence[Mapping[str, Any]]) -> list[dict]:
+    """Read the driver's framed output back into one record per probe.
+
+    A probe with no record in the transcript is reported as having produced no
+    answer rather than dropped. That case means the driver died partway — the
+    container was killed, the shell was not there — and it is a fact about the
+    sweep, not about the command.
+    """
+    found: dict[str, dict[str, Any]] = {}
+    blocks = transcript.split(MARK + "BEGIN ")
+    for block in blocks[1:]:
+        name, _, body = block.partition("\n")
+        name = name.strip()
+        record: dict[str, Any] = {"returncode": None, "stdout": "", "stderr": ""}
+        if f"{MARK}RC " in body:
+            after = body.split(f"{MARK}RC ", 1)[1]
+            digits, _, body = after.partition("\n")
+            try:
+                record["returncode"] = int(digits.strip())
+            except ValueError:
+                record["returncode"] = None
+        if f"{MARK}OUT" in body:
+            out, _, rest = body.split(f"{MARK}OUT", 1)[1].partition(f"{MARK}ERR")
+            record["stdout"] = out.strip()
+            record["stderr"] = rest.split(f"{MARK}END")[0].strip()
+        found[name] = record
+
+    records = []
+    for probe in probes:
+        name = str(probe["name"])
+        answer = found.get(name)
+        row = {
+            "name": name,
+            "capability": probe.get("capability", ""),
+            "kind": probe.get("kind", "command"),
+            "argv": list(probe["probe"]),
+        }
+        if answer is None:
+            row.update(
+                {
+                    "answered": False,
+                    "present": False,
+                    "returncode": None,
+                    "first_line": "",
+                    "stderr": "",
+                    "grounds": (
+                        "the driver produced no record for this probe, so the "
+                        "sweep did not finish — this is not a statement about "
+                        "the command"
+                    ),
+                }
+            )
+        else:
+            status = answer["returncode"]
+            first = (answer["stdout"] or answer["stderr"]).splitlines()
+            row.update(
+                {
+                    "answered": True,
+                    "present": status == 0,
+                    "returncode": status,
+                    "first_line": first[0].strip() if first else "",
+                    "stderr": answer["stderr"][:400],
+                    "grounds": (
+                        "the probe exited 0"
+                        if status == 0
+                        else f"the probe exited {status}"
+                    ),
+                }
+            )
+        records.append(row)
+    return records
+
+
+def sweep(
+    *,
+    image: str,
+    manifest_path: Path = DEFAULT_MANIFEST,
+    runtime: str = "docker",
+    timeout_seconds: int = PROBE_TIMEOUT_SECONDS,
+    run: Any = None,
+) -> dict[str, Any]:
+    """Run every declared probe inside one image and say what came back."""
+    if not _is_pinned(image):
+        raise SweepRefused(
+            f"the image reference {image!r} is not pinned. Give a registry "
+            "digest (repo@sha256:…) or a local image ID (sha256:…): a sweep of "
+            "a moving tag describes whatever happened to be behind it at the "
+            "time and cannot be checked later"
+        )
+    manifest = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+
+    probes: list[dict[str, Any]] = [dict(p, kind="command") for p in ALWAYS_ASKED]
+    probes += [dict(p, kind="command") for p in manifest["commands"]]
+    probes += _module_probes(manifest["python_modules"], "python3")
+    probes += _font_probes(manifest["font_families"])
+
+    argv = [
+        runtime, "run", "--rm",
+        "--network", "none",
+        "--read-only",
+        "--tmpfs", "/tmp",
+        "--entrypoint", "/bin/sh",
+        image,
+        "-c", _shell_driver(probes),
+    ]
+    runner = run or _run
+    started = time.time()
+    completed = runner(argv, timeout_seconds)
+    took = time.time() - started
+
+    transcript = getattr(completed, "stdout", "") or ""
+    records = _parse(transcript, probes)
+    answered = [row for row in records if row["answered"]]
+    return {
+        "artifact": "agentic-v2-declared-command-sweep",
+        "artifact_version": "1.0",
+        "is_not": [
+            "a capability receipt",
+            "a signature or provenance verification",
+            "a vulnerability scan",
+            "an isolation or containment measurement",
+        ],
+        "image": image,
+        "manifest_sha256": _canonical_sha256(manifest),
+        "manifest_path": Path(manifest_path).as_posix(),
+        "declared": {
+            "commands": len(manifest["commands"]),
+            "python_modules": len(manifest["python_modules"]),
+            "font_families": len(manifest["font_families"]),
+            "platform": manifest["platform"],
+        },
+        "host": _where_this_was_taken(runtime),
+        "runtime_argv": argv[:-1] + ["<driver>"],
+        "sweep_seconds": round(took, 2),
+        "sweep_returncode": getattr(completed, "returncode", None),
+        "sweep_stderr": (getattr(completed, "stderr", "") or "").strip()[:2000],
+        "probes_declared": len(probes),
+        "probes_answered": len(answered),
+        "present": sum(1 for row in answered if row["present"]),
+        "absent": sum(1 for row in answered if not row["present"]),
+        "records": records,
+    }
+
+
+def _run(argv: Sequence[str], timeout_seconds: int) -> Any:
+    return subprocess.run(  # noqa: S603
+        list(argv),
+        check=False,
+        capture_output=True,
+        text=True,
+        errors="replace",
+        timeout=timeout_seconds,
+    )
+
+
+def _where_this_was_taken(runtime: str) -> dict[str, Any]:
+    """The host, because a probe result belongs to the place it was taken.
+
+    A sweep on this box's 3.10 kernel and a sweep on the Azure host are two
+    measurements, and an artifact that did not say which would let one be read
+    as the other.
+    """
+    version = ""
+    try:
+        version = subprocess.run(  # noqa: S603
+            [runtime, "version", "--format", "{{.Server.Version}}"],
+            check=False, capture_output=True, text=True, timeout=30,
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        version = ""
+    return {
+        "kernel": platform.release(),
+        "machine": platform.machine(),
+        "system": platform.system(),
+        "runtime": runtime,
+        "runtime_version": version,
+        "cgroup_version": _cgroup_version(),
+    }
+
+
+def _cgroup_version() -> int | None:
+    """2 when the unified hierarchy is mounted at ``/sys/fs/cgroup``, else 1.
+
+    Read rather than assumed, and ``None`` when neither is legible. The policy
+    stage D runs under requires v2, and a host that cannot say is a host that
+    has not answered.
+    """
+    try:
+        with open("/proc/mounts", encoding="utf-8") as mounts:
+            for line in mounts:
+                parts = line.split()
+                if len(parts) > 2 and parts[1] == "/sys/fs/cgroup":
+                    return 2 if parts[2] == "cgroup2" else 1
+    except OSError:
+        return None
+    return None
+
+
+def _canonical_sha256(value: Any) -> str:
+    import hashlib
+
+    return hashlib.sha256(
+        json.dumps(
+            value, sort_keys=True, separators=(",", ":"), ensure_ascii=True,
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _pinned_parent(lock_path: Path = DEFAULT_LOCK) -> str:
+    lock = json.loads(Path(lock_path).read_text(encoding="utf-8"))
+    return str(lock["reference"])
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--image",
+        default=None,
+        help="a digest-pinned reference; defaults to what parent.lock.json pins",
+    )
+    parser.add_argument("--manifest", default=str(DEFAULT_MANIFEST))
+    parser.add_argument("--runtime", default="docker")
+    parser.add_argument("--timeout", type=int, default=PROBE_TIMEOUT_SECONDS)
+    parser.add_argument("--out", default="/var/tmp/gdpval-declared-command-sweep.json")
+    args = parser.parse_args(argv)
+
+    image = args.image or _pinned_parent()
+    try:
+        result = sweep(
+            image=image,
+            manifest_path=Path(args.manifest),
+            runtime=args.runtime,
+            timeout_seconds=args.timeout,
+        )
+    except SweepRefused as refused:
+        print(f"refused: {refused}", file=sys.stderr)
+        return 2
+    except subprocess.TimeoutExpired:
+        print(f"the sweep did not finish within {args.timeout}s", file=sys.stderr)
+        return 3
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(result, indent=2, sort_keys=True), encoding="utf-8")
+
+    print(f"image      {result['image']}")
+    print(f"host       {result['host']['kernel']} {result['host']['machine']}")
+    print(
+        f"answered   {result['probes_answered']}/{result['probes_declared']}"
+        f"   present {result['present']}   absent {result['absent']}"
+    )
+    for row in result["records"]:
+        mark = "ok " if row["present"] else ("-- " if row["answered"] else "?? ")
+        print(f"  {mark}{row['name']:<28} {row['first_line'][:70]}")
+    print(f"written    {out.as_posix()}")
+    # A sweep that ran is a success even when things are absent. Absence is the
+    # answer it was sent to get, and exiting non-zero for it would make a real
+    # finding indistinguishable from a broken run.
+    return 0 if result["probes_answered"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/batch-runner/scripts/run_agentic_stage_d_probe.py
+++ b/batch-runner/scripts/run_agentic_stage_d_probe.py
@@ -64,6 +64,7 @@ BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
 if str(BATCH_RUNNER_ROOT) not in sys.path:
     sys.path.insert(0, str(BATCH_RUNNER_ROOT))
 
+from core.agentic_v2_guest_image import sha256_file  # noqa: E402
 from core.agentic_v2_microvm_backend import GuestImage  # noqa: E402
 from core.agentic_v2_one_call_machine import OneCallMachine  # noqa: E402
 from core.agentic_v2_stage_d_probe import (  # noqa: E402
@@ -151,6 +152,63 @@ def read_what_c2_left(path: Path) -> dict[str, Any]:
     return artefact
 
 
+def the_images_are_still_the_ones_c2_booted(
+    artefact: dict[str, Any], *, sha256: Any = None
+) -> dict[str, Any]:
+    """Re-hash the kernel and rootfs, and refuse if they are not C2's.
+
+    C3 already declines to attack a machine whose boot nobody recorded — it
+    stops with ``different_guest`` rather than produce seven verdicts about the
+    wrong thing. Stage D has the same reason and one more: it is the stage that
+    pays. A model call bought against a rebuilt rootfs is charged in full and
+    discarded at the first command.
+
+    The gap this closes is real rather than theoretical. C2 and C3 ran on a host
+    that has since been deallocated, and stage D will run after it is started
+    again. These files are on ``/var/tmp``, which is the OS disk and survives
+    that — which is why this is expected to pass, and expecting a check to pass
+    is not a reason to skip it. A reprovisioned disk, a truncated download and a
+    rootfs somebody rebuilt between stages all look like a healthy host until
+    the first ``exec_run``, and by then the money is gone.
+
+    **The work disk is deliberately not checked**, and its absence here is a
+    decision rather than an omission. Stage C's own record hands stage D the
+    ``workdir: ephemeral`` obligation it could not attack — a guest cannot make
+    its own disk survive, only the code handing out disks can fail to replace
+    one. Every call gets a freshly built work disk, so pinning C2's
+    ``work.ext4`` would assert exactly the thing that must not be true.
+
+    Costs one read of about 8.7 GiB, which is seconds against a paid run.
+    """
+    measure = sha256 or sha256_file
+    images = artefact["images"]
+    checked: dict[str, Any] = {}
+    for which in ("kernel", "rootfs"):
+        recorded = images[which]
+        where = Path(str(recorded["path"]))
+        if not where.is_file():
+            raise StageDRefused(
+                f"C2 booted {which} at {where} and it is not there now. The "
+                "host has been reprovisioned or the file was removed; run "
+                "scripts/run_agentic_c2_first_boot.py again before paying for "
+                "anything on it"
+            )
+        found = measure(where)
+        if found != str(recorded["sha256"]):
+            raise StageDRefused(
+                f"the {which} at {where} hashes {found}, and C2 booted "
+                f"{recorded['sha256']}. These are different bytes, so C2's "
+                "record is not evidence about the machine this run would use"
+            )
+        checked[which] = {"path": where.as_posix(), "sha256": found}
+    checked["matches_the_guest_c2_booted"] = True
+    checked["work_disk"] = (
+        "not checked, deliberately — every call builds its own, which is the "
+        "workdir: ephemeral obligation stage C recorded and left to stage D"
+    )
+    return checked
+
+
 def the_guest_c2_booted(artefact: dict[str, Any]) -> GuestImage:
     """The image, named by what C2 measured rather than by what was intended.
 
@@ -215,12 +273,17 @@ def exit_condition_met(outcome) -> bool:
     )
 
 
-def build_record(*, verdict, said, outcome, fingerprint, workspace, artefact) -> dict:
+def build_record(
+    *, verdict, said, outcome, fingerprint, workspace, artefact, images=None
+) -> dict:
     """What is kept about a paid run, assembled in one place a test can check.
 
     ``image_evidence`` is in here on purpose and is expected to read
     ``not_run``. A record that named an image and stopped would be read as
     though the evidence followed the name.
+
+    ``images_checked`` is the other half of that: the digest says which bytes,
+    and this says they were still those bytes when the run started.
     """
     return {
         "stage": "agentic-v2-stage-d",
@@ -230,6 +293,7 @@ def build_record(*, verdict, said, outcome, fingerprint, workspace, artefact) ->
         "route_fingerprint": fingerprint,
         "workspace": str(workspace),
         "c2_artefact": str(artefact),
+        "images_checked": images,
         "approved_maximum_usd": said["approved_maximum_usd"],
         "most_it_could_cost_usd": said["most_it_could_cost_usd"],
         "exit_condition_met": exit_condition_met(outcome),
@@ -276,6 +340,7 @@ def main(argv: list[str] | None = None) -> int:
     stage_a = _stage_a_runner()
     try:
         artefact = read_what_c2_left(args.c2_artefact)
+        images_checked = the_images_are_still_the_ones_c2_booted(artefact)
         plan, verdict, catalog = stage_a._verdict(args.plan)
         task = catalog.by_task_id()[verdict.task_id]
         prompt = stage_a.read_task_prompt(
@@ -316,6 +381,11 @@ def main(argv: list[str] | None = None) -> int:
         f"{artefact['host'].get('firecracker_version')}"
     )
     print(f"  jailed to      {artefact['jail_account']['name']}")
+    print(
+        f"  images         still the ones C2 booted — kernel "
+        f"{images_checked['kernel']['sha256'][:12]}, rootfs "
+        f"{images_checked['rootfs']['sha256'][:12]}"
+    )
     print()
 
     if args.dry_run:
@@ -389,6 +459,7 @@ def main(argv: list[str] | None = None) -> int:
         fingerprint=fingerprint,
         workspace=workspace,
         artefact=args.c2_artefact,
+        images=images_checked,
     )
     written = json.dumps(record, indent=2, sort_keys=True)
     if args.output is not None:

--- a/batch-runner/scripts/run_agentic_stage_d_probe.py
+++ b/batch-runner/scripts/run_agentic_stage_d_probe.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""Stage D: ask a real deployment one task's worth of questions over a real guest.
+
+Stage A proved a model reached over a route will choose a tool and then work
+from what came back. It proved that against a backend that wrote into a host
+directory. Stage D asks the same question with the machine underneath it: every
+``exec_run`` is one microVM, booted under the jailer, given a work disk, killed,
+and read back off that disk.
+
+**This runs on the execution host and nowhere else.** It refuses on any other
+machine, and it refuses by reading rather than guessing: it will not start
+unless C2 has already booted a guest here and left the artefact saying so. That
+is not ceremony. Stage D is the paid stage, and a model call made on a host that
+has never booted a guest would be bought and then thrown away when the first
+``exec_run`` failed.
+
+    # on the execution host, after run_agentic_c2_first_boot.py has passed
+    cd batch-runner
+    python scripts/run_agentic_stage_d_probe.py --dry-run
+    python scripts/run_agentic_stage_d_probe.py
+
+**What it takes from C2 rather than building again.** The kernel, the rootfs,
+the jail account, the firecracker and jailer binaries, and the cgroup version.
+All of them come out of C2's artefact, so stage D runs against the images that
+were actually booted and recorded, not against a second build that happens to
+have been made the same way. If C2's artefact says the boot failed, this refuses
+and names that as the reason.
+
+**What it takes from stage A rather than copying.** The free gate and the
+wording check are loaded out of ``run_agentic_stage_a_probe.py`` as that
+module's own functions. A copy would be a second place for the prompt hash to
+drift, and stage A's runner is a path that has already been through a paid run —
+moving code out of it to make this one tidier would perturb something proven to
+buy something cosmetic.
+
+**What is written down, and what is not.** One row per model call: turn,
+deployment asked for, model that answered, tokens, how much earlier conversation
+the call carried, and either a price or an explicit ``price_missing``. One row
+per boot: outcome, exit status, teardown. Plus what is *known* about the guest
+image — which is currently ``not_run``, because the digest this repository can
+fetch is the parent the capability receipt was never measured against. Nothing
+of what was said, and not the benchmark wording.
+
+**The exit code answers stage D's question.** Zero means a real model was
+reached, a command really ran inside a guest, and a later call went out holding
+what that command produced. A model that was reached and chose to do nothing is
+a finding, and it is reported as one — but it did not answer the question, so it
+exits 1. A boot that failed is not laundered into a model result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.agentic_v2_microvm_backend import GuestImage  # noqa: E402
+from core.agentic_v2_one_call_machine import OneCallMachine  # noqa: E402
+from core.agentic_v2_stage_d_probe import (  # noqa: E402
+    PROBE_TOOLS,
+    TURNS_STAGE_D_NEEDS,
+    ProbeCannotDescribeItself,
+    ProbeToolsAreWrong,
+    capability_evidence_for,
+    run_stage_d_probe,
+)
+from core.agentic_v2_stage_one_budget import STAGE_ONE_PLAN_PATH  # noqa: E402
+from core.agentic_v2_substrate import AgenticV2SubstrateManifest  # noqa: E402
+from core.execution_envelope_cost import load_price_table  # noqa: E402
+from core.execution_envelope_tasks import DATASET_REVISION  # noqa: E402
+
+#: Where C2 leaves the artefact this refuses to run without.
+C2_ARTEFACT = Path("/var/tmp/gdpval-c2/c2-first-boot.json")
+
+SUBSTRATE_MANIFEST = BATCH_RUNNER_ROOT / "sandbox" / "agentic_v2_capabilities.json"
+
+STAGE_A_RUNNER = BATCH_RUNNER_ROOT / "scripts" / "run_agentic_stage_a_probe.py"
+
+
+class StageDRefused(RuntimeError):
+    """Every reason stage D must not spend anything, raised before it does."""
+
+
+def _stage_a_runner() -> Any:
+    """Load stage A's runner as a module, for its gate and its wording check.
+
+    By path because ``scripts`` is not a package, which is also how the tests
+    already load these runners. The alternative — lifting both functions into
+    ``core`` — would edit a file that a completed paid run was made with, and
+    the tidiness is not worth the change.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "run_agentic_stage_a_probe", STAGE_A_RUNNER
+    )
+    if spec is None or spec.loader is None:  # pragma: no cover - a missing file
+        raise StageDRefused(f"stage A's runner is not at {STAGE_A_RUNNER}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_what_c2_left(path: Path) -> dict[str, Any]:
+    """C2's artefact, and a refusal if it does not describe a booted guest.
+
+    Four separate refusals rather than one, because they call for four different
+    things from whoever reads them: run C2, run C2 *here*, fix the host, or look
+    at why the boot failed. A single "stage D cannot run" would hide which.
+    """
+    if not path.is_file():
+        raise StageDRefused(
+            f"there is no C2 artefact at {path}. Stage D runs on a host that has "
+            "already booted a guest, and this host has not been shown to have "
+            "done so. Run scripts/run_agentic_c2_first_boot.py first"
+        )
+    artefact = json.loads(path.read_text(encoding="utf-8"))
+
+    outcome = str(artefact.get("outcome") or "")
+    if outcome != "booted":
+        raise StageDRefused(
+            f"C2's artefact records {outcome!r}, not a boot"
+            + (f" — {artefact['reason']}" if artefact.get("reason") else "")
+            + ". A model call made now would be paid for and then have nothing "
+            "to run its commands on"
+        )
+
+    recorded = str((artefact.get("host") or {}).get("kernel_release") or "")
+    running = os.uname().release
+    if recorded and recorded != running:
+        raise StageDRefused(
+            f"C2 booted on kernel {recorded} and this host is running {running}, "
+            "so the artefact describes a different machine than the one about "
+            "to be paid for"
+        )
+
+    for binary in ("firecracker", "jailer"):
+        where = (artefact.get("host") or {}).get(binary)
+        if not where or not Path(str(where)).exists():
+            raise StageDRefused(
+                f"C2 recorded {binary} at {where!r} and it is not there now"
+            )
+    return artefact
+
+
+def the_guest_c2_booted(artefact: dict[str, Any]) -> GuestImage:
+    """The image, named by what C2 measured rather than by what was intended.
+
+    The digest is the *manifest* digest C2 pulled — the amd64 child, where the
+    pinned reference was an index — because that is the thing whose bytes became
+    the rootfs. The kernel and rootfs hashes are C2's own, over the files this
+    run is about to boot.
+
+    Naming is not verifying. What is known about this image is a separate
+    question with a separate answer, and
+    :func:`core.agentic_v2_stage_d_probe.capability_evidence_for` gives it.
+    """
+    images = artefact["images"]
+    pulled = images["image"]
+    return GuestImage(
+        reference=str(pulled["repository"]),
+        digest=str(pulled.get("pinned_digest") or pulled["manifest_digest"]),
+        kernel_sha256=str(images["kernel"]["sha256"]),
+        rootfs_sha256=str(images["rootfs"]["sha256"]),
+    )
+
+
+def the_machine_c2_proved(
+    artefact: dict[str, Any], *, scratch: Path, session: str, vcpu_count: int
+) -> OneCallMachine:
+    """One microVM per call, on the binaries and the account C2 used."""
+    host = artefact["host"]
+    account = artefact["jail_account"]
+    images = artefact["images"]
+    return OneCallMachine(
+        kernel=Path(images["kernel"]["path"]),
+        rootfs=Path(images["rootfs"]["path"]),
+        firecracker_binary=Path(str(host["firecracker"])),
+        jailer_binary=str(host["jailer"]),
+        uid=int(account["uid"]),
+        gid=int(account["gid"]),
+        vcpu_count=vcpu_count,
+        cgroup_version=int(host["cgroup_version"]),
+        scratch=scratch,
+        session=session,
+    )
+
+
+def exit_condition_met(outcome) -> bool:
+    """Whether the run answered stage D's question.
+
+    Three things, and the middle one is the whole difference from stage A. A
+    model can be reached without ever asking for a command; it can ask for one
+    that the backend refuses on the host and never boots for; and it can be
+    handed a result and stop. Stage D asked whether a real model works over a
+    real machine, so: reached, a command really ran in a guest, and the model
+    went on afterwards.
+
+    Not "did it do the task well". A model that ran a command, got a useless
+    answer and wrote nonsense meets this. That is a finding about the model, and
+    stage D exists to collect findings rather than to require successes.
+    """
+    return (
+        bool(outcome.reached_a_model)
+        and bool(outcome.a_command_really_ran)
+        and bool(outcome.worked_on_after_running_something)
+    )
+
+
+def build_record(*, verdict, said, outcome, fingerprint, workspace, artefact) -> dict:
+    """What is kept about a paid run, assembled in one place a test can check.
+
+    ``image_evidence`` is in here on purpose and is expected to read
+    ``not_run``. A record that named an image and stopped would be read as
+    though the evidence followed the name.
+    """
+    return {
+        "stage": "agentic-v2-stage-d",
+        "task_id": verdict.task_id,
+        "dataset_revision": DATASET_REVISION,
+        "prompt_sha256": said["prompt_sha256"],
+        "route_fingerprint": fingerprint,
+        "workspace": str(workspace),
+        "c2_artefact": str(artefact),
+        "approved_maximum_usd": said["approved_maximum_usd"],
+        "most_it_could_cost_usd": said["most_it_could_cost_usd"],
+        "exit_condition_met": exit_condition_met(outcome),
+        "probe": outcome.as_dict(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Stage D: one paid task over one real guest per call."
+    )
+    parser.add_argument("--plan", type=Path, default=STAGE_ONE_PLAN_PATH)
+    parser.add_argument("--c2-artefact", type=Path, default=C2_ARTEFACT)
+    parser.add_argument("--parquet", type=Path, default=None)
+    parser.add_argument("--vcpu-count", type=int, default=2)
+    parser.add_argument(
+        "--max-tool-calls",
+        type=int,
+        default=TURNS_STAGE_D_NEEDS,
+        help="One boot apiece. Every one of them is a microVM and a teardown.",
+    )
+    parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=None,
+        help=(
+            "Where the session's work directory and the collected outputs go. A "
+            "fresh temporary one is made if this is left out; an existing one is "
+            "never emptied."
+        ),
+    )
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Everything except the network and the boots: the gate, C2's "
+            "artefact, the host, the wording, the machine. Exits 0 when the "
+            "paid run would be allowed to go ahead."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    stage_a = _stage_a_runner()
+    try:
+        artefact = read_what_c2_left(args.c2_artefact)
+        plan, verdict, catalog = stage_a._verdict(args.plan)
+        task = catalog.by_task_id()[verdict.task_id]
+        prompt = stage_a.read_task_prompt(
+            verdict.task_id,
+            parquet=args.parquet or stage_a.PINNED_DATASET_PARQUET,
+            expected_sha256=task.prompt_sha256,
+        )
+    except (StageDRefused, stage_a.ProbeRefused) as refusal:
+        print(f"Refused before spending anything.\n\n{refusal}")
+        return 1
+
+    image = the_guest_c2_booted(artefact)
+    known = capability_evidence_for(image)
+    deployment = str((plan.get("model") or {}).get("deployment") or "")
+    connection = plan.get("azure_connection") or {}
+    resource = str(connection.get("account") or "")
+    said = dict(verdict.as_dict())
+    said["prompt_sha256"] = task.prompt_sha256
+
+    print("Agentic Sandbox V2, stage D — one paid task over one guest per call")
+    print("=" * 74)
+    print(f"  task           {verdict.task_id}")
+    print(f"  prompt         {len(prompt)} characters, wording checked against")
+    print(f"                 the catalogue's hash for revision "
+          f"{DATASET_REVISION[:12]}")
+    print(f"  tools offered  {', '.join(PROBE_TOOLS)}")
+    print(f"  boots at most  {args.max_tool_calls}, one microVM each")
+    print(
+        f"  at most        ${said['most_it_could_cost_usd']} against the "
+        f"${said['approved_maximum_usd']} approved"
+    )
+    print(f"  deployment     {deployment} at {resource}")
+    print(f"  guest image    {image.digest}")
+    print(f"  known about it {known['status']} — {known['grounds']}")
+    print(
+        f"  host           {artefact['host']['kernel_release']}, cgroup v"
+        f"{artefact['host']['cgroup_version']}, firecracker "
+        f"{artefact['host'].get('firecracker_version')}"
+    )
+    print(f"  jailed to      {artefact['jail_account']['name']}")
+    print()
+
+    if args.dry_run:
+        print(
+            "Dry run. Nothing was asked, nothing was booted and nothing was "
+            "spent. Every condition for the paid run is met."
+        )
+        return 0
+
+    workspace = (
+        args.workspace
+        if args.workspace is not None
+        else Path(tempfile.mkdtemp(prefix="agentic-v2-stage-d-"))
+    )
+    scratch = workspace / "machines"
+    print(f"  workspace      {workspace}")
+
+    from core.azure_ai_clients import AzureAIRouteSettings, AzureAIWorkload
+    from core.llm_client import create_typed_azure_client
+
+    settings = AzureAIRouteSettings.from_env()
+    seconds = float(plan["fixed_settings"]["per_task_timeout_seconds"])
+    managed = create_typed_azure_client(
+        AzureAIWorkload.INFERENCE, deployment, settings=settings, timeout=seconds
+    )
+    try:
+        wrong_route = stage_a.check_route_is_the_one_the_plan_fixed(
+            managed.route, connection, settings=settings
+        )
+        if wrong_route:
+            print(
+                "Refused after building a client and before asking it "
+                "anything.\n\n  - " + "\n  - ".join(wrong_route)
+            )
+            return 1
+
+        outcome = run_stage_d_probe(
+            client=managed.client,
+            deployment=deployment,
+            resource=resource,
+            budget=verdict.budget,
+            task_prompt=prompt,
+            workspace_root=workspace / "session",
+            image=image,
+            boot_one_command=the_machine_c2_proved(
+                artefact,
+                scratch=scratch,
+                session=f"stage-d-{verdict.task_id}",
+                vcpu_count=args.vcpu_count,
+            ),
+            substrate_manifest=AgenticV2SubstrateManifest.load(SUBSTRATE_MANIFEST),
+            max_output_tokens_per_turn=verdict.max_output_tokens_per_turn,
+            max_seconds=seconds,
+            max_tool_calls=args.max_tool_calls,
+            collect_outputs_into=workspace / "collected",
+            prices=load_price_table(),
+            tools=PROBE_TOOLS,
+        )
+        fingerprint = managed.runtime_fingerprint
+    except (ProbeToolsAreWrong, ProbeCannotDescribeItself) as refusal:
+        print(f"Refused before the first model call.\n\n{refusal}")
+        return 1
+    finally:
+        managed.close()
+        shutil.rmtree(scratch, ignore_errors=True)
+
+    record = build_record(
+        verdict=verdict,
+        said=said,
+        outcome=outcome,
+        fingerprint=fingerprint,
+        workspace=workspace,
+        artefact=args.c2_artefact,
+    )
+    written = json.dumps(record, indent=2, sort_keys=True)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(written + "\n", encoding="utf-8")
+        print(f"  record         {args.output}")
+    print()
+    print(written)
+    print()
+
+    booted = sum(1 for row in outcome.boots if row.get("boot_outcome") == "booted")
+    print(f"  boots          {booted} of {len(outcome.boots)} came back")
+    print(f"  carriage       {outcome.carriage_failures} infrastructure failures")
+    print(f"  collected      {outcome.collected.get('files', 0)} files")
+    if outcome.price_missing:
+        # An unpriced call is partial, and writing zero for it would be a
+        # smaller number than the truth rather than an unknown one.
+        print("  spent          partial — at least one call had no price")
+    else:
+        print(f"  spent          ${outcome.spent_usd}")
+    print()
+    print(
+        "  image evidence "
+        f"{known['status']} — this run booted an image nothing here holds a "
+        "capability receipt, a signature or a provenance attestation for"
+    )
+
+    if exit_condition_met(outcome):
+        print("\nStage D's question is answered: reached, ran, and worked on.")
+        return 0
+    print(
+        f"\nStage D's question is not answered — {outcome.stop_reason}: "
+        f"{outcome.detail}. The record above is the finding."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/batch-runner/tests/test_agentic_v2_stage_d_probe.py
+++ b/batch-runner/tests/test_agentic_v2_stage_d_probe.py
@@ -45,6 +45,7 @@ from core.agentic_v2_stage_a_probe import (  # noqa: E402
     PROBE_TOOLS as STAGE_A_TOOLS,
 )
 from core.agentic_v2_stage_d_probe import (  # noqa: E402
+    PARENT_LOCK,
     PROBE_INSTRUCTIONS,
     PROBE_TOOLS,
     TOOLS_THIS_BACKEND_REFUSES,
@@ -52,6 +53,7 @@ from core.agentic_v2_stage_d_probe import (  # noqa: E402
     ProbeCannotDescribeItself,
     ProbeToolsAreWrong,
     StageDProbeOutcome,
+    capability_evidence_for,
     check_probe_tools,
     run_stage_d_probe,
 )
@@ -599,3 +601,66 @@ def test_running_something_is_read_from_the_boots_not_from_the_tool_calls():
 
     assert asked_but_refused.asked_to_run_something is True
     assert asked_but_refused.a_command_really_ran is False
+
+
+class TestWhatIsKnownAboutTheImageAsOpposedToDeclaredAboutIt:
+    """The manifest says what an image should hold. It is not the check.
+
+    ``sandbox/agentic_v2_capabilities.json`` lists twenty commands with a
+    ``probe`` argv apiece and a ``supply_chain`` block naming policy profiles.
+    Both are instructions for a measurement, not its result. The measurement is
+    a capability receipt, and the one that reads ``verified`` was taken on a
+    locally built candidate that was never pushed. The digest this repository
+    can actually fetch is the parent that candidate was built from.
+
+    So a stage D record that named an image and stopped there would be read as
+    though the evidence followed the name. These tests exist to keep the gap in
+    the record.
+    """
+
+    def test_the_pinned_digest_is_the_parent_and_its_evidence_is_not_run(self):
+        known = capability_evidence_for(AN_IMAGE)
+        assert known["status"] == "not_run"
+        assert known["subject"] == AN_IMAGE.digest
+        assert "parent" in known["grounds"]
+
+    def test_the_answer_is_read_off_the_lock_file_and_not_asserted(self):
+        pinned = json.loads(Path(PARENT_LOCK).read_text(encoding="utf-8"))
+        assert pinned["manifest_digest"] == AN_IMAGE.digest
+        assert capability_evidence_for(AN_IMAGE)["source_revision"] == (
+            pinned["source_revision"]
+        )
+
+    def test_a_digest_nobody_holds_a_receipt_for_is_unknown_not_verified(self):
+        # The failure mode being closed: defaulting to a friendly answer for an
+        # image the repository has never seen. Unknown and not_run are both
+        # honest; verified would be the only wrong answer here.
+        stranger = GuestImage(
+            reference="example.invalid/nothing",
+            digest="sha256:" + "c" * 64,
+            kernel_sha256="a" * 64,
+            rootfs_sha256="b" * 64,
+        )
+        assert capability_evidence_for(stranger)["status"] == "unknown"
+
+    def test_nothing_ever_comes_back_verified(self):
+        # Until a receipt is measured against a fetchable digest, there is no
+        # input to this function that should produce "verified". If that changes
+        # this test is the thing that has to change with it, deliberately.
+        for image in (AN_IMAGE,):
+            assert capability_evidence_for(image)["status"] != "verified"
+
+    def test_an_unreadable_lock_file_is_an_answer_rather_than_a_crash(self, tmp_path):
+        # Losing a whole probe run -- model calls, boot record, price -- because
+        # a lock file moved would be a poor trade for a field.
+        known = capability_evidence_for(AN_IMAGE, lock_path=tmp_path / "absent.json")
+        assert known["status"] == "unknown"
+        assert "could not be read" in known["grounds"]
+
+    def test_the_record_carries_the_gap_rather_than_only_the_name(self, tmp_path):
+        guest = AGuestThatReallyWritesADisk(writes={"out.txt": "done\n"})
+        client = FakeClient([runs(["true"]), says_nothing_useful()])
+        outcome = run_probe([], tmp_path, client=client, guest=guest)
+        recorded = outcome.as_dict()
+        assert recorded["guest_image"]["digest"] == AN_IMAGE.digest
+        assert recorded["image_evidence"]["status"] == "not_run"

--- a/batch-runner/tests/test_probe_declared_commands.py
+++ b/batch-runner/tests/test_probe_declared_commands.py
@@ -1,0 +1,315 @@
+"""Sweeping one image against what the manifest declares — and not overclaiming it.
+
+The module under test exists because of a gap that was found rather than
+assumed. ``sandbox/agentic_v2_capabilities.json`` declares twenty commands with
+a ``probe`` argv apiece and no versions; the *measurement* of those probes is a
+capability receipt; and the receipt that reads ``verified`` in
+``sandbox/v2/README.md`` was taken on a candidate image (``sha256:e47537b8…``)
+that was never pushed. The image this repository can fetch is the parent that
+candidate was built from. So the evidence and the reachable image are two
+different things, and a sweep is what closes the distance for one of them.
+
+Two properties are load-bearing here and both are tested directly:
+
+**A probe with no record is not an absent command.** The driver runs inside the
+container; if it dies partway — killed container, no shell — the probes after
+that point have no answer. Reporting those as absent would turn a broken sweep
+into twenty findings about the image.
+
+**The artifact must not validate as a capability receipt.** It is narrower: no
+SBOM, no license classification, no package inventory, no smoke matrix. A test
+asserts the validator rejects it, so that a later edit which quietly widened the
+shape could not make this artifact answer to a name it has not earned.
+
+Nothing here starts a container. The runner is injected, exactly as the boot is
+in the stage D tests, because what needs proving is the framing and the reading
+of it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.agentic_v2_substrate import (
+    AgenticV2SubstrateManifest,
+    validate_capability_receipt,
+)
+from sandbox.v2.probe_declared_commands import (
+    MARK,
+    SweepRefused,
+    _is_pinned,
+    _parse,
+    _shell_driver,
+    sweep,
+)
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+
+
+A_REGISTRY_PIN = (
+    "ghcr.io/hyeonsangjeon/gdpval-sandbox@sha256:"
+    "ee6ef798631d3c3aeaed28658c640e6f5d021677449852bf2e1f18be5bd24edb"
+)
+A_LOCAL_IMAGE_ID = "sha256:" + "9" * 64
+
+MANIFEST = BATCH_RUNNER_ROOT / "sandbox" / "agentic_v2_capabilities.json"
+
+
+class ARunnerThatWasNeverAskedToStartAnything:
+    """Stands in for ``docker run`` and records whether it was called."""
+
+    def __init__(self, *, stdout: str = "", returncode: int = 0, stderr: str = ""):
+        self.stdout = stdout
+        self.returncode = returncode
+        self.stderr = stderr
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv, timeout_seconds):
+        self.calls.append(list(argv))
+        return self
+
+    # subprocess.CompletedProcess is duck-typed here; these are the three fields
+    # the module reads and nothing else.
+
+
+def _transcript(answers) -> str:
+    """Build what the in-container driver would have printed."""
+    blocks = []
+    for name, status, out, err in answers:
+        blocks.append(
+            f"{MARK}BEGIN {name}\n"
+            f"{MARK}RC {status}\n"
+            f"{MARK}OUT\n{out}\n"
+            f"{MARK}ERR\n{err}\n"
+            f"{MARK}END"
+        )
+    return "\n".join(blocks) + "\n"
+
+
+class TestPinningTheThingBeingMeasured:
+    def test_a_registry_digest_is_a_pin(self):
+        assert _is_pinned(A_REGISTRY_PIN) is True
+
+    def test_a_local_image_id_is_a_pin(self):
+        # The case that matters: the candidate carrying the professional-work
+        # layer was built and never pushed, so an image ID is the only content
+        # address it has.
+        assert _is_pinned(A_LOCAL_IMAGE_ID) is True
+
+    @pytest.mark.parametrize(
+        "reference",
+        [
+            "ghcr.io/hyeonsangjeon/gdpval-sandbox:latest",
+            "gdpval-agentic-v2-candidate:dev",
+            "sha256:abc",
+            "",
+        ],
+    )
+    def test_a_tag_or_a_fragment_is_not_a_pin(self, reference):
+        assert _is_pinned(reference) is False
+
+    def test_an_unpinned_sweep_starts_nothing(self):
+        # Refusing after starting a 7 GB image would be refusing at the most
+        # expensive moment available.
+        runner = ARunnerThatWasNeverAskedToStartAnything()
+        with pytest.raises(SweepRefused) as refused:
+            sweep(image="gdpval-agentic-v2-candidate:dev", run=runner)
+        assert "not pinned" in str(refused.value)
+        assert runner.calls == []
+
+
+class TestTheDriverTheContainerRuns:
+    def test_every_declared_probe_appears_in_it(self):
+        driver = _shell_driver(
+            [
+                {"name": "Rscript", "probe": ["Rscript", "--version"]},
+                {"name": "node", "probe": ["node", "--version"]},
+            ]
+        )
+        assert f"{MARK}BEGIN Rscript" in driver
+        assert f"{MARK}BEGIN node" in driver
+        assert driver.count(f"{MARK}END") == 2
+
+    def test_an_argument_holding_a_space_stays_one_argument(self):
+        driver = _shell_driver(
+            [{"name": "font", "probe": ["fc-match", "Noto Sans CJK KR"]}]
+        )
+        assert "'Noto Sans CJK KR'" in driver
+
+    def test_an_argument_holding_a_quote_cannot_break_out_of_the_driver(self):
+        # The argv come from a file in this repository, which is a reason to
+        # expect them to be ordinary rather than a licence to concatenate.
+        driver = _shell_driver(
+            [{"name": "odd", "probe": ["sh", "-c", "echo 'x'; rm -rf /"]}]
+        )
+        assert "\nrm -rf /" not in driver
+
+    def test_each_probe_gets_its_own_exit_status(self):
+        driver = _shell_driver([{"name": "a", "probe": ["true"]}])
+        assert "status=$?" in driver
+        assert f"{MARK}RC " in driver
+
+
+class TestReadingTheAnswersBack:
+    def test_a_probe_that_exited_zero_is_present(self):
+        records = _parse(
+            _transcript([("bash", 0, "GNU bash, version 5.2.15", "")]),
+            [{"name": "bash", "probe": ["bash", "--version"]}],
+        )
+        assert records[0]["present"] is True
+        assert records[0]["returncode"] == 0
+        assert records[0]["first_line"] == "GNU bash, version 5.2.15"
+
+    def test_a_probe_that_failed_is_absent_and_says_why(self):
+        records = _parse(
+            _transcript([("Rscript", 127, "", "sh: Rscript: not found")]),
+            [{"name": "Rscript", "probe": ["Rscript", "--version"]}],
+        )
+        assert records[0]["answered"] is True
+        assert records[0]["present"] is False
+        assert records[0]["returncode"] == 127
+        assert "not found" in records[0]["first_line"]
+
+    def test_a_probe_with_no_record_is_not_reported_as_an_absent_command(self):
+        # The sweep died partway. Ten probes never ran, and calling them absent
+        # would turn one broken container into ten findings about the image.
+        records = _parse(
+            _transcript([("bash", 0, "GNU bash", "")]),
+            [
+                {"name": "bash", "probe": ["bash", "--version"]},
+                {"name": "node", "probe": ["node", "--version"]},
+            ],
+        )
+        node = records[1]
+        assert node["answered"] is False
+        assert node["present"] is False
+        assert node["returncode"] is None
+        assert "not a statement about the command" in node["grounds"]
+
+    def test_only_the_first_line_is_kept_from_a_talkative_probe(self):
+        records = _parse(
+            _transcript([("libreoffice", 0, "LibreOffice 7.4.7.2\nand more\n", "")]),
+            [{"name": "libreoffice", "probe": ["libreoffice", "--version"]}],
+        )
+        assert records[0]["first_line"] == "LibreOffice 7.4.7.2"
+
+    def test_the_order_asked_is_the_order_reported(self):
+        asked = [{"name": n, "probe": [n]} for n in ("c", "a", "b")]
+        records = _parse(
+            _transcript([("a", 0, "", ""), ("b", 0, "", ""), ("c", 0, "", "")]), asked
+        )
+        assert [row["name"] for row in records] == ["c", "a", "b"]
+
+
+class TestTheArtifactAndWhatItRefusesToBeCalled:
+    def _swept(self, **kwargs):
+        runner = ARunnerThatWasNeverAskedToStartAnything(**kwargs)
+        return sweep(image=A_REGISTRY_PIN, manifest_path=MANIFEST, run=runner), runner
+
+    def test_it_says_what_it_is_not(self):
+        result, _ = self._swept()
+        assert "a capability receipt" in result["is_not"]
+        assert "a signature or provenance verification" in result["is_not"]
+
+    def test_it_does_not_validate_as_a_capability_receipt(self):
+        # The strongest anti-overclaim check available: the repository's own
+        # validator is asked, and has to say no. If a later edit widened this
+        # artifact's shape until it passed, this test is what would notice.
+        result, _ = self._swept()
+        manifest = AgenticV2SubstrateManifest.load(MANIFEST)
+        with pytest.raises(ValueError):
+            validate_capability_receipt(result, manifest)
+
+    def test_it_names_the_host_it_was_taken_on(self):
+        # A sweep on a 3.10 kernel and a sweep on the Azure host are two
+        # measurements even when the image is the same bytes.
+        result, _ = self._swept()
+        assert result["host"]["machine"]
+        assert result["host"]["kernel"]
+        assert "cgroup_version" in result["host"]
+
+    def test_it_names_the_declaration_it_was_checked_against(self):
+        result, _ = self._swept()
+        assert len(result["manifest_sha256"]) == 64
+        assert result["declared"]["commands"] == 20
+        assert result["declared"]["python_modules"] == 13
+
+    def test_the_container_is_started_with_no_network_and_a_read_only_root(self):
+        _, runner = self._swept()
+        argv = runner.calls[0]
+        assert "--network" in argv and argv[argv.index("--network") + 1] == "none"
+        assert "--read-only" in argv
+        assert A_REGISTRY_PIN in argv
+
+    def test_the_driver_is_not_copied_into_the_record(self):
+        # It is several kilobytes of generated shell and it is reproducible from
+        # the manifest. What matters in the record is how the container was
+        # started.
+        result, _ = self._swept()
+        assert result["runtime_argv"][-1] == "<driver>"
+        assert not any(MARK in part for part in result["runtime_argv"])
+
+    def test_python_and_python3_are_both_asked_of_every_image(self):
+        # The manifest declares platform.python == "3.11" and never says which
+        # name reaches it. A command built around the wrong one fails in a way
+        # that reads as the model writing a broken command.
+        result, _ = self._swept()
+        names = [row["name"] for row in result["records"]]
+        assert "python" in names and "python3" in names
+
+    def test_absent_commands_are_counted_rather_than_dropped(self):
+        transcript = _transcript(
+            [("python3", 0, "Python 3.11.15", ""), ("Rscript", 127, "", "not found")]
+        )
+        result, _ = self._swept(stdout=transcript)
+        assert result["probes_declared"] == len(result["records"])
+        assert result["present"] >= 1
+        assert result["absent"] >= 1
+        by_name = {row["name"]: row for row in result["records"]}
+        assert by_name["Rscript"]["present"] is False
+        assert by_name["python3"]["first_line"] == "Python 3.11.15"
+
+
+class TestTheMeasurementThatWasActuallyTaken:
+    """A regression check on the finding, not on the code.
+
+    These two numbers were measured on 2026-09-10 against the pinned parent and
+    a locally built candidate. They are recorded because the *difference*
+    between them is the whole professional-work layer, and because a later run
+    that quietly produced different numbers should be noticed rather than
+    absorbed.
+    """
+
+    ARTEFACT = BATCH_RUNNER_ROOT / "sandbox" / "v2" / "declared-command-sweep.json"
+
+    @pytest.mark.skipif(
+        not ARTEFACT.is_file(), reason="the recorded sweep has not been committed"
+    )
+    def test_the_parent_is_missing_exactly_the_professional_work_commands(self):
+        recorded = json.loads(self.ARTEFACT.read_text(encoding="utf-8"))
+        parent = recorded["parent"]
+        absent = {row["name"] for row in parent["records"] if not row["present"]}
+        assert absent == {
+            "Rscript", "chromium", "cmake", "node", "npm", "python3:ezdxf"
+        }
+
+    @pytest.mark.skipif(
+        not ARTEFACT.is_file(), reason="the recorded sweep has not been committed"
+    )
+    def test_the_candidate_answered_every_declared_probe(self):
+        recorded = json.loads(self.ARTEFACT.read_text(encoding="utf-8"))
+        candidate = recorded["candidate"]
+        assert candidate["absent"] == 0
+        assert candidate["present"] == candidate["probes_declared"]
+
+    @pytest.mark.skipif(
+        not ARTEFACT.is_file(), reason="the recorded sweep has not been committed"
+    )
+    def test_neither_sweep_is_recorded_as_evidence_it_is_not(self):
+        recorded = json.loads(self.ARTEFACT.read_text(encoding="utf-8"))
+        assert recorded["capability_receipt_status"] == "not_run"
+        assert recorded["signature_status"] == "not_run"
+        assert recorded["provenance_status"] == "not_run"

--- a/batch-runner/tests/test_run_agentic_stage_d_probe.py
+++ b/batch-runner/tests/test_run_agentic_stage_d_probe.py
@@ -1,0 +1,359 @@
+"""The runner that spends stage D's money, exercised without spending it.
+
+Stage D costs more per run than stage A did and costs it in two currencies —
+model calls and boots — so the parts that decide whether it happens are worth
+more than the run. Four of them are tested here.
+
+**Refusing on the wrong host.** Stage D runs where C2 booted a guest, and it
+establishes that by reading C2's artefact rather than by trying. A model call
+made on a host with no KVM would be bought and then discarded at the first
+``exec_run``. Each refusal is separate, because they ask the reader for
+different things: run C2, run C2 here, fix the host, or go and look at why the
+boot failed.
+
+**Using what C2 measured rather than what was intended.** The kernel, the
+rootfs, the jail account and the binaries all come out of the artefact, so the
+paid run is against the images that were actually booted.
+
+**The exit condition, which is not stage A's.** A model can be reached, ask for
+a command that the backend refuses on the host, and never boot. Stage D's middle
+term is that a command really ran inside a guest, and a test proves the middle
+term is load-bearing by removing only it.
+
+**What survives.** The record carries what is *known* about the guest image —
+``not_run`` — beside its digest, so no reader can take a stage D pass for image
+verification. It does not carry the benchmark wording or anything the model
+said.
+
+Nothing here boots anything or reaches a network.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+RUNNER_PATH = BATCH_RUNNER_ROOT / "scripts" / "run_agentic_stage_d_probe.py"
+
+from core.agentic_v2_stage_d_probe import (  # noqa: E402
+    PROBE_TOOLS,
+    StageDProbeOutcome,
+)
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location(
+        "run_agentic_stage_d_probe", RUNNER_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+runner = _load_runner()
+
+A_DIGEST = "sha256:ee6ef798631d3c3aeaed28658c640e6f5d021677449852bf2e1f18be5bd24edb"
+
+#: One boot that came back the way a working one does.
+#:
+#: The returncode matters and ``boot_outcome`` does not, because those answer
+#: different questions: a machine can start cleanly and its guest still write no
+#: status, and only the guest's own returncode file separates that from a
+#: command that ran and exited.
+A_BOOT_THAT_CAME_BACK = {
+    "boot_outcome": "booted",
+    "booted": True,
+    "result": {"data": {"returncode": 0}},
+}
+
+
+def a_c2_artefact(tmp_path: Path, **changes) -> Path:
+    """What C2 leaves behind after a boot that worked, minus what stage D never reads."""
+    firecracker = tmp_path / "firecracker"
+    jailer = tmp_path / "jailer"
+    firecracker.write_text("#!/bin/sh\n", encoding="utf-8")
+    jailer.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    artefact = {
+        "schema_version": "1.0",
+        "stage": "C2",
+        "outcome": "booted",
+        "host": {
+            "kernel_release": os.uname().release,
+            "cgroup_version": 2,
+            "kvm_present": True,
+            "firecracker": firecracker.as_posix(),
+            "jailer": jailer.as_posix(),
+            "firecracker_version": "v1.13.1",
+        },
+        "jail_account": {"name": "gdpvaljail", "uid": 997, "gid": 997},
+        "images": {
+            "kernel": {"path": (tmp_path / "vmlinux").as_posix(), "sha256": "a" * 64},
+            "rootfs": {"path": (tmp_path / "rootfs.ext4").as_posix(), "sha256": "b" * 64},
+            "image": {
+                "repository": "ghcr.io/hyeonsangjeon/gdpval-sandbox",
+                "pinned_digest": A_DIGEST,
+                "manifest_digest": "sha256:" + "9" * 64,
+            },
+            "work_disk": {"path": (tmp_path / "work.ext4").as_posix()},
+        },
+        "boot": {"outcome": "booted"},
+    }
+    artefact.update(changes)
+    written = tmp_path / "c2-first-boot.json"
+    written.write_text(json.dumps(artefact), encoding="utf-8")
+    return written
+
+
+def an_outcome(**changes) -> StageDProbeOutcome:
+    settings = {
+        "reached_a_model": True,
+        "resolved_model": "gpt-5.4",
+        "requested_deployment": "gpt-5.4",
+        "resource": "a-foundry-resource",
+        "tools_offered": PROBE_TOOLS,
+        "tools_asked_for": ("exec_run", "workspace_apply"),
+        "turns_taken": 4,
+        "stop_reason": "model_stopped_without_finishing",
+        "detail": "",
+        "guest_image": {"digest": A_DIGEST},
+        "image_evidence": {"status": "not_run", "subject": A_DIGEST, "grounds": "x"},
+        "boots": (
+            A_BOOT_THAT_CAME_BACK,
+            A_BOOT_THAT_CAME_BACK,
+        ),
+        "ledger": (
+            {"turn": 1, "history_entries_sent": 0},
+            {"turn": 2, "history_entries_sent": 1},
+            {"turn": 3, "history_entries_sent": 2},
+        ),
+    }
+    settings.update(changes)
+    return StageDProbeOutcome(**settings)
+
+
+def run_command(*arguments: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(RUNNER_PATH), *arguments],
+        cwd=BATCH_RUNNER_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+
+# ── the host, established by reading rather than by trying ────────────────
+
+
+class TestWhatStageDRefusesToRunOn:
+    def test_a_host_that_has_never_booted_a_guest(self, tmp_path):
+        with pytest.raises(runner.StageDRefused) as refused:
+            runner.read_what_c2_left(tmp_path / "nothing.json")
+        assert "Run scripts/run_agentic_c2_first_boot.py first" in str(refused.value)
+
+    def test_a_c2_run_that_recorded_a_failure_says_what_c2_said(self, tmp_path):
+        artefact = a_c2_artefact(
+            tmp_path,
+            outcome="host_cannot_boot",
+            reason="no /dev/kvm or no jailer on this machine",
+        )
+        with pytest.raises(runner.StageDRefused) as refused:
+            runner.read_what_c2_left(artefact)
+        said = str(refused.value)
+        assert "'host_cannot_boot'" in said
+        assert "no /dev/kvm" in said
+
+    def test_an_artefact_from_a_different_machine(self, tmp_path):
+        # The specific way this goes wrong in practice: the artefact is copied
+        # from the execution host to a developer box, and everything in it still
+        # reads as a successful boot.
+        artefact = a_c2_artefact(tmp_path)
+        moved = json.loads(artefact.read_text())
+        moved["host"]["kernel_release"] = "6.8.0-somewhere-else"
+        artefact.write_text(json.dumps(moved), encoding="utf-8")
+
+        with pytest.raises(runner.StageDRefused) as refused:
+            runner.read_what_c2_left(artefact)
+        assert "different machine" in str(refused.value)
+
+    def test_binaries_that_have_gone_since_c2_ran(self, tmp_path):
+        artefact = a_c2_artefact(tmp_path)
+        (tmp_path / "jailer").unlink()
+
+        with pytest.raises(runner.StageDRefused) as refused:
+            runner.read_what_c2_left(artefact)
+        assert "jailer" in str(refused.value)
+
+    def test_a_good_artefact_is_returned_whole(self, tmp_path):
+        artefact = runner.read_what_c2_left(a_c2_artefact(tmp_path))
+        assert artefact["outcome"] == "booted"
+        assert artefact["jail_account"]["uid"] == 997
+
+
+# ── the guest, named by what C2 measured ──────────────────────────────────
+
+
+class TestTheImageAndTheMachineComeFromC2:
+    def test_the_digest_is_the_one_c2_pinned_and_the_hashes_are_c2_s_own(
+        self, tmp_path
+    ):
+        image = runner.the_guest_c2_booted(
+            json.loads(a_c2_artefact(tmp_path).read_text())
+        )
+        assert image.digest == A_DIGEST
+        assert image.kernel_sha256 == "a" * 64
+        assert image.rootfs_sha256 == "b" * 64
+
+    def test_naming_the_image_is_not_evidence_about_it(self, tmp_path):
+        # The whole reason this field exists. A record that named a digest and
+        # stopped reads as though the evidence followed the name.
+        from core.agentic_v2_stage_d_probe import capability_evidence_for
+
+        image = runner.the_guest_c2_booted(
+            json.loads(a_c2_artefact(tmp_path).read_text())
+        )
+        assert capability_evidence_for(image)["status"] == "not_run"
+
+    def test_the_machine_jails_to_the_account_c2_used(self, tmp_path):
+        artefact = json.loads(a_c2_artefact(tmp_path).read_text())
+        machine = runner.the_machine_c2_proved(
+            artefact, scratch=tmp_path / "m", session="stage-d", vcpu_count=2
+        )
+        assert (machine.uid, machine.gid) == (997, 997)
+        assert machine.cgroup_version == 2
+        assert Path(machine.firecracker_binary).name == "firecracker"
+
+    def test_each_call_would_get_its_own_machine_name(self, tmp_path):
+        artefact = json.loads(a_c2_artefact(tmp_path).read_text())
+        machine = runner.the_machine_c2_proved(
+            artefact, scratch=tmp_path / "m", session="stage-d-task", vcpu_count=2
+        )
+        assert machine.name_the_machine() == "stage-d-task-0000"
+
+
+# ── the question stage D asked, which is not the one stage A asked ────────
+
+
+class TestTheExitCondition:
+    def test_reached_ran_and_worked_on_is_what_counts(self):
+        assert runner.exit_condition_met(an_outcome()) is True
+
+    def test_a_model_that_never_asked_for_a_command_does_not_count(self):
+        declined = an_outcome(
+            tools_asked_for=("capabilities_query",),
+            boots=(),
+            turns_taken=2,
+            ledger=({"turn": 1, "history_entries_sent": 0},),
+        )
+        assert declined.reached_a_model is True
+        assert runner.exit_condition_met(declined) is False
+
+    def test_a_command_the_backend_refused_before_booting_does_not_count(self):
+        # The middle term, alone. The model was reached and did go on afterwards
+        # — it went on from a refusal. Stage A's condition would pass this and it
+        # would prove nothing about the machine.
+        never_booted = an_outcome(boots=())
+        assert never_booted.reached_a_model is True
+        assert never_booted.worked_on_after_running_something is True
+        assert never_booted.a_command_really_ran is False
+        assert runner.exit_condition_met(never_booted) is False
+
+    def test_a_boot_that_failed_is_not_a_command_that_ran(self):
+        broken = an_outcome(
+            boots=({"boot_outcome": "workspace_did_not_come_back"},)
+        )
+        assert runner.exit_condition_met(broken) is False
+
+    def test_a_service_that_never_answered_does_not_count(self):
+        unreachable = an_outcome(
+            reached_a_model=False, resolved_model=None, turns_taken=0,
+            boots=(), ledger=(),
+        )
+        assert runner.exit_condition_met(unreachable) is False
+
+
+# ── what is left on disk afterwards ───────────────────────────────────────
+
+
+class FakeVerdict:
+    task_id = "02aa1805-c658-4069-8a6a-02dec146063a"
+
+
+def a_record(**changes):
+    said = {
+        "prompt_sha256": "c" * 64,
+        "approved_maximum_usd": "12.00",
+        "most_it_could_cost_usd": "3.40",
+    }
+    return runner.build_record(
+        verdict=FakeVerdict(),
+        said=said,
+        outcome=an_outcome(**changes),
+        fingerprint={"route_profile": "project-ci"},
+        workspace=Path("/tmp/agentic-v2-stage-d-xyz"),
+        artefact=Path("/var/tmp/gdpval-c2/c2-first-boot.json"),
+    )
+
+
+class TestTheRecord:
+    def test_it_names_the_task_and_hashes_its_wording_but_keeps_neither(self):
+        record = a_record()
+        assert record["task_id"] == FakeVerdict.task_id
+        assert record["prompt_sha256"] == "c" * 64
+        assert "prompt" not in record
+        assert "task_prompt" not in record
+
+    def test_it_carries_what_is_known_about_the_image_beside_the_digest(self):
+        probe = a_record()["probe"]
+        assert probe["guest_image"]["digest"] == A_DIGEST
+        assert probe["image_evidence"]["status"] == "not_run"
+
+    def test_it_says_whether_the_question_was_answered(self):
+        assert a_record()["exit_condition_met"] is True
+        assert a_record(boots=())["exit_condition_met"] is False
+
+    def test_it_points_at_the_c2_artefact_the_run_stood_on(self):
+        assert a_record()["c2_artefact"].endswith("c2-first-boot.json")
+
+    def test_it_can_be_written_down_as_it_stands(self):
+        json.dumps(a_record(), indent=2, sort_keys=True)
+
+
+# ── the free path really being free ───────────────────────────────────────
+
+
+def test_a_missing_c2_artefact_stops_the_command_before_anything_is_built(tmp_path):
+    """The first thing checked, because it is the cheapest and the most likely."""
+    finished = run_command(
+        "--dry-run", "--c2-artefact", str(tmp_path / "nothing.json")
+    )
+
+    assert finished.returncode == 1
+    assert "Refused before spending anything" in finished.stdout
+    assert "run_agentic_c2_first_boot.py first" in finished.stdout
+
+
+def test_the_refusal_happens_without_an_azure_route_configured():
+    """Not asserted — demonstrated.
+
+    Nothing in the test environment configures a route, and the client factory
+    refuses to build without one. A command that exits on the C2 check has not
+    reached that far, which is the ordering that makes the free path free.
+    """
+    assert "AZURE_AI_ROUTE_PROFILE" not in os.environ
+
+    finished = run_command("--dry-run", "--c2-artefact", "/nonexistent/c2.json")
+
+    assert finished.returncode == 1
+    assert "Traceback" not in finished.stderr

--- a/batch-runner/tests/test_run_agentic_stage_d_probe.py
+++ b/batch-runner/tests/test_run_agentic_stage_d_probe.py
@@ -242,6 +242,128 @@ class TestTheImageAndTheMachineComeFromC2:
         assert machine.name_the_machine() == "stage-d-task-0000"
 
 
+# ── the same bytes, not merely the same paths ─────────────────────────────
+#
+# C2 and C3 ran on a host that was then deallocated, and stage D runs after it
+# is started again. These files are on the OS disk and are expected to survive
+# that, which is exactly why the check is worth having: nothing here would
+# notice a reprovisioned disk until the money had been spent.
+
+
+def _images_that_are_really_there(tmp_path: Path) -> Path:
+    """C2's artefact with a kernel and rootfs that exist and hash to what it says."""
+    from core.agentic_v2_guest_image import sha256_file
+
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.write_bytes(b"not really a kernel")
+    rootfs.write_bytes(b"not really a filesystem")
+    written = a_c2_artefact(tmp_path)
+    artefact = json.loads(written.read_text())
+    artefact["images"]["kernel"]["sha256"] = sha256_file(kernel)
+    artefact["images"]["rootfs"]["sha256"] = sha256_file(rootfs)
+    written.write_text(json.dumps(artefact), encoding="utf-8")
+    return written
+
+
+class TestTheImagesAreStillTheOnesC2Booted:
+    def test_files_that_hash_to_what_c2_recorded_pass(self, tmp_path):
+        checked = runner.the_images_are_still_the_ones_c2_booted(
+            json.loads(_images_that_are_really_there(tmp_path).read_text())
+        )
+        assert checked["matches_the_guest_c2_booted"] is True
+        assert checked["kernel"]["sha256"] and checked["rootfs"]["sha256"]
+
+    def test_a_rootfs_that_is_gone_stops_the_run(self, tmp_path):
+        written = _images_that_are_really_there(tmp_path)
+        (tmp_path / "rootfs.ext4").unlink()
+        with pytest.raises(runner.StageDRefused) as refused:
+            runner.the_images_are_still_the_ones_c2_booted(
+                json.loads(written.read_text())
+            )
+        assert "not there now" in str(refused.value)
+        assert "run_agentic_c2_first_boot" in str(refused.value)
+
+    def test_a_rootfs_rebuilt_since_c2_stops_the_run(self, tmp_path):
+        # The case a path check alone would miss, and the expensive one: the
+        # file is present, the host looks healthy, and the model call is
+        # charged in full before the first command finds a different machine.
+        written = _images_that_are_really_there(tmp_path)
+        (tmp_path / "rootfs.ext4").write_bytes(b"a filesystem somebody rebuilt")
+        with pytest.raises(runner.StageDRefused) as refused:
+            runner.the_images_are_still_the_ones_c2_booted(
+                json.loads(written.read_text())
+            )
+        assert "different bytes" in str(refused.value)
+
+    def test_the_work_disk_is_not_pinned_and_says_why(self, tmp_path):
+        # Pinning it would assert the opposite of the workdir: ephemeral
+        # obligation stage C recorded and handed to stage D.
+        checked = runner.the_images_are_still_the_ones_c2_booted(
+            json.loads(_images_that_are_really_there(tmp_path).read_text())
+        )
+        assert isinstance(checked["work_disk"], str), "a note, not a measurement"
+        assert "ephemeral" in checked["work_disk"]
+
+
+# ── against the artefact the host really wrote ────────────────────────────
+
+
+class TestAgainstTheRealC2Record:
+    """The readers are held to C2's committed artefact, not only to fixtures.
+
+    Everything above builds the shape stage D expects and then checks stage D
+    reads it. That is circular in one specific way: it cannot notice the shape
+    being wrong. ``tasks/0822_saturday/c2_first_boot.json`` is what the Azure
+    host actually wrote on 2026-09-10, so these tests fail if the two ever
+    disagree — which is a failure that would otherwise appear on a started host
+    with a paid run waiting behind it.
+    """
+
+    REAL = (
+        Path(__file__).resolve().parents[2]
+        / "tasks"
+        / "0822_saturday"
+        / "c2_first_boot.json"
+    )
+
+    @pytest.fixture
+    def real(self):
+        if not self.REAL.is_file():  # pragma: no cover - it is committed
+            pytest.skip(f"{self.REAL} is not committed here")
+        return json.loads(self.REAL.read_text(encoding="utf-8"))
+
+    def test_the_guest_reads_out_of_the_real_artefact(self, real):
+        image = runner.the_guest_c2_booted(real)
+        assert image.digest == A_DIGEST
+        assert len(image.kernel_sha256) == 64
+        assert len(image.rootfs_sha256) == 64
+
+    def test_the_machine_reads_out_of_the_real_artefact(self, real):
+        machine = runner.the_machine_c2_proved(
+            real, scratch=Path("/tmp/never-used"), session="d", vcpu_count=2
+        )
+        assert machine.cgroup_version == 2, "stage D's policy needs cgroup v2"
+        assert Path(machine.kernel).name and Path(machine.rootfs).name
+        assert machine.uid > 0 and machine.gid > 0, "not root on the host"
+
+    def test_this_box_is_refused_by_the_real_artefact(self, real, tmp_path):
+        # Not a contrived refusal: the artefact says 6.17.0-azure and this
+        # suite runs on a 3.10 Synology kernel, so the gate is doing the exact
+        # job it was written for. On the execution host this test passes by
+        # the other branch.
+        copied = tmp_path / "c2-first-boot.json"
+        copied.write_text(json.dumps(real), encoding="utf-8")
+        recorded = real["host"]["kernel_release"]
+        if recorded == os.uname().release:
+            assert runner.read_what_c2_left(copied)["outcome"] == "booted"
+            return
+        with pytest.raises(runner.StageDRefused) as refused:
+            runner.read_what_c2_left(copied)
+        assert recorded in str(refused.value)
+        assert os.uname().release in str(refused.value)
+
+
 # ── the question stage D asked, which is not the one stage A asked ────────
 
 

--- a/batch-runner/tests/test_run_agentic_stage_d_probe.py
+++ b/batch-runner/tests/test_run_agentic_stage_d_probe.py
@@ -348,20 +348,36 @@ class TestAgainstTheRealC2Record:
         assert machine.uid > 0 and machine.gid > 0, "not root on the host"
 
     def test_this_box_is_refused_by_the_real_artefact(self, real, tmp_path):
-        # Not a contrived refusal: the artefact says 6.17.0-azure and this
-        # suite runs on a 3.10 Synology kernel, so the gate is doing the exact
-        # job it was written for. On the execution host this test passes by
-        # the other branch.
+        """Wherever this suite runs, it is not the host C2 booted on — and the
+        reason it is refused says which check caught it.
+
+        Written first as a kernel comparison, and CI corrected it. GitHub's
+        hosted runners are Azure virtual machines carrying the same
+        ``6.17.0-…-azure`` kernel build as the development host, so on a runner
+        the kernel matches and the artefact still describes a different
+        machine. The binaries are what separated them. So kernel equality is
+        necessary and not sufficient, both checks are load-bearing, and this
+        asserts the refusal rather than the route it took.
+        """
         copied = tmp_path / "c2-first-boot.json"
         copied.write_text(json.dumps(real), encoding="utf-8")
         recorded = real["host"]["kernel_release"]
-        if recorded == os.uname().release:
+        firecracker = Path(str(real["host"]["firecracker"]))
+
+        if recorded == os.uname().release and firecracker.is_file():
+            # The execution host itself. Nothing is refused here, which is the
+            # whole point of the gate.
             assert runner.read_what_c2_left(copied)["outcome"] == "booted"
             return
+
         with pytest.raises(runner.StageDRefused) as refused:
             runner.read_what_c2_left(copied)
-        assert recorded in str(refused.value)
-        assert os.uname().release in str(refused.value)
+        said = str(refused.value)
+        if recorded != os.uname().release:
+            assert recorded in said and os.uname().release in said
+        else:
+            assert "is not there now" in said
+            assert firecracker.as_posix() in said
 
 
 # ── the question stage D asked, which is not the one stage A asked ────────


### PR DESCRIPTION
Two things, both of which had to happen before stage D is allowed to cost anything.

## The overclaim, closed

`run_stage_d_probe`'s docstring and `ProbeCannotDescribeItself` both read as though naming the substrate manifest verified the guest image. It does not. The manifest is a **declaration** — twenty commands shaped `{"name": "Rscript", "probe": ["Rscript", "--version"]}`, no versions, no hashes — plus a `supply_chain` block naming *policy profiles* (`cosign-offline-v1`) rather than the result of applying them.

Worse, there is a gap underneath it that the repository was not saying out loud:

| | |
|---|---|
| the receipt that reads `verified` | measured on `sha256:e47537b8…`, a candidate **never pushed** and not present on any host here |
| the digest stage D is handed | `sha256:ee6ef798…` — which `parent.lock.json` pins, i.e. the **parent** the candidate was built *from* |
| signature / provenance / CVE | `not_run` for both, per `sandbox/v2/README.md` |

So the image stage D can fetch is not the image the capability evidence describes.

`capability_evidence_for()` reads that off the lock file rather than asserting it, in the vocabulary `core/agentic_v2_supply_chain.py:57` already uses — `verified` / `failed` / `not_run`, plus `unknown` for a digest nothing here holds a record of. The answer travels in the record as `image_evidence`, so a stage D result can never be read as a claim that the image it booted was verified. For the fetchable digest the answer is `not_run`, and that is the point of having the field.

A sha256 this repository computed over bytes it fetched is an identity for those bytes. It is not a supplier's assertion about what is in them, and nothing here presents it as one.

## The gap, measured

`sandbox/v2/probe_declared_commands.py` runs every declared probe inside one pinned image — one container, each probe its own `execve` and exit status. Deliberately **not** a capability receipt: a test hands the artifact to the repository's own `validate_capability_receipt` and requires it to say no, so a later edit that quietly widened the shape would be caught.

Two design points worth the review time:

- **fonts go through `fc-match`, not `fc-list | grep`.** Fontconfig substitutes silently — an absent `Noto Sans CJK KR` resolves to something else and exits 0. `fc-match` answers what a document would actually be rendered with.
- **a probe with no record is `answered: false`, not absent.** A driver that died partway is one fact about the sweep, not twenty findings about the image.

Both images swept on this box, recorded in `sandbox/v2/declared-command-sweep.json`:

```
parent    ee6ef798    40/40 answered   34 present   6 absent
                      absent: Rscript, chromium, cmake, node, npm, ezdxf
                      python AND python3 both reach 3.11.15 — this settles it
candidate 94ea6cb4    40/40 answered   40 present   0 absent
```

The difference between those two answer sets is the professional-work layer, measured rather than assumed. The reachable parent already carries LibreOffice, pandoc, GDAL, tesseract, ffmpeg, gcc/gfortran, and twelve of the thirteen declared Python modules — which is most of what the office and data tasks need.

Both sweeps were taken on a **cgroup v1, kernel 3.10.102** host, which the artifact records. Stage D's policy needs v2. Nothing here is an isolation result, and the artifact says so in an `is_not` field.

## The runner

`scripts/run_agentic_stage_d_probe.py` — the thing that will actually spend stage D.

**It refuses on the wrong host by reading, not by trying.** It will not start unless C2 has already booted a guest *here* and left the artefact saying so. A model call bought on a host with no KVM is discarded at the first `exec_run`, having cost the same as a useful one. Four separate refusals, because they ask the reader for four different things: run C2 · run C2 **here** (an artefact copied to a developer box still reads as a successful boot, so the kernel release is compared) · fix the host · go and look at why C2's boot failed.

**Its exit condition is not stage A's**, and the difference is the middle term: *a command really ran inside a guest*. A model can be reached, ask for a command the backend refuses on the host, and go on afterwards — stage A's condition passes that and it proves nothing about the machine. A test removes only the middle term to show it is load-bearing.

The gate and the prompt-wording check are loaded out of stage A's runner as that module's own functions rather than copied. A copy is a second place for the prompt hash to drift, and stage A's runner is a path a completed paid run was made with.

Committed past `batch-runner/scripts/*` the way its siblings are, with the same kind of note.

## Verification

- `--dry-run` against a synthetic C2 artefact, end to end and free: reads the real gate (**$0.59** of the **$1.00** approved), the real prompt at the pinned revision with its hash check, and prints the `not_run` evidence line. Exit 0.
- 45 new tests. None starts a container, boots anything, or reaches a network.
- `pytest -k "agentic or substrate or licen or sandbox or probe"` — 2351 passed, 4 skipped.

## What this does not do

No guard flipped. `foundation_only`, `production_activation` and the `exec_run` block are untouched. No paid call was made and no Azure resource was started — this window cost $0.