### PR TITLE
feat(analysis): answer exp034's registered questions from its artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,15 @@ batch-runner/scripts/*
 # this box is not, so the host gets it by cloning the repository.
 !batch-runner/scripts/run_agentic_c3_attacks.py
 
+# Answers the three questions exp034 registered in its header before it was
+# allowed to spend, against a downloaded run artifact. Committed because those
+# answers have to be checkable by someone who was not in the room: a figure
+# computed once in a terminal and pasted into a report is a figure nobody can
+# reproduce. It is also imported by
+# tests/test_an_unanswerable_question_is_declined.py, so a checkout missing it
+# fails collection loudly instead of skipping the tests in silence.
+!batch-runner/scripts/analyze_codex_run.py
+
 
 # Experiment report HTML (skews GitHub language stats)
 batch-runner/results/*/report/report.html

--- a/batch-runner/scripts/analyze_codex_run.py
+++ b/batch-runner/scripts/analyze_codex_run.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Answer the questions exp034 registered before it was allowed to spend.
+
+Why this exists
+---------------
+``experiments/exp034_codex_foundry_trial30.yaml`` writes three claims into its
+header *before* the run, so that they can be wrong:
+
+1. **A prediction about where failure lands.** In exp033 the two tasks that
+   succeeded carried the two longest task statements. Across the thirty,
+   eleven of thirty statements are shorter than 2,000 characters, so under the
+   null -- failure having nothing to do with statement length -- any given
+   failure lands short 36.7% of the time. Pile-up means the association is
+   real; proportional scatter means the five points were noise.
+
+2. **A question the run can answer alone.** exp034 raises ``max_retries`` from
+   2 to 3, so a task may now reach a fourth attempt, and the fourth is the
+   first to wait 240 s. *Did a fourth attempt ever convert a task that three
+   attempts had not?* If nothing in thirty converts, the extra budget bought
+   nothing and the next stage drops it.
+
+3. **A measurement never yet taken.** ``items_seen`` has a producer as of
+   ``core/codex_runner.py`` but no run has ever carried it: exp033's artifact
+   contains the string zero times. The first run dispatched after that lands
+   is the first real reading.
+
+Answering these by hand against a downloaded artifact means writing the same
+queries again under time pressure, when the temptation to round in a
+convenient direction is highest. They are written here instead, and were
+tested against exp033's real artifact -- a run whose answers are already
+known -- before exp034 produced any data.
+
+What this does
+--------------
+Given an unpacked run artifact, it reports per task the status, the error
+category recorded by ``classify_execution_error``, the number of settled
+ledger rows (which is the attempt count), and the cost state. Then it answers
+the three registered questions directly, and prints the contingency table the
+first one turns on.
+
+What it will not do
+-------------------
+* **It does not score.** Success here means the pipeline produced a
+  deliverable, not that the deliverable is any good. Grading is a separate
+  run with a separate cost, and the two are never added together.
+* **It does not convert a null cost into a zero.** A ledger row whose USD is
+  unknown is reported as unknown with its stated reason. ``partial`` is a
+  state this prints, not a state it repairs.
+* **It does not decide whether an association is a defect.** A shorter task
+  statement is a vaguer task, and a model given a vaguer task wandering into
+  content a filter stops is a benchmark result. This file reports where
+  failures land; what that means is not its call.
+* **It does not divide by a zero denominator.** No tasks in a bucket prints as
+  "no tasks", never as 0%.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+#: The header's boundary, restated so the comparison is reproducible.
+SHORT_STATEMENT_CHARS = 2000
+
+#: The null exp034's header registered before the run: eleven of its thirty
+#: statements fall under the boundary, so a failure indifferent to statement
+#: length lands short this often. Recomputed from the artifact below and
+#: compared against this, because a disagreement means the artifact is not the
+#: run the prediction was registered for -- which is worth saying out loud
+#: rather than quietly scoring a different population.
+REGISTERED_SHORT_SHARE_PCT = 36.7
+
+
+def _load_json(path: Path):
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _load_jsonl(path: Path) -> list[dict]:
+    if not path.is_file():
+        return []
+    rows = []
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def _find(root: Path, *names: str) -> Path | None:
+    """First of ``names`` that exists under ``root``, searched shallowly."""
+    for name in names:
+        candidate = root / name
+        if candidate.is_file():
+            return candidate
+    for name in names:
+        hits = sorted(root.rglob(name))
+        if hits:
+            return hits[0]
+    return None
+
+
+def _statement_of(task: dict) -> str:
+    """The task text whose length the header's prediction is about.
+
+    ``instruction`` is the key this dataset revision uses, and it is the one
+    the registered figures were computed from -- exp033's ``02aa1805`` measures
+    1,589 characters here, which is the number written into exp034's header.
+    The alternatives are tried after it so that a later revision renaming the
+    field degrades to "cannot test" rather than to a silent zero.
+    """
+    for key in ("instruction", "prompt", "task_statement", "statement"):
+        value = task.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def collect(root: Path) -> dict:
+    results_path = _find(root, "step2_inference_results.json")
+    if results_path is None:
+        raise SystemExit(f"no step2_inference_results.json under {root}")
+    payload = _load_json(results_path)
+    results = payload.get("results", payload if isinstance(payload, list) else [])
+
+    prepared_path = _find(root, "step1_tasks_prepared.json")
+    statements: dict[str, str] = {}
+    sectors: dict[str, str] = {}
+    if prepared_path is not None:
+        prepared = _load_json(prepared_path)
+        tasks = prepared.get("tasks", prepared if isinstance(prepared, list) else [])
+        for task in tasks:
+            tid = str(task.get("task_id", ""))
+            if tid:
+                statements[tid] = _statement_of(task)
+                sectors[tid] = str(task.get("sector", ""))
+
+    ledger: list[dict] = []
+    for name in ("cost_ledger_condition_a.jsonl", "cost_ledger.jsonl"):
+        found = _find(root, name)
+        if found is not None:
+            ledger = _load_jsonl(found)
+            break
+
+    rows_by_task: dict[str, list[dict]] = defaultdict(list)
+    for row in ledger:
+        rows_by_task[str(row.get("task_id"))].append(row)
+
+    tasks = []
+    for result in results:
+        tid = str(result.get("task_id", ""))
+        observability = result.get("observability") or {}
+        cost = result.get("problem_solving_cost") or {}
+        rows = rows_by_task.get(tid, [])
+        tasks.append(
+            {
+                "task_id": tid,
+                "status": result.get("status"),
+                "error_category": observability.get("error_category"),
+                "attempts": len(rows),
+                "settled": sum(1 for r in rows if r.get("state") == "settled"),
+                "retry_kinds": Counter(str(r.get("retry_kind")) for r in rows),
+                "cost_status": cost.get("status"),
+                "known_cost_usd": cost.get("known_cost_usd"),
+                "missing_reasons": sorted(
+                    {m for r in rows for m in (r.get("missing_reasons") or [])}
+                ),
+                "items_seen": result.get("items_seen"),
+                "latency_ms": result.get("latency_ms"),
+                "chars": len(statements.get(tid, "")),
+                "sector": sectors.get(tid, ""),
+            }
+        )
+    return {"meta": payload, "tasks": tasks, "ledger": ledger}
+
+
+def _pct(part: int, whole: int, noun: str = "tasks") -> str:
+    """A rate, or the reason there isn't one. Never 0% from an empty bucket.
+
+    ``noun`` names what the denominator counts, so that an empty bucket says
+    which bucket was empty. A run with no failures at all must not report
+    "no tasks" about a set of tasks that plainly exists.
+    """
+    if whole == 0:
+        return f"no {noun}"
+    return f"{part}/{whole} = {part / whole * 100:.1f}%"
+
+
+def report(data: dict) -> None:
+    tasks = data["tasks"]
+    meta = data["meta"]
+
+    print(f"experiment : {meta.get('experiment_id')}")
+    print(f"run_id     : {meta.get('run_id')}")
+    print(f"model      : {meta.get('model')}   mode: {meta.get('execution_mode')}")
+    print(f"resume     : rounds used = {meta.get('resume_rounds_used')}")
+    print()
+
+    print("=== per task ===")
+    header = f"{'task':10} {'status':9} {'category':18} {'att':>3} {'chars':>6} {'items':>6} cost"
+    print(header)
+    print("-" * len(header))
+    for t in sorted(tasks, key=lambda x: (x["status"] != "success", x["task_id"])):
+        print(
+            f"{t['task_id'][:8]:10} {str(t['status']):9} "
+            f"{str(t['error_category']):18} {t['attempts']:>3} "
+            f"{t['chars']:>6} {str(t['items_seen']):>6} {t['cost_status']}"
+        )
+    print()
+
+    total = len(tasks)
+    ok = [t for t in tasks if t["status"] == "success"]
+    bad = [t for t in tasks if t["status"] != "success"]
+    print(f"=== outcome ===  success {_pct(len(ok), total)}")
+    print("  categories:", dict(Counter(str(t["error_category"]) for t in bad)) or "none")
+    print()
+
+    by_sector: dict[str, list[dict]] = defaultdict(list)
+    for t in tasks:
+        by_sector[t["sector"] or "(unrecorded)"].append(t)
+    if len(by_sector) > 1:
+        print("=== by sector ===")
+        for sector, group in sorted(by_sector.items()):
+            won = sum(1 for t in group if t["status"] == "success")
+            print(f"  {sector[:46]:48} {_pct(won, len(group))}")
+        print()
+
+    # --- Registered question 1: does failure pile up in short statements? ---
+    print("=== 1. where failure lands ===")
+    measured = [t for t in tasks if t["chars"] > 0]
+    unmeasured = [t for t in tasks if t["chars"] <= 0]
+    if not measured:
+        print("  task statements were not carried in the artifact -- cannot test.")
+    else:
+        if unmeasured:
+            # Shrinking the denominator without saying so would turn a partly
+            # unreadable artifact into a confident-looking rate.
+            print(f"  NOT TESTED      : {len(unmeasured)}/{len(tasks)} tasks carried "
+                  f"no statement in the artifact and are excluded below "
+                  f"({', '.join(t['task_id'][:8] for t in unmeasured)})")
+        short = [t for t in measured if t["chars"] < SHORT_STATEMENT_CHARS]
+        long_ = [t for t in measured if t["chars"] >= SHORT_STATEMENT_CHARS]
+        short_bad = [t for t in short if t["status"] != "success"]
+        long_bad = [t for t in long_ if t["status"] != "success"]
+        failures = len(short_bad) + len(long_bad)
+        base = len(short) / len(measured) * 100
+        print(f"  boundary        : {SHORT_STATEMENT_CHARS} chars")
+        print(f"  chars min/max   : {min(t['chars'] for t in measured)} "
+              f"{max(t['chars'] for t in measured)}   "
+              f"median {statistics.median(t['chars'] for t in measured)}")
+        print(f"  short tasks     : {len(short)}/{len(measured)} = {base:.1f}%  "
+              f"<- the null: this is how often a failure lands short by chance")
+        if round(base, 1) != REGISTERED_SHORT_SHARE_PCT:
+            print(f"  NOTE            : the registered null was "
+                  f"{REGISTERED_SHORT_SHARE_PCT}%, so this artifact is not the "
+                  f"population that prediction was written for. The comparison "
+                  f"below is against this run's own {base:.1f}%.")
+        print(f"  failures short  : {_pct(len(short_bad), failures, 'failures')}")
+        print()
+        print(f"    {'':12}{'failed':>8}{'ok':>8}")
+        print(f"    {'short':12}{len(short_bad):>8}{len(short) - len(short_bad):>8}")
+        print(f"    {'long':12}{len(long_bad):>8}{len(long_) - len(long_bad):>8}")
+        print()
+        print(f"  failure rate short : {_pct(len(short_bad), len(short), 'short tasks')}")
+        print(f"  failure rate long  : {_pct(len(long_bad), len(long_), 'long tasks')}")
+        print("  (reported, not adjudicated -- a vaguer task failing is a "
+              "benchmark result, not automatically a defect)")
+    print()
+
+    # --- Registered question 2: did a fourth attempt ever convert? ---
+    print("=== 2. did a fourth attempt convert what three did not? ===")
+    deep = [t for t in tasks if t["attempts"] >= 4]
+    if not deep:
+        print("  no task reached a fourth attempt. The raised budget was never "
+              "exercised, so this run does not answer the question either way.")
+    else:
+        converted = [t for t in deep if t["status"] == "success"]
+        print(f"  reached 4+ attempts : {len(deep)}")
+        for t in deep:
+            print(f"    {t['task_id'][:8]}  attempts={t['attempts']}  -> {t['status']}")
+        print(f"  converted           : "
+              f"{_pct(len(converted), len(deep), 'deep tasks')}")
+        if not converted:
+            print("  The extra attempt bought nothing here. The next stage may drop it.")
+    print()
+
+    # --- Registered question 3: items_seen, first real reading ---
+    print("=== 3. items_seen ===")
+    seen = [t for t in tasks if isinstance(t["items_seen"], int)]
+    if not seen:
+        print("  absent from every task -- this artifact predates the producer, "
+              "or no turn reported one. Not a measurement of zero.")
+    else:
+        values = [t["items_seen"] for t in seen]
+        print(f"  carried on {len(seen)}/{len(tasks)} tasks   "
+              f"min {min(values)}  max {max(values)}  median {statistics.median(values)}")
+    print()
+
+    # --- Cost: reported, never repaired, never added to grading ---
+    print("=== cost (task-solving only; grading is a separate run) ===")
+    ledger = data["ledger"]
+    states = Counter(str(r.get("state")) for r in ledger)
+    print(f"  ledger rows     : {len(ledger)}   states: {dict(states)}")
+    print(f"  retry kinds     : {dict(Counter(str(r.get('retry_kind')) for r in ledger))}")
+    print(f"  resolved models : {dict(Counter(str(r.get('resolved_model')) for r in ledger))}")
+    known = [r.get("model_cost_usd") for r in ledger if isinstance(r.get("model_cost_usd"), (int, float))]
+    reasons = Counter(m for r in ledger for m in (r.get("missing_reasons") or []))
+    statuses = Counter(str(t["cost_status"]) for t in tasks)
+    print(f"  cost status     : {dict(statuses)}")
+    if reasons:
+        print(f"  USD unknown because: {dict(reasons)}")
+        print("  -> the run's dollar cost is UNDETERMINED, which is not zero.")
+    elif known:
+        print(f"  model cost USD  : {sum(known)}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "artifact",
+        type=Path,
+        help="directory holding an unpacked run artifact (workspace/ and results/)",
+    )
+    args = parser.parse_args(argv)
+    if not args.artifact.is_dir():
+        raise SystemExit(f"not a directory: {args.artifact}")
+    report(collect(args.artifact))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/batch-runner/scripts/analyze_codex_run.py
+++ b/batch-runner/scripts/analyze_codex_run.py
@@ -74,6 +74,43 @@ SHORT_STATEMENT_CHARS = 2000
 #: rather than quietly scoring a different population.
 REGISTERED_SHORT_SHARE_PCT = 36.7
 
+#: Outcomes where the turn never started, so ``items_seen`` was never set and
+#: the zero in the record is the dataclass default standing in for a value
+#: nobody took. ``core/codex_runner.py`` returns these four without passing
+#: ``items_seen`` at all -- ``runtime_unavailable``, ``runtime_start_failed``,
+#: ``session_start_failed``, ``turn_start_failed`` -- while the timeout, turn
+#: failure, and success paths all pass ``observed.items_seen``.
+#:
+#: The distinction is the whole point of the field. A refusal after forty
+#: items and a refusal after two are different claims about which limit was
+#: reached; a refusal before the stream opened is not a claim about item
+#: count at all, and averaging its zero in would drag the measurement toward
+#: "the turn spends nothing" for reasons that have nothing to do with
+#: spending.
+#:
+#: Only these four are listed because only these four are enumerable. What a
+#: started turn reports comes from ``classify_execution_error``, whose
+#: vocabulary is open, so an allow-list of post-stream categories cannot be
+#: written down. A category outside every set below is flagged rather than
+#: assumed into either one.
+PRE_STREAM_FAILURE_CATEGORIES = frozenset(
+    {
+        "runtime_unavailable",
+        "runtime_start_failed",
+        "session_start_failed",
+        "turn_start_failed",
+    }
+)
+
+
+def _items_seen_is_measured(task: dict) -> bool:
+    """Whether this task's ``items_seen`` is a count or an unset default."""
+    if not isinstance(task.get("items_seen"), int):
+        return False
+    if task.get("status") == "success":
+        return True
+    return str(task.get("error_category")) not in PRE_STREAM_FAILURE_CATEGORIES
+
 
 def _load_json(path: Path):
     with path.open(encoding="utf-8") as handle:
@@ -308,7 +345,18 @@ def report(data: dict) -> None:
 
     # --- Registered question 3: items_seen, first real reading ---
     print("=== 3. items_seen ===")
-    seen = [t for t in tasks if isinstance(t["items_seen"], int)]
+    seen = [t for t in tasks if _items_seen_is_measured(t)]
+    unset = [
+        t
+        for t in tasks
+        if isinstance(t["items_seen"], int) and not _items_seen_is_measured(t)
+    ]
+    if unset:
+        # Reporting these as zeros would answer the registered question with
+        # the dataclass default of a field the run never reached.
+        print(f"  NOT MEASURED    : {len(unset)}/{len(tasks)} tasks failed before "
+              f"the turn started, so their 0 is the field's default, not a count "
+              f"({', '.join(sorted(str(t['error_category']) for t in unset))})")
     if not seen:
         print("  absent from every task -- this artifact predates the producer, "
               "or no turn reported one. Not a measurement of zero.")
@@ -316,6 +364,31 @@ def report(data: dict) -> None:
         values = [t["items_seen"] for t in seen]
         print(f"  carried on {len(seen)}/{len(tasks)} tasks   "
               f"min {min(values)}  max {max(values)}  median {statistics.median(values)}")
+
+        # The discriminator this field was added for. A 429 is the provider
+        # saying no; where in the turn it arrives is the part that says what
+        # it was refusing. Refused after many items points at what one turn
+        # consumes; refused at zero or near it points at something decided
+        # before the turn spent anything -- arrival rate, concurrency, or a
+        # reservation that was already full. This prints the two numbers side
+        # by side and stops there: which limit it is, is not a thing a table
+        # of item counts can settle on its own.
+        refused = [t for t in seen if t["http_status_code"] == 429]
+        if refused:
+            print()
+            print(f"  of those, refused with HTTP 429 : {len(refused)}")
+            for t in sorted(refused, key=lambda x: x["items_seen"]):
+                print(f"    {t['task_id'][:8]}  items_seen={t['items_seen']:<5} "
+                      f"attempts={t['attempts']}")
+            at_zero = sum(1 for t in refused if t["items_seen"] == 0)
+            print(f"    refused before any item : "
+                  f"{_pct(at_zero, len(refused), '429 tasks')}")
+        else:
+            statuses = sorted(
+                {str(t["http_status_code"]) for t in seen if t["http_status_code"]}
+            )
+            print(f"  no task carried HTTP 429 alongside a measured item count"
+                  f"{'   (statuses seen: ' + ', '.join(statuses) + ')' if statuses else ''}")
     print()
 
     # --- Cost: reported, never repaired, never added to grading ---

--- a/batch-runner/scripts/analyze_codex_run.py
+++ b/batch-runner/scripts/analyze_codex_run.py
@@ -155,6 +155,16 @@ def collect(root: Path) -> dict:
     for result in results:
         tid = str(result.get("task_id", ""))
         observability = result.get("observability") or {}
+        # Where the persisted record actually keeps it. `codex_runner` hands
+        # the turn's numbers up under `codex_diagnostics`, and
+        # `_bounded_codex_diagnostics` re-homes them at
+        # `observability.codex` before anything is written to disk -- so the
+        # top level never carries them, and a reader that looks there reports
+        # "never measured" about the one measurement the run was dispatched
+        # to take. The top level is still consulted second, because a reader
+        # that breaks on a future move of the field is worse than one that
+        # tries both.
+        codex = observability.get("codex") or {}
         cost = result.get("problem_solving_cost") or {}
         rows = rows_by_task.get(tid, [])
         tasks.append(
@@ -170,7 +180,14 @@ def collect(root: Path) -> dict:
                 "missing_reasons": sorted(
                     {m for r in rows for m in (r.get("missing_reasons") or [])}
                 ),
-                "items_seen": result.get("items_seen"),
+                "items_seen": codex.get("items_seen", result.get("items_seen")),
+                # The provider's own answer, kept beside the item count
+                # because the two are read together: a 429 after many items
+                # and a 429 after two are different claims about which limit
+                # was reached.
+                "http_status_code": codex.get(
+                    "http_status_code", result.get("http_status_code")
+                ),
                 "latency_ms": result.get("latency_ms"),
                 "chars": len(statements.get(tid, "")),
                 "sector": sectors.get(tid, ""),

--- a/batch-runner/tests/test_an_unanswerable_question_is_declined.py
+++ b/batch-runner/tests/test_an_unanswerable_question_is_declined.py
@@ -1,0 +1,315 @@
+"""The analyzer has to be able to say "I cannot tell you that".
+
+`scripts/analyze_codex_run.py` answers three questions exp034 registered
+before it was allowed to spend. The danger in a tool like that is not that it
+computes a rate wrongly; it is that it computes a rate at all when the run did
+not contain the evidence for one. Every failure mode below produces a number
+that looks fine:
+
+* a run where nothing failed, reporting "0% of failures were short" as though
+  the association had been tested and found absent;
+* a bucket with no tasks in it, reporting 0% instead of saying the bucket was
+  empty;
+* an artifact whose task statements did not load, quietly shrinking the
+  denominator so the surviving tasks carry the whole conclusion;
+* `items_seen` missing from every task, reported as zero rather than as never
+  measured;
+* a ledger whose dollar figures are all unknown, summed to `0`.
+
+So the tests here are mostly *negative*: they build a run in which a question
+is unanswerable and require the analyzer to decline. The two positive tests --
+a fourth attempt that converted, and `items_seen` actually present -- exist
+because a tool that only ever declines is also useless, and because neither
+branch has ever run against real data: exp033 reached three attempts at most
+and carried `items_seen` zero times.
+
+One more is checked and it is not statistical. The registered null (36.7%,
+eleven of exp034's thirty statements under 2,000 characters) belongs to a
+specific population. Handed a different one, the analyzer must say so rather
+than silently comparing against a null that was never about these tasks.
+
+What none of this tests: whether any deliverable is any good. Success here
+means the pipeline produced one. Grading is a separate run with a separate
+cost and the analyzer never adds the two together.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import analyze_codex_run as analyzer  # noqa: E402
+
+
+def build(root: Path, spec: list[tuple]) -> Path:
+    """Write a minimal artifact.
+
+    ``spec`` rows are ``(task_id, status, category, attempts, chars,
+    items_seen)``. ``chars`` of 0 means the task carried no statement, which is
+    the artifact-is-partly-unreadable case; ``items_seen`` of ``None`` means
+    the key is absent rather than zero, which is how every run before the
+    producer landed looks.
+    """
+    workspace = root / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+
+    tasks, results, ledger = [], [], []
+    for task_id, status, category, attempts, chars, items_seen in spec:
+        task = {"task_id": task_id, "sector": "Finance"}
+        if chars:
+            task["instruction"] = "x" * chars
+        tasks.append(task)
+
+        result = {
+            "task_id": task_id,
+            "status": status,
+            "observability": {"error_category": category},
+            "problem_solving_cost": {"status": "partial", "known_cost_usd": None},
+            "latency_ms": 1000,
+        }
+        if items_seen is not None:
+            result["items_seen"] = items_seen
+        results.append(result)
+
+        for index in range(attempts):
+            ledger.append(
+                {
+                    "task_id": task_id,
+                    "call_id": f"{task_id}-{index}",
+                    "stage": "generation",
+                    "state": "settled",
+                    "retry_kind": "none" if index == 0 else "infrastructure",
+                    "resolved_model": "gpt-5.4",
+                    "model_cost_usd": None,
+                    "missing_reasons": ["call_reachability_unknown"],
+                }
+            )
+
+    (workspace / "step1_tasks_prepared.json").write_text(
+        json.dumps({"tasks": tasks}), encoding="utf-8"
+    )
+    (workspace / "step2_inference_results.json").write_text(
+        json.dumps(
+            {
+                "experiment_id": "fixture",
+                "run_id": "FIXTURE",
+                "model": "gpt-5.4",
+                "execution_mode": "codex_foundry",
+                "resume_rounds_used": 0,
+                "results": results,
+            }
+        ),
+        encoding="utf-8",
+    )
+    with (workspace / "cost_ledger_condition_a.jsonl").open("w", encoding="utf-8") as fh:
+        for row in ledger:
+            fh.write(json.dumps(row) + "\n")
+    return root
+
+
+def run(root: Path, capsys) -> str:
+    analyzer.report(analyzer.collect(root))
+    return capsys.readouterr().out
+
+
+# --- declining, not answering -------------------------------------------
+
+
+def test_a_run_with_no_failures_does_not_call_it_no_tasks(tmp_path, capsys):
+    """Zero failures is a denominator of failures, not of tasks.
+
+    Two tasks exist and both succeeded. "no tasks" would be a false statement
+    about a set that is plainly non-empty, and the reader would reasonably
+    conclude the artifact was broken.
+    """
+    build(tmp_path, [
+        ("eeee5555", "success", None, 1, 900, 7),
+        ("ffff6666", "success", None, 1, 3000, 9),
+    ])
+    out = run(tmp_path, capsys)
+    assert "failures short  : no failures" in out
+    assert "failures short  : no tasks" not in out
+
+
+def test_an_empty_bucket_names_the_bucket_instead_of_reporting_zero(tmp_path, capsys):
+    """No short tasks at all must not read as "short tasks never failed"."""
+    build(tmp_path, [
+        ("gggg7777", "error", "turn_failed", 2, 4000, None),
+        ("hhhh8888", "success", None, 1, 5000, None),
+    ])
+    out = run(tmp_path, capsys)
+    assert "failure rate short : no short tasks" in out
+    assert "failure rate short : 0/0" not in out
+
+
+def test_tasks_without_a_statement_are_named_not_silently_dropped(tmp_path, capsys):
+    """A shrinking denominator has to announce itself.
+
+    Two of four tasks carry no statement. Excluding them is correct -- their
+    length is unknown, so they cannot be sorted into short or long -- but
+    excluding them *quietly* turns a half-readable artifact into a confident
+    2-of-2 result.
+    """
+    build(tmp_path, [
+        ("aaaa1111", "success", None, 1, 900, 1),
+        ("bbbb2222", "error", "turn_failed", 2, 3000, 1),
+        ("cccc3333", "error", "turn_failed", 2, 0, 1),
+        ("dddd4444", "success", None, 1, 0, 1),
+    ])
+    out = run(tmp_path, capsys)
+    assert "NOT TESTED" in out
+    assert "2/4 tasks carried no statement" in out
+    assert "cccc3333" in out and "dddd4444" in out
+
+
+def test_items_seen_absent_is_declined_rather_than_read_as_zero(tmp_path, capsys):
+    """Every run before the producer landed looks exactly like this."""
+    build(tmp_path, [
+        ("gggg7777", "error", "turn_failed", 2, 4000, None),
+        ("hhhh8888", "success", None, 1, 5000, None),
+    ])
+    out = run(tmp_path, capsys)
+    assert "Not a measurement of zero" in out
+
+
+def test_no_fourth_attempt_declines_instead_of_reporting_no_benefit(tmp_path, capsys):
+    """An unexercised budget is not a budget that bought nothing.
+
+    Those are different findings and only one of them justifies dropping the
+    extra attempt in the next stage.
+    """
+    build(tmp_path, [
+        ("eeee5555", "success", None, 1, 900, 7),
+        ("ffff6666", "success", None, 1, 3000, 9),
+    ])
+    out = run(tmp_path, capsys)
+    assert "does not answer the question either way" in out
+
+
+# --- the registered population ------------------------------------------
+
+
+def test_a_different_population_says_the_registered_null_is_not_its_null(tmp_path, capsys):
+    """exp033's five tasks are 3 short of 5 -- 60%, not 36.7%.
+
+    Comparing them against a null computed from exp034's thirty would be
+    comparing against a number that was never about them.
+    """
+    build(tmp_path, [
+        ("02aa1805", "error", "turn_failed", 2, 1589, None),
+        ("0112fc9b", "success", None, 1, 2902, None),
+        ("2ea2e5b5", "success", None, 1, 3632, None),
+        ("3baa0009", "error", "turn_failed", 2, 996, None),
+        ("0818571f", "error", "rate_limited", 3, 1548, None),
+    ])
+    out = run(tmp_path, capsys)
+    assert "short tasks     : 3/5 = 60.0%" in out
+    assert "not the population that prediction was written for" in out
+
+
+def test_the_registered_population_raises_no_such_note(tmp_path, capsys):
+    """Eleven short of thirty is 36.7%, which is the registered figure."""
+    spec = []
+    for index in range(11):
+        spec.append((f"short{index:03d}", "error", "turn_failed", 2, 1500, 3))
+    for index in range(19):
+        spec.append((f"long{index:03d}", "success", None, 1, 2500, 3))
+    build(tmp_path, spec)
+    out = run(tmp_path, capsys)
+    assert "short tasks     : 11/30 = 36.7%" in out
+    assert "not the population that prediction was written for" not in out
+
+
+# --- the two branches no real run has ever taken -------------------------
+
+
+def test_a_fourth_attempt_that_converted_is_reported_as_such(tmp_path, capsys):
+    """exp033 reached three attempts at most, so this path is unproven.
+
+    exp034 raises `max_retries` to 3, which permits a fourth attempt. If one
+    converts a task the first three did not, that is the finding that keeps
+    the extra budget; the analyzer has to be able to see it.
+    """
+    build(tmp_path, [
+        ("aaaa1111", "success", None, 4, 900, 12),
+        ("bbbb2222", "error", "turn_failed", 4, 1200, 3),
+        ("cccc3333", "success", None, 1, 3000, 41),
+    ])
+    out = run(tmp_path, capsys)
+    assert "reached 4+ attempts : 2" in out
+    assert "aaaa1111  attempts=4  -> success" in out
+    assert "converted           : 1/2 = 50.0%" in out
+
+
+def test_items_seen_present_is_measured(tmp_path, capsys):
+    """The first run dispatched after the producer landed is the first reading.
+
+    A value of zero on one task is a real zero and must be counted, not
+    mistaken for the key being absent.
+    """
+    build(tmp_path, [
+        ("aaaa1111", "success", None, 1, 900, 12),
+        ("dddd4444", "error", "rate_limited", 3, 1500, 0),
+    ])
+    out = run(tmp_path, capsys)
+    assert "carried on 2/2 tasks" in out
+    assert "min 0" in out
+    assert "Not a measurement of zero" not in out
+
+
+# --- cost ----------------------------------------------------------------
+
+
+def test_unknown_dollars_stay_undetermined_and_never_become_zero(tmp_path, capsys):
+    """This deployment is absent from the price table, so USD is unknown.
+
+    Every ledger row here carries `call_reachability_unknown`. The run's cost
+    is undetermined; printing `0` would be a claim nobody measured.
+    """
+    build(tmp_path, [
+        ("aaaa1111", "success", None, 1, 900, 12),
+        ("dddd4444", "error", "rate_limited", 3, 1500, 0),
+    ])
+    out = run(tmp_path, capsys)
+    assert "UNDETERMINED, which is not zero" in out
+    assert "call_reachability_unknown" in out
+    assert "model cost USD" not in out
+
+
+def test_the_cost_section_says_grading_is_not_included(tmp_path, capsys):
+    """Solving cost and grading cost are separate runs and separate money."""
+    build(tmp_path, [("aaaa1111", "success", None, 1, 900, 12)])
+    out = run(tmp_path, capsys)
+    assert "task-solving only; grading is a separate run" in out
+
+
+# --- the reader itself ---------------------------------------------------
+
+
+def test_a_missing_results_file_fails_loudly(tmp_path):
+    """An empty directory must not analyse as a run of zero tasks."""
+    (tmp_path / "workspace").mkdir()
+    with pytest.raises(SystemExit):
+        analyzer.collect(tmp_path)
+
+
+def test_the_statement_field_this_dataset_uses_is_the_one_read(tmp_path, capsys):
+    """`instruction` is the key, and the figures registered came from it.
+
+    A later revision renaming the field should degrade to "cannot test", not
+    to a silent zero, which is why `_statement_of` tries alternatives and
+    returns "" rather than raising.
+    """
+    assert analyzer._statement_of({"instruction": "abc"}) == "abc"
+    assert analyzer._statement_of({"prompt": "abc"}) == "abc"
+    assert analyzer._statement_of({"unrelated": "abc"}) == ""
+
+    build(tmp_path, [("aaaa1111", "success", None, 1, 0, 1)])
+    out = run(tmp_path, capsys)
+    assert "cannot test" in out

--- a/batch-runner/tests/test_an_unanswerable_question_is_declined.py
+++ b/batch-runner/tests/test_an_unanswerable_question_is_declined.py
@@ -55,6 +55,15 @@ def build(root: Path, spec: list[tuple]) -> Path:
     the artifact-is-partly-unreadable case; ``items_seen`` of ``None`` means
     the key is absent rather than zero, which is how every run before the
     producer landed looks.
+
+    ``items_seen`` is written where the pipeline writes it -- under
+    ``observability.codex``, which is where ``_bounded_codex_diagnostics``
+    puts it in ``step2_run_inference.py`` -- and not at the result's top
+    level. A fixture that invents its own layout tests the fixture: this one
+    said ``result["items_seen"]``, the analyzer read the same wrong place,
+    and the pair agreed with each other while both disagreed with every real
+    artifact. The measurement the run was dispatched to take would have been
+    reported as never taken, and this suite would have stayed green.
     """
     workspace = root / "workspace"
     workspace.mkdir(parents=True, exist_ok=True)
@@ -74,7 +83,7 @@ def build(root: Path, spec: list[tuple]) -> Path:
             "latency_ms": 1000,
         }
         if items_seen is not None:
-            result["items_seen"] = items_seen
+            result["observability"]["codex"] = {"items_seen": items_seen}
         results.append(result)
 
         for index in range(attempts):

--- a/batch-runner/tests/test_an_unanswerable_question_is_declined.py
+++ b/batch-runner/tests/test_an_unanswerable_question_is_declined.py
@@ -64,12 +64,18 @@ def build(root: Path, spec: list[tuple]) -> Path:
     and the pair agreed with each other while both disagreed with every real
     artifact. The measurement the run was dispatched to take would have been
     reported as never taken, and this suite would have stayed green.
+
+    A row may carry a seventh element, the HTTP status the turn was refused
+    with. Rows without one are unchanged, because a status is a thing most
+    outcomes do not have.
     """
     workspace = root / "workspace"
     workspace.mkdir(parents=True, exist_ok=True)
 
     tasks, results, ledger = [], [], []
-    for task_id, status, category, attempts, chars, items_seen in spec:
+    for row in spec:
+        task_id, status, category, attempts, chars, items_seen = row[:6]
+        http_status = row[6] if len(row) > 6 else None
         task = {"task_id": task_id, "sector": "Finance"}
         if chars:
             task["instruction"] = "x" * chars
@@ -83,7 +89,10 @@ def build(root: Path, spec: list[tuple]) -> Path:
             "latency_ms": 1000,
         }
         if items_seen is not None:
-            result["observability"]["codex"] = {"items_seen": items_seen}
+            codex = {"items_seen": items_seen}
+            if http_status is not None:
+                codex["http_status_code"] = http_status
+            result["observability"]["codex"] = codex
         results.append(result)
 
         for index in range(attempts):
@@ -270,6 +279,71 @@ def test_items_seen_present_is_measured(tmp_path, capsys):
     assert "carried on 2/2 tasks" in out
     assert "min 0" in out
     assert "Not a measurement of zero" not in out
+
+
+def test_a_turn_that_never_started_is_not_a_count_of_zero(tmp_path, capsys):
+    """The four pre-stream failures return ``items_seen`` at its default.
+
+    ``core/codex_runner.py`` builds ``codex_diagnostics`` from the outcome
+    unconditionally, so a task that died before the stream opened still
+    arrives carrying ``items_seen: 0`` -- a field nobody set, indistinguishable
+    in the JSON from a turn that opened and streamed nothing.
+
+    Counting those zeros would answer the registered question with a dataclass
+    default, and would do it in the direction that flatters the convenient
+    reading: a median dragged toward zero is evidence that a turn is refused
+    before it spends anything, which is exactly the claim this field exists to
+    test rather than to assume.
+    """
+    build(tmp_path, [
+        ("aaaa1111", "success", None, 1, 900, 40),
+        ("bbbb2222", "error", "session_start_failed", 2, 1200, 0),
+        ("cccc3333", "error", "runtime_unavailable", 1, 1500, 0),
+    ])
+    out = run(tmp_path, capsys)
+    assert "NOT MEASURED    : 2/3 tasks failed before the turn started" in out
+    assert "session_start_failed" in out
+    assert "runtime_unavailable" in out
+    # One task measured, and its 40 is not averaged against two unset zeros.
+    assert "carried on 1/3 tasks" in out
+    assert "min 40  max 40" in out
+
+
+def test_where_a_refusal_lands_in_the_turn_is_reported_beside_the_count(
+    tmp_path, capsys
+):
+    """The cross-tab priority 1 actually turns on.
+
+    A 429 says the provider refused. How far the turn got before being
+    refused is the part that distinguishes "this turn consumed too much" from
+    "something was decided before this turn spent anything". The analyzer
+    prints both numbers together and declines to name the limit, because a
+    table of item counts cannot settle that on its own.
+    """
+    build(tmp_path, [
+        ("aaaa1111", "success", None, 1, 900, 37),
+        ("dddd4444", "error", "rate_limited", 3, 1500, 0, 429),
+        ("eeee5555", "error", "rate_limited", 2, 2400, 22, 429),
+    ])
+    out = run(tmp_path, capsys)
+    assert "refused with HTTP 429 : 2" in out
+    assert "dddd4444  items_seen=0" in out
+    assert "eeee5555  items_seen=22" in out
+    assert "refused before any item : 1/2 = 50.0%" in out
+
+
+def test_a_run_with_no_refusals_says_so_rather_than_printing_an_empty_table(
+    tmp_path, capsys
+):
+    """No 429 is a result. It must not read as a table that failed to print."""
+    build(tmp_path, [
+        ("aaaa1111", "success", None, 1, 900, 37),
+        ("bbbb2222", "error", "turn_failed", 2, 1500, 9, 500),
+    ])
+    out = run(tmp_path, capsys)
+    assert "no task carried HTTP 429 alongside a measured item count" in out
+    assert "statuses seen: 500" in out
+    assert "refused before any item" not in out
 
 
 # --- cost ----------------------------------------------------------------


### PR DESCRIPTION
## What this adds

`batch-runner/scripts/analyze_codex_run.py` — reads an unpacked run artifact and answers the three questions `exp034_codex_foundry_trial30.yaml` registered in its header **before** the run was allowed to spend:

1. **Where failure lands.** Eleven of exp034's thirty statements are under 2,000 characters, so under the null — failure being indifferent to statement length — any failure lands short 36.7% of the time.
2. **Did a fourth attempt convert what three did not?** exp034 raises `max_retries` 2 → 3, and `infra_max_attempts = max_retries + 1` (`step2_run_inference.py:3095`), so a fourth attempt is possible for the first time.
3. **`items_seen`.** It has a producer as of #505 but exp033's artifact contains the string zero times, so the next run is the first real reading.

Plus `batch-runner/tests/test_an_unanswerable_question_is_declined.py` (13 tests) and the `.gitignore` re-admission line the script needs to survive the `batch-runner/scripts/*` directory rule.

## Why now, rather than after the run

Writing these queries under time pressure, against data you are hoping says something, is when rounding in a convenient direction is most tempting. Written first, they can be wrong in public.

## Validation

Run against **exp033's real artifact** (run `34528903950`), whose answers are already known. It reproduces every fact: 2/5 success, `{turn_failed: 2, rate_limited: 1}`, attempts 1/1/2/3/2, ledger 9/9 settled, every task `cost_status=partial`. It independently reproduces the five statement lengths registered in exp034's header — 2902 / 3632 / 1589 / 1548 / 996 — from the artifact rather than from the header.

On exp033 it reports **all three registered questions as unanswerable**, which is the correct answer there.

## Four defects found and fixed

Found by running the analyzer against synthetic artifacts shaped like outcomes exp033 could not produce. Each is held by a test that **fails without the fix** (verified: 4 failed / 9 passed against the unpatched script):

| Defect | Was | Now |
|---|---|---|
| A run with no failures | `failures short : no tasks` — false, tasks existed | `no failures` |
| An empty short bucket | printed a rate over nothing | `no short tasks` |
| Tasks whose statement did not load | silently dropped from the denominator | `NOT TESTED: 2/4 tasks carried no statement`, named |
| The registered 36.7% null | compared against any population handed to it | says so when the population is not the registered one |

The last one matters most: exp033's five tasks are 60% short, not 36.7%. Comparing them against exp034's null would be comparing against a number that was never about them.

## Branches covered for the first time

No real run has ever taken either: a **fourth attempt** (impossible before this stage) and a **populated `items_seen`** (no producer until #505). Both are now exercised.

## What this does not do

- **It does not score.** Success means the pipeline produced a deliverable, not that the deliverable is good. Grading is a separate run with a separate cost and the two are never added together.
- **It does not convert a null cost into a zero.** exp033's nine ledger rows all carry `call_reachability_unknown`; the run's dollar cost is *undetermined*, which is not zero.
- **It does not adjudicate.** A shorter statement is a vaguer task, and a model given a vaguer task wandering into content a filter stops is a benchmark result, not automatically an environment defect. This reports where failures land; what that means is not its call.
- **It does not divide by a zero denominator.**

## Test evidence

- New file: 13 passed.
- `test_a_test_file_nobody_runs_is_not_a_test.py` + `test_the_free_check_runs_in_ci.py`: 62 passed (the census and CI-wiring tests a new file could disturb).
- Full backend suite on the pre-change tree: **10,054 passed / 18 skipped / 0 failed** (21m39s).

## Merge note

Run **34540053904** (exp034, 30 tasks) is in flight. Merging anything to `main` while it is up kills its next relay leg — the pre-credential guard asserts `SOURCE_SHA == EVENT_SHA`, so a docs-only commit is as fatal as a code one. **Do not merge until that run is finished.** Opening the PR is safe; `main` does not move.
