### PR TITLE
feat(sandbox-v2): take the declared-command sweep inside the guest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,6 +195,11 @@ tasks/0822_saturday/*
 # if the thing being read is only on a VM that gets deallocated.
 !tasks/0822_saturday/c2_first_boot.json
 !tasks/0822_saturday/c3_attacks.json
+# The declared-command sweep taken inside a guest, for the same reason: the
+# prose above reads it, and a reading nobody can check is not evidence. Its
+# tests assert against this file directly, so it is also the thing that would
+# fail if the module and the artefact ever stopped agreeing.
+!tasks/0822_saturday/guest_declared_command_sweep.json
 !tasks/0828_friday/
 tasks/0828_friday/*
 !tasks/0828_friday/TASK_PER_TASK_COST_RECEIPTS.md

--- a/batch-runner/sandbox/v2/sweep_in_guest.py
+++ b/batch-runner/sandbox/v2/sweep_in_guest.py
@@ -1,0 +1,401 @@
+"""Take the declared-command sweep again, inside the guest stage D will boot.
+
+:mod:`sandbox.v2.probe_declared_commands` answers *what is in this image* by
+running the probes in a container. It says, in its own artifact, that the
+answer belongs to the place it was taken — and both sweeps it has produced so
+far were taken with docker on a cgroup v1 host running a 3.10 kernel, which is
+not where any task will run.
+
+This module takes the same measurement in the place that matters: the rootfs
+C2 booted, in a Firecracker microVM, under
+:data:`core.agentic_v2_substrate.REQUIRED_MICROVM_POLICY`, on the host whose
+kernel C2 recorded. Same probes, same framing, same reader — the only thing
+that changes is the machine, which is the whole point.
+
+**Two changes to the driver, both recorded in the artifact.**
+
+The container sweep gives each probe ``/tmp`` to write to. In the guest the
+rootfs is mounted read-only by policy and the work disk at ``/work`` is the only
+writable mount, so the redirections move there and ``HOME`` and ``TMPDIR``
+follow. That second one is not tidiness: a probe that fails because it had
+nowhere to write exits non-zero exactly like a probe whose command is absent,
+and the artifact would record the wrong reason.
+
+**What a result here is still not.** Not a capability receipt — it carries no
+SBOM, no licence classification, no package inventory — and
+:func:`core.agentic_v2_substrate.validate_capability_receipt` rejects it, which
+a test asserts. Not a signature or provenance check; those remain ``not_run``.
+Not an isolation measurement; C3 made that one, separately, by attacking.
+
+**On ``guest_uid``.** The artifact records ``0``, and that is not a containment
+failure. Root inside the guest is the ordinary arrangement for a microVM: the
+boundary is the virtual machine, not a uid, and the *host* side of it runs as
+the unprivileged jail account C2 recorded. Both numbers are kept side by side
+so no reader has to take that on trust.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+BATCH_ROOT = Path(__file__).resolve().parents[2]
+if str(BATCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_ROOT))
+
+from core.agentic_v2_first_boot import first_boot  # noqa: E402
+from core.agentic_v2_guest_image import build_ext4, sha256_file  # noqa: E402
+from core.agentic_v2_microvm_launch import build_launch_plan  # noqa: E402
+from core.agentic_v2_substrate import REQUIRED_MICROVM_POLICY  # noqa: E402
+from sandbox.v2.probe_declared_commands import (  # noqa: E402
+    ALWAYS_ASKED,
+    DEFAULT_MANIFEST,
+    _canonical_sha256,
+    _font_probes,
+    _module_probes,
+    _parse,
+    _shell_driver,
+)
+
+#: Where C2 left its record, and where its images still are.
+C2_ARTEFACT = Path("/var/tmp/gdpval-c2/c2-first-boot.json")
+
+#: The guest's only writable mount, created by the init at ``/work``.
+WRITABLE_MOUNT = "/work"
+
+#: The input path the guest init reads its command from, and the two result
+#: files this module needs back out of the work disk.
+WORK_DISK_INPUT = "/in/command.sh"
+
+
+class GuestSweepRefused(RuntimeError):
+    """The sweep was not run, and the reason is not a fact about the image."""
+
+
+def read_the_c2_record(path: Path = C2_ARTEFACT) -> dict[str, Any]:
+    """C2's artefact, or a refusal that says which of four things to do.
+
+    The same four questions the stage D runner asks, for the same reason and at
+    a fraction of the cost: this sweep is free, so its refusals are about not
+    producing a measurement that would be read as belonging to a machine it was
+    not taken on.
+    """
+    path = Path(path)
+    if not path.is_file():
+        raise GuestSweepRefused(
+            f"there is no C2 record at {path}. Run "
+            "scripts/run_agentic_c2_first_boot.py first: without it there is no "
+            "rootfs to sweep and no evidence this host can boot one"
+        )
+    record = json.loads(path.read_text(encoding="utf-8"))
+    outcome = record.get("outcome")
+    if outcome != "booted":
+        raise GuestSweepRefused(
+            f"C2 recorded {outcome!r} on this host"
+            + (f": {record['reason']}" if record.get("reason") else "")
+            + ". A sweep needs a guest that starts, so fix that first"
+        )
+    recorded_kernel = str(record["host"]["kernel_release"])
+    running_kernel = platform.release()
+    if recorded_kernel != running_kernel:
+        raise GuestSweepRefused(
+            f"C2 booted on kernel {recorded_kernel} and this is {running_kernel}, "
+            "so the record was copied from a different machine. Run C2 here "
+            "before sweeping here"
+        )
+    return record
+
+
+def images_are_where_c2_left_them(
+    record: Mapping[str, Any], *, rehash: bool = False, measure: Any = None
+) -> dict[str, Any]:
+    """Kernel and rootfs present, and optionally still the same bytes.
+
+    Presence is always checked because a missing file produces a boot failure
+    that reads like a broken image. Re-hashing is opt-in: it costs a full read
+    of about nine gibibytes, which is nothing against a paid stage D run and is
+    most of the wall clock of a free sweep.
+    """
+    hasher = measure or sha256_file
+    checked: dict[str, Any] = {"rehashed": bool(rehash)}
+    for which in ("kernel", "rootfs"):
+        recorded = record["images"][which]
+        where = Path(str(recorded["path"]))
+        if not where.is_file():
+            raise GuestSweepRefused(
+                f"C2 booted {which} at {where} and it is not there now; the host "
+                "has been reprovisioned or the file was removed"
+            )
+        entry: dict[str, Any] = {"path": where.as_posix()}
+        if rehash:
+            found = hasher(where)
+            if found != str(recorded["sha256"]):
+                raise GuestSweepRefused(
+                    f"the {which} at {where} hashes {found} and C2 booted "
+                    f"{recorded['sha256']}; these are different bytes"
+                )
+            entry["sha256"] = found
+        else:
+            entry["sha256_recorded_by_c2"] = str(recorded["sha256"])
+        checked[which] = entry
+    return checked
+
+
+def build_probes(manifest: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Every probe the container sweep would ask, in the same order.
+
+    Built here rather than imported as a list because
+    :func:`~sandbox.v2.probe_declared_commands.sweep` assembles them inline; the
+    four helpers it assembles them from are shared, so the two sweeps cannot
+    drift into asking different questions.
+    """
+    probes: list[dict[str, Any]] = [dict(p, kind="command") for p in ALWAYS_ASKED]
+    probes += [dict(p, kind="command") for p in manifest["commands"]]
+    probes += _module_probes(manifest["python_modules"], "python3")
+    probes += _font_probes(manifest["font_families"])
+    return probes
+
+
+#: Prepended to the shared driver. Exported so the artifact can quote what it
+#: actually ran rather than describe it.
+GUEST_PREAMBLE = f"HOME={WRITABLE_MOUNT}\nTMPDIR={WRITABLE_MOUNT}\nexport HOME TMPDIR\n"
+
+
+def guest_driver(probes: Sequence[Mapping[str, Any]]) -> str:
+    """The shared driver with its scratch paths moved onto the work disk.
+
+    A textual substitution on a generated string, which is worth being uneasy
+    about — so it is checked rather than trusted. If the shared driver ever
+    stops writing to ``/tmp/probe.``, or starts writing somewhere else as well,
+    the assertion fails here instead of the sweep silently recording every probe
+    as absent because the redirect hit a read-only filesystem.
+    """
+    driver = _shell_driver(probes)
+    if "/tmp/probe." not in driver:
+        raise GuestSweepRefused(
+            "the shared driver no longer redirects to /tmp/probe., so this "
+            "module's substitution has nothing to do and would leave the "
+            "scratch paths pointing at a read-only rootfs. Update it together "
+            "with probe_declared_commands._shell_driver"
+        )
+    moved = driver.replace("/tmp/probe.", f"{WRITABLE_MOUNT}/probe.")
+    if "/tmp/probe." in moved:
+        raise GuestSweepRefused("a /tmp scratch path survived the substitution")
+    return GUEST_PREAMBLE + moved
+
+
+def boot_one_guest(
+    *,
+    driver: str,
+    record: Mapping[str, Any],
+    workdir: Path,
+    vcpu_count: int = 1,
+    policy: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """One machine, one driver, and whatever it wrote on the way out.
+
+    ``workdir`` is where the work disk is built, and it is deliberately not
+    C2's directory: building one there would put a fresh ``work.ext4`` beside
+    the rootfs whose hash C2 recorded, and the next person to read that
+    directory would have to work out which files are evidence.
+    """
+    host = record["host"]
+    account = record["jail_account"]
+    in_force = dict(policy or REQUIRED_MICROVM_POLICY)
+
+    staging = Path(workdir) / "work-in"
+    (staging / "in").mkdir(parents=True, exist_ok=True)
+    (staging / "out").mkdir(parents=True, exist_ok=True)
+    (staging / WORK_DISK_INPUT.lstrip("/")).write_text(driver, encoding="utf-8")
+    disk = build_ext4(
+        Path(workdir) / "work-sweep.ext4",
+        size_mib=int(in_force["workdir_quota_mib"]),
+        populate_from=staging,
+    )
+
+    kernel = Path(str(record["images"]["kernel"]["path"]))
+    rootfs = Path(str(record["images"]["rootfs"]["path"]))
+    plan = build_launch_plan(
+        vm_id="declared-sweep",
+        firecracker_binary=host["firecracker"],
+        kernel_path=kernel,
+        rootfs_path=rootfs,
+        work_disk_path=disk["path"],
+        uid=account["uid"],
+        gid=account["gid"],
+        vcpu_count=vcpu_count,
+        cgroup_version=host["cgroup_version"],
+        policy=in_force,
+    )
+    result = first_boot(
+        plan,
+        jailer_binary=host["jailer"],
+        kernel=kernel,
+        rootfs=rootfs,
+        work_disk=disk["path"],
+        uid=account["uid"],
+        gid=account["gid"],
+    )
+    result["policy_is_the_required_one"] = in_force == dict(REQUIRED_MICROVM_POLICY)
+    result["work_disk"] = disk
+    return result
+
+
+def sweep_in_guest(
+    *,
+    record: Mapping[str, Any],
+    workdir: Path,
+    manifest_path: Path = DEFAULT_MANIFEST,
+    vcpu_count: int = 1,
+    images_checked: Mapping[str, Any] | None = None,
+    boot: Callable[..., dict[str, Any]] | None = None,
+    clock: Callable[[], float] = time.monotonic,
+) -> dict[str, Any]:
+    """Run every declared probe in one guest and say what came back."""
+    manifest = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+    probes = build_probes(manifest)
+    driver = guest_driver(probes)
+
+    started = clock()
+    booted = (boot or boot_one_guest)(
+        driver=driver, record=record, workdir=Path(workdir), vcpu_count=vcpu_count
+    )
+    took = clock() - started
+
+    results = booted.get("results") or {}
+    transcript = results.get("/out/stdout") or ""
+    records = _parse(transcript, probes)
+    answered = [row for row in records if row["answered"]]
+
+    return {
+        "artifact": "agentic-v2-declared-command-sweep",
+        "artifact_version": "1.0",
+        "taken": (
+            "inside a Firecracker guest, on the execution host, under the "
+            "required microVM policy"
+        ),
+        "is_not": [
+            "a capability receipt",
+            "a signature or provenance verification",
+            "a vulnerability scan",
+            "an isolation or containment measurement",
+        ],
+        "supersedes_nothing": (
+            "the container sweeps stand as what they are: measurements of the "
+            "same image somewhere else. This one answers the question they "
+            "recorded that they could not"
+        ),
+        "driver_changes": [
+            f"probe scratch paths go to {WRITABLE_MOUNT} rather than /tmp, "
+            "because the rootfs is mounted read-only by policy",
+            f"HOME and TMPDIR are {WRITABLE_MOUNT}, because a probe with nowhere "
+            "to write exits non-zero exactly like an absent command",
+        ],
+        "image": record["images"]["image"],
+        "images_checked": dict(images_checked or {}),
+        "manifest_sha256": _canonical_sha256(manifest),
+        "manifest_path": Path(manifest_path).as_posix(),
+        "declared": {
+            "commands": len(manifest["commands"]),
+            "python_modules": len(manifest["python_modules"]),
+            "font_families": len(manifest["font_families"]),
+            "platform": manifest["platform"],
+        },
+        "host": {
+            "kernel": platform.release(),
+            "machine": platform.machine(),
+            "system": platform.system(),
+            "cgroup_version": record["host"]["cgroup_version"],
+            "firecracker_version": record["host"].get("firecracker_version"),
+            "jailed_to_uid": record["jail_account"]["uid"],
+        },
+        "guest": {
+            "vm_id": booted.get("vm_id"),
+            "plan_sha256": booted.get("plan_sha256"),
+            "policy_sha256": booted.get("policy_sha256"),
+            "policy_is_the_required_one": booted.get("policy_is_the_required_one"),
+            "outcome": booted.get("outcome"),
+            "ran_for_seconds": booted.get("ran_for_seconds"),
+            "deadline_seconds": booted.get("deadline_seconds"),
+            "stopped_by_the_deadline": booted.get("stopped_by_the_deadline"),
+            "command_exit_status": booted.get("command_exit_status"),
+            "kernel": (results.get("/out/guest_kernel") or "").strip(),
+            "uid": (results.get("/out/guest_uid") or "").strip(),
+            "uid_note": (
+                "root inside the guest is the ordinary arrangement for a "
+                "microVM: the boundary is the machine, and the host-side "
+                "process runs as host.jailed_to_uid"
+            ),
+            "init_reached_the_end": bool(
+                (results.get("/out/init_reached_the_end") or "").strip()
+            ),
+            "teardown": booted.get("teardown"),
+        },
+        "transcript_bytes": len(transcript),
+        "sweep_seconds": round(took, 2),
+        "probes_declared": len(probes),
+        "probes_answered": len(answered),
+        "present": sum(1 for row in answered if row["present"]),
+        "absent": sum(1 for row in answered if not row["present"]),
+        "records": records,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--c2-artefact", default=str(C2_ARTEFACT))
+    parser.add_argument("--workdir", default="/var/tmp/gdpval-sweep")
+    parser.add_argument("--manifest", default=str(DEFAULT_MANIFEST))
+    parser.add_argument("--vcpu-count", type=int, default=1)
+    parser.add_argument(
+        "--rehash-images",
+        action="store_true",
+        help="re-read the kernel and rootfs and compare to C2's hashes (~9 GiB)",
+    )
+    parser.add_argument("--out", default="")
+    args = parser.parse_args(argv)
+
+    try:
+        record = read_the_c2_record(Path(args.c2_artefact))
+        checked = images_are_where_c2_left_them(record, rehash=args.rehash_images)
+    except GuestSweepRefused as refused:
+        print(f"Refused before booting anything: {refused}")
+        return 1
+
+    workdir = Path(args.workdir)
+    workdir.mkdir(parents=True, exist_ok=True)
+    result = sweep_in_guest(
+        record=record,
+        workdir=workdir,
+        manifest_path=Path(args.manifest),
+        vcpu_count=args.vcpu_count,
+        images_checked=checked,
+        clock=time.time,
+    )
+
+    out = Path(args.out) if args.out else workdir / "guest-declared-command-sweep.json"
+    out.write_text(json.dumps(result, indent=2, sort_keys=True), encoding="utf-8")
+
+    guest = result["guest"]
+    print(f"guest      {guest['outcome']}  ran {guest['ran_for_seconds']}s of "
+          f"{guest['deadline_seconds']}s  exit {guest['command_exit_status']}")
+    print(f"host       {result['host']['kernel']} {result['host']['machine']}  "
+          f"cgroup v{result['host']['cgroup_version']}")
+    print(f"answered   {result['probes_answered']}/{result['probes_declared']}"
+          f"   present {result['present']}   absent {result['absent']}")
+    for row in result["records"]:
+        mark = "ok " if row["present"] else ("-- " if row["answered"] else "?? ")
+        print(f"  {mark}{row['name']:<28} {row['first_line'][:70]}")
+    print(f"written    {out.as_posix()}")
+    # A sweep that ran is a success even when things are absent: absence is the
+    # answer it was sent to get. A guest that never booted is not.
+    return 0 if result["probes_answered"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/batch-runner/tests/test_sweep_in_guest.py
+++ b/batch-runner/tests/test_sweep_in_guest.py
@@ -1,0 +1,308 @@
+"""The sweep taken in the guest, exercised without booting one.
+
+The container sweep's own artifact says its numbers belong to the host it ran
+on — docker, cgroup v1, a 3.10 kernel — and asks to be re-taken where tasks
+will actually run. :mod:`sandbox.v2.sweep_in_guest` is that re-take. What needs
+proving here is not that probes work; the shared module already proves that.
+It is the three things that are new:
+
+**The driver's scratch paths really move.** In the guest the rootfs is
+read-only, so a redirect to ``/tmp`` fails and every probe exits non-zero — a
+sweep that would report an image with nothing in it at all. The substitution is
+checked, and so is the case where the shared driver changes underneath it.
+
+**A guest that wrote nothing is not an image with nothing in it.** Same
+property the container sweep has, in a machine that has more ways to produce
+it, so it is asserted again here rather than assumed to carry over.
+
+**The committed artifact was taken in a guest.** The last class reads
+``tasks/0822_saturday/guest_declared_command_sweep.json`` and asserts the guest
+kernel differs from the host kernel. Running the driver on the host would
+produce a plausible-looking sweep with the same probe names in it, and that one
+comparison is what separates the two.
+
+Nothing here boots anything. The boot is injected, exactly as it is in the
+stage D tests.
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+from pathlib import Path
+
+import pytest
+
+from core.agentic_v2_substrate import validate_capability_receipt
+from sandbox.v2 import sweep_in_guest as module
+from sandbox.v2.probe_declared_commands import MARK, DEFAULT_MANIFEST
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+REAL_SWEEP = (
+    BATCH_RUNNER_ROOT.parent
+    / "tasks"
+    / "0822_saturday"
+    / "guest_declared_command_sweep.json"
+)
+
+
+def a_c2_record(tmp_path: Path, **changes) -> dict:
+    """What C2 writes after a boot that worked, with files that exist."""
+    (tmp_path / "vmlinux").write_bytes(b"not really a kernel")
+    (tmp_path / "rootfs.ext4").write_bytes(b"not really a filesystem")
+    record = {
+        "outcome": "booted",
+        "host": {
+            "kernel_release": platform.release(),
+            "cgroup_version": 2,
+            "firecracker": "/usr/local/bin/firecracker",
+            "jailer": "/usr/local/bin/jailer",
+            "firecracker_version": "Firecracker v1.13.1",
+        },
+        "jail_account": {"uid": 997, "gid": 997},
+        "images": {
+            "kernel": {"path": (tmp_path / "vmlinux").as_posix(), "sha256": "a" * 64},
+            "rootfs": {"path": (tmp_path / "rootfs.ext4").as_posix(), "sha256": "b" * 64},
+            "image": {"pinned_digest": "sha256:" + "e" * 64},
+        },
+    }
+    record.update(changes)
+    return record
+
+
+def framed(name: str, returncode: int, stdout: str = "", stderr: str = "") -> str:
+    """One probe's answer, in the framing the shared driver emits."""
+    return (
+        f"{MARK}BEGIN {name}\n"
+        f"{MARK}RC {returncode}\n"
+        f"{MARK}OUT\n{stdout}\n"
+        f"{MARK}ERR\n{stderr}\n"
+        f"{MARK}END\n"
+    )
+
+
+# ── the substitution, which is the only thing this module changes ─────────
+
+
+class TestTheDriverGoesToTheWorkDisk:
+    def test_no_scratch_path_is_left_on_the_read_only_rootfs(self):
+        probes = module.build_probes(
+            json.loads(DEFAULT_MANIFEST.read_text(encoding="utf-8"))
+        )
+        driver = module.guest_driver(probes)
+        assert "/tmp/probe." not in driver
+        # Twice per probe each: once as the redirect, once as the ``head`` that
+        # reads it back. A count of len(probes) would mean half the paths had
+        # been missed.
+        assert driver.count("/work/probe.out") == 2 * len(probes)
+        assert driver.count("/work/probe.err") == 2 * len(probes)
+
+    def test_the_environment_gives_probes_somewhere_to_write(self):
+        # Without this a probe that needed a temporary file would exit
+        # non-zero, and the artifact would call its command absent.
+        driver = module.guest_driver([{"name": "sh", "probe": ["sh", "-c", "echo ok"]}])
+        assert driver.startswith("HOME=/work\nTMPDIR=/work\nexport HOME TMPDIR\n")
+
+    def test_every_probe_is_still_framed_the_way_the_reader_expects(self):
+        probes = [
+            {"name": "python3", "probe": ["python3", "--version"]},
+            {"name": "sh", "probe": ["sh", "-c", "echo ok"]},
+        ]
+        driver = module.guest_driver(probes)
+        for probe in probes:
+            assert f"{MARK}BEGIN {probe['name']}" in driver
+
+    def test_a_shared_driver_that_stopped_using_tmp_stops_this_module(
+        self, monkeypatch
+    ):
+        # The failure this guards against is silent: the substitution would
+        # match nothing, the redirect would hit a read-only filesystem, and the
+        # sweep would report every command in the image as absent.
+        monkeypatch.setattr(
+            module, "_shell_driver", lambda probes: "echo somewhere-else\n"
+        )
+        with pytest.raises(module.GuestSweepRefused) as refused:
+            module.guest_driver([{"name": "sh", "probe": ["sh"]}])
+        assert "read-only rootfs" in str(refused.value)
+
+
+# ── what it declines to sweep ─────────────────────────────────────────────
+
+
+class TestWhatItRefuses:
+    def test_a_host_that_has_never_booted_a_guest(self, tmp_path):
+        with pytest.raises(module.GuestSweepRefused) as refused:
+            module.read_the_c2_record(tmp_path / "nothing.json")
+        assert "run_agentic_c2_first_boot.py first" in str(refused.value)
+
+    def test_a_c2_run_that_recorded_a_failure(self, tmp_path):
+        written = tmp_path / "c2.json"
+        written.write_text(
+            json.dumps(
+                a_c2_record(tmp_path, outcome="host_cannot_boot", reason="no /dev/kvm")
+            ),
+            encoding="utf-8",
+        )
+        with pytest.raises(module.GuestSweepRefused) as refused:
+            module.read_the_c2_record(written)
+        assert "no /dev/kvm" in str(refused.value)
+
+    def test_a_record_copied_from_another_machine(self, tmp_path):
+        record = a_c2_record(tmp_path)
+        record["host"]["kernel_release"] = "6.8.0-somewhere-else"
+        written = tmp_path / "c2.json"
+        written.write_text(json.dumps(record), encoding="utf-8")
+        with pytest.raises(module.GuestSweepRefused) as refused:
+            module.read_the_c2_record(written)
+        assert "different machine" in str(refused.value)
+
+    def test_a_good_record_comes_back_whole(self, tmp_path):
+        written = tmp_path / "c2.json"
+        written.write_text(json.dumps(a_c2_record(tmp_path)), encoding="utf-8")
+        assert module.read_the_c2_record(written)["outcome"] == "booted"
+
+
+class TestTheImagesAreThere:
+    def test_presence_is_checked_without_reading_nine_gibibytes(self, tmp_path):
+        checked = module.images_are_where_c2_left_them(a_c2_record(tmp_path))
+        assert checked["rehashed"] is False
+        assert checked["rootfs"]["sha256_recorded_by_c2"] == "b" * 64
+        assert "sha256" not in checked["rootfs"], "nothing was measured"
+
+    def test_a_rootfs_that_is_gone_stops_the_sweep(self, tmp_path):
+        record = a_c2_record(tmp_path)
+        (tmp_path / "rootfs.ext4").unlink()
+        with pytest.raises(module.GuestSweepRefused) as refused:
+            module.images_are_where_c2_left_them(record)
+        assert "not there now" in str(refused.value)
+
+    def test_asking_for_hashes_gets_them_compared(self, tmp_path):
+        record = a_c2_record(tmp_path)
+        with pytest.raises(module.GuestSweepRefused) as refused:
+            module.images_are_where_c2_left_them(record, rehash=True)
+        assert "different bytes" in str(refused.value)
+
+    def test_hashes_that_agree_are_recorded_as_measured(self, tmp_path):
+        record = a_c2_record(tmp_path)
+        checked = module.images_are_where_c2_left_them(
+            record, rehash=True, measure=lambda path: "b" * 64 if "rootfs" in str(path) else "a" * 64
+        )
+        assert checked["rehashed"] is True
+        assert checked["kernel"]["sha256"] == "a" * 64
+
+
+# ── reading a guest that answered, and one that did not ───────────────────
+
+
+def sweep_with(transcript: str, tmp_path: Path, **guest) -> dict:
+    booted = {
+        "vm_id": "declared-sweep",
+        "outcome": "booted",
+        "ran_for_seconds": 9.2,
+        "deadline_seconds": 1200.0,
+        "command_exit_status": 0,
+        "policy_is_the_required_one": True,
+        "teardown": {"all_gone": True},
+        "results": {
+            "/out/stdout": transcript,
+            "/out/guest_kernel": "6.1.141\n",
+            "/out/guest_uid": "0\n",
+            "/out/init_reached_the_end": "done\n",
+        },
+    }
+    booted.update(guest)
+    return module.sweep_in_guest(
+        record=a_c2_record(tmp_path),
+        workdir=tmp_path,
+        boot=lambda **_: booted,
+    )
+
+
+class TestReadingWhatTheGuestWrote:
+    def test_a_command_that_answered_zero_is_present(self, tmp_path):
+        result = sweep_with(framed("python3", 0, "Python 3.11.15"), tmp_path)
+        row = next(r for r in result["records"] if r["name"] == "python3")
+        assert row["present"] is True
+        assert row["first_line"] == "Python 3.11.15"
+
+    def test_a_command_that_is_not_there_is_absent_not_missing(self, tmp_path):
+        result = sweep_with(framed("node", 127, "", "node: not found"), tmp_path)
+        row = next(r for r in result["records"] if r["name"] == "node")
+        assert row["answered"] is True and row["present"] is False
+
+    def test_a_guest_that_wrote_nothing_is_not_an_empty_image(self, tmp_path):
+        # The expensive misreading. Forty probes with no record would otherwise
+        # read as forty findings about the image.
+        result = sweep_with("", tmp_path, outcome="booted_but_wrote_nothing")
+        assert result["probes_answered"] == 0
+        assert result["present"] == 0 and result["absent"] == 0
+        assert all("did not finish" in r["grounds"] for r in result["records"])
+
+    def test_the_host_and_the_guest_are_both_named(self, tmp_path):
+        result = sweep_with(framed("sh", 0, "ok"), tmp_path)
+        assert result["guest"]["kernel"] == "6.1.141"
+        assert result["host"]["kernel"] == platform.release()
+        assert result["host"]["jailed_to_uid"] == 997
+
+    def test_root_in_the_guest_is_explained_rather_than_left_to_be_read(
+        self, tmp_path
+    ):
+        guest = sweep_with(framed("sh", 0, "ok"), tmp_path)["guest"]
+        assert guest["uid"] == "0"
+        assert "the boundary is the machine" in guest["uid_note"]
+
+    def test_it_does_not_answer_to_the_name_capability_receipt(self, tmp_path):
+        result = sweep_with(framed("sh", 0, "ok"), tmp_path)
+        assert result["is_not"][0] == "a capability receipt"
+        with pytest.raises(Exception):
+            validate_capability_receipt(result)
+
+
+# ── the artifact the host really wrote ────────────────────────────────────
+
+
+class TestTheCommittedSweep:
+    """Held to what came off the execution host on 2026-09-10.
+
+    Everything above builds a shape and checks the reader reads it, which
+    cannot notice the shape being wrong. This can.
+    """
+
+    @pytest.fixture
+    def real(self):
+        if not REAL_SWEEP.is_file():  # pragma: no cover - it is committed
+            pytest.skip(f"{REAL_SWEEP} is not committed here")
+        return json.loads(REAL_SWEEP.read_text(encoding="utf-8"))
+
+    def test_it_was_taken_in_a_guest_and_not_on_the_host(self, real):
+        # The one comparison that separates this from running the driver on the
+        # host and calling the result a guest sweep.
+        assert real["guest"]["kernel"] and real["host"]["kernel"]
+        assert real["guest"]["kernel"] != real["host"]["kernel"]
+
+    def test_the_guest_ran_under_the_required_policy_and_was_cleaned_up(self, real):
+        guest = real["guest"]
+        assert guest["policy_is_the_required_one"] is True
+        assert guest["outcome"] == "booted"
+        assert guest["command_exit_status"] == 0
+        assert guest["stopped_by_the_deadline"] is False
+        assert guest["ran_for_seconds"] < guest["deadline_seconds"]
+        assert guest["teardown"]["all_gone"] is True
+
+    def test_every_declared_probe_got_an_answer(self, real):
+        assert real["probes_answered"] == real["probes_declared"]
+        assert real["present"] + real["absent"] == real["probes_declared"]
+
+    def test_it_swept_the_image_c2_booted(self, real):
+        assert real["image"]["pinned_digest"].startswith("sha256:")
+        assert real["host"]["cgroup_version"] == 2
+
+    def test_what_is_absent_is_named_rather_than_summarised(self, real):
+        absent = sorted(
+            row["name"] for row in real["records"] if row["answered"] and not row["present"]
+        )
+        assert absent, "a sweep with nothing absent would make this test vacuous"
+        for name in absent:
+            row = next(r for r in real["records"] if r["name"] == name)
+            assert row["returncode"] not in (0, None)
+            assert row["grounds"].startswith("the probe exited")

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
@@ -1820,5 +1820,199 @@ constant, defaulting to D1's mapping. The capability probe runs both and records
 the answer, and the answer gets pinned here without editing D1 on the strength of
 what is usually true.
 
+##### D3 — what is actually in the guest, measured in the guest
+
+`sandbox/v2/sweep_in_guest.py`, `tests/test_sweep_in_guest.py` (**23 tests**),
+artefact `tasks/0822_saturday/guest_declared_command_sweep.json`.
+
+The container sweep committed earlier says so itself, in its own `host_caveat`:
+it was taken with docker, on a cgroup v1 host running a 3.10 kernel, and asks to
+be re-taken where tasks will run before its numbers are treated as stage D's.
+This is that re-take. Same probes, same framing, same reader — the only thing
+that changed is the machine, and the machine was the entire question.
+
+**What ran.** One Firecracker guest on `gdpval-devhost-vm`, the rootfs C2
+booted, under `REQUIRED_MICROVM_POLICY`, `policy_sha256`
+`6a5e665d3253c80302f001e8fd624b77838c38f92add1af63024277c5215888e`. Outcome
+`booted`, command exit status 0, **11.775 s of a 1200 s deadline**, teardown
+`all_gone: true`. Kernel and rootfs were re-hashed against C2's record before
+the boot — `b36a4a1b…` and `489188…`, both matching — so this is a measurement
+of the same bytes C2 booted and not of a directory that happens to share their
+paths.
+
+**40 of 40 probes answered. 34 present, 6 absent.** The absent are `Rscript`,
+`chromium`, `cmake`, `node`, `npm` and `python3:ezdxf` — the same six the
+container sweep found in the parent image. That agreement is worth stating
+plainly: the container numbers were not wrong about *the image*, they were
+unable to say anything about *the machine*, and now something can.
+
+**Two changes to the driver, both in the artefact rather than left to be
+noticed.** The container sweep gives each probe `/tmp` to write to; in the guest
+the rootfs is read-only by policy and `/work` is the only writable mount, so the
+redirections move there and `HOME` and `TMPDIR` follow. The second is not
+tidiness. A probe that fails because it had nowhere to write exits non-zero
+exactly like a probe whose command is absent, and without it the artefact would
+have recorded the wrong reason for an unknown number of the forty. The
+substitution is checked at runtime and the check has its own test: if the shared
+driver ever stops writing to `/tmp/probe.`, this module refuses instead of
+silently reporting an image with nothing in it.
+
+**`guest_uid` is 0, and that is not a containment failure.** Root inside the
+guest is the ordinary arrangement for a microVM — the boundary is the machine,
+not a uid — and the host-side process runs as the unprivileged jail account,
+uid 999. Both numbers are in the artefact side by side so no reader has to take
+that on trust. C3 measured the boundary itself, separately, by attacking it.
+
+**It is still not a capability receipt**, and a test asserts
+`validate_capability_receipt` rejects it. No SBOM, no licence classification, no
+package inventory. Signature and provenance remain `not_run`.
+
+###### The `python` versus `python3` question, settled
+
+D2 recorded that the substrate manifest requires a command named `python`, that
+D1 invokes `python3`, that both normally exist on a Debian image — and that
+*normally* is not evidence, so it had to be settled by probing rather than by
+reasoning. It is settled: **both are present and both are Python 3.11.15**, in
+this guest, on this host. `ALWAYS_ASKED` asks for both on every sweep precisely
+so this stays answered rather than assumed after any image change.
+
+###### The first run of this was not reproducible, and that was the point of the second
+
+The sweep was first taken by a one-off script and produced the same 34/6. Its
+artefact used different field names from the module written afterwards, which
+meant a file committed as *what `sweep_in_guest.py` produces* could not have been
+produced by `sweep_in_guest.py`. The test that matters here —
+`test_it_was_taken_in_a_guest_and_not_on_the_host`, which compares the guest
+kernel `6.1.141` against the host kernel `6.17.0-1022-azure` — only means
+anything if the file came out of the code under test. So the host was started
+again and the sweep re-taken by the committed module with `--rehash-images`.
+Cost: about six minutes of a `Standard_D8as_v5`. That is the correct trade
+against a committed artefact that quietly overstates its own provenance.
+
+###### What the six absent commands mean for stage D, stated before it runs
+
+`chromium` is moot: the microVM backend refuses `browser_run` in every form,
+including `open_local`, and D2 already recorded that a task failing for want of
+a browser must read as that. The other five are real narrowing. A task that
+needs R, node, npm, cmake or `ezdxf` will fail in this guest, and **that failure
+is an environment defect, not a model failure** — the distinction stage F is
+required to keep. The image carrying all forty (`sha256:e47537b8…`) was built
+and never pushed, so it is not reachable from here; the reachable parent is what
+stage D executes against. This is written down before execution so no post-hoc
+reading can convert those failures into a claim about the model.
+
+##### The block stage D cannot clear from inside the repository
+
+Stage D needs two things at once, and they live in different Azure tenants.
+
+| | the guest host | the Foundry model |
+|---|---|---|
+| resource | `gdpval-devhost-vm`, RG `RG-GDPVAL-DEVHOST-KRC`, koreacentral | account `hjeon-fdpo-foundry-eus2`, project `gdpval-realworks`, deployment `gpt-5.4` |
+| subscription | `4b7c60a5-b0e5-468e-9a2d-f0dcb2cc60d1` | `d372e9cf-d5f4-497e-b487-1a9973d20df9` |
+| tenant | `6d93cc9b-abb8-4dab-9406-892843d0de0b` | `16b3c013-d300-468d-ac64-7eda0820b6d3` |
+| what reaches it | `az vm run-command invoke` as the local signed-in admin | the GitHub OIDC application `f5e0ecfa-6d29-46b1-bdff-bb19ed3307ba` |
+
+Established by converging readings rather than by one: `az cognitiveservices
+account list` does not return the Foundry account, `az account list` shows one
+subscription, Resource Graph returns **0 records** for it, no workflow in the
+repository invokes `run-command`, and there are no C2 or C3 workflow runs —
+every boot so far was driven from a local shell. The VM's system-assigned
+identity `8544cbfc-76cc-4bd2-81e2-8985afc11a9f` holds **zero role assignments**,
+and a managed identity cannot hold a role in another tenant regardless.
+
+So the paid leg needs one of: a cross-tenant service-principal grant, or a
+booting host inside subscription `d372e9cf…`. **Both are access changes, and
+neither is covered by the cost approval**, which is why this is reported rather
+than performed — even though the credentials to do the first are on this box.
+GitHub-hosted runners remain ruled out for the host role on the grounds already
+recorded here: nested virtualisation is documented as unsupported, and a
+boundary offered with no guarantee is not a boundary. That finding is not loose
+prose — it is `RECORDED_FINDINGS[0]` in
+`batch-runner/core/agentic_v2_containment_readiness.py`, dated 2026-08-26 and
+carrying the GitHub documentation URL it was established from, and
+`_LABELS_COVERED_BY_A_FINDING` maps `ubuntu-latest`, `ubuntu-24.04`,
+`ubuntu-22.04` and `ubuntu-20.04` onto it. Re-checked against that record in
+this window, and it holds. Worth being explicit about why no measurement
+reopens it: the objection is to the *support status*, not to the hardware, so a
+job that found `/dev/kvm` present on a runner would have measured something
+true and answered a different question. `check_every_machine_has_a_containment_finding`
+also means a workflow introducing a *new* runner label reports a gap rather
+than silently inheriting this answer.
+
+The cheapest thing that could dissolve this without any grant has not been tried
+and costs nothing: a read-only `workflow_dispatch` job that logs in as the OIDC
+identity and asks what it can already do in *its own* subscription — `az account
+show`, `az vm list`, provider registration, role assignments, `az vm
+list-usage`. That is the next free step, and it is free because it asks for
+nothing.
+
+###### A matching kernel does not mean the same machine
+
+CI corrected a test in this window, which is the outcome worth having and worth
+recording. `test_this_box_is_refused_by_the_real_artefact` branched on
+`kernel_release == os.uname().release` and read equality as *this is the
+execution host*. GitHub's hosted runners are Azure virtual machines carrying the
+same `6.17.0-…-azure` kernel build as the development host, so on a runner the
+equality held, the test took the execution-host branch, and the reader refused
+for the reason it should have: no `/usr/local/bin/firecracker`. Kernel equality
+is necessary and not sufficient; the binaries check is what separates a runner
+from the machine C2 booted on. Both gates were already there and both are
+load-bearing — only the test's reasoning about them was wrong.
+
+###### Host ledger for this window
+
+Two windows on `gdpval-devhost-vm`, `Standard_D8as_v5`, koreacentral:
+23:02→23:20 UTC and 23:23→23:29 UTC on 2026-09-10, about **25 minutes**
+combined, both ended by `az vm deallocate` after confirming no logged-in users
+and no `firecracker`, `jailer` or sweep processes. List rate 0.424 USD/h puts
+the arithmetic near 0.18 USD; the actual charge is **not verifiable from this
+box** — the local `az` tenant is not the one that bills these workflows — so the
+window is recorded as `partial` and **not** as zero. **Zero model calls were
+made in this window; the only spend is the host.**
+
 ### Stage E — not yet run
+
+Before any of it is written, what the repository already has. Two searches this
+window each turned up a finished implementation of something that looked like
+new work, and both are recorded here so the next reader spends the hour on
+stage E rather than on rediscovering them.
+
+**The three-way retry distinction is built.**
+`core/execution_environment_readiness.py` defines
+`RETRY_INFRASTRUCTURE_ERROR`, `RETRY_MODEL_SELF_REVIEW` and
+`RETRY_TOOL_LOOP_INTERNAL_RECOVERY`, maps them onto the ledger's own
+`retry_kind` vocabulary through `RETRY_KIND_TO_REASON`, and counts them off
+ledger rows in `retry_counts_by_reason`. It also deliberately declines to map
+`RETRY_RESUME` onto any of the three — a resumed round re-attempts a task, but
+because the previous *process* stopped, and calling that an infrastructure
+error would inflate the one count the run is trying to measure. Unmapped kinds
+are reported separately under `unmapped_retry_kinds`, present-and-empty rather
+than absent, so an empty count is a measurement.
+
+**The per-task cost ledger is built, with the rules stage E was going to
+restate.** `core/cost_receipts.py` already holds each task's cost as two
+receipts that never add up — `BUCKET_PROBLEM_SOLVING` and `BUCKET_GRADING` —
+which is the separation of grading cost this task asks for. It already refuses
+to treat a missing usage block as free: `STATUS_PARTIAL` with
+`REASON_USAGE_ABSENT`, `known_cost_usd` carrying the confirmed part and
+`estimated_cost_usd` left `None`. Its own words are "zero is a measurement, not
+a default", and the only real `$0` is a path that never contacted a provider.
+It also refuses prefix or nearest-neighbour price matching, and never removes a
+call that happened, even when the output it paid for was thrown away.
+
+So stage E's work is **wiring, not invention**: making the V2 runner emit one
+ledger row per call in that existing vocabulary, so the existing counting and
+the existing two-bucket receipt apply to a V2 run unchanged. A second ledger
+would be the wrong shape of effort and would give the run two answers about its
+own cost.
+
+**The runner-as-host route is closed, and re-checking it is not free thinking.**
+`RECORDED_FINDINGS[0]` in `core/agentic_v2_containment_readiness.py` rules out
+GitHub-hosted runners for the guest role, and `_LABELS_COVERED_BY_A_FINDING`
+binds all four `ubuntu-*` labels to it. The objection is the documented support
+status, not the hardware, so a job that measured `/dev/kvm` on a runner would
+answer a true but different question — and presenting that measurement as
+reopening the route would be the same overclaim as reading a self-computed
+digest as a supplier signature.
+
 ### Stage F — not yet run

--- a/tasks/0822_saturday/guest_declared_command_sweep.json
+++ b/tasks/0822_saturday/guest_declared_command_sweep.json
@@ -1,0 +1,767 @@
+{
+  "absent": 6,
+  "artifact": "agentic-v2-declared-command-sweep",
+  "artifact_version": "1.0",
+  "declared": {
+    "commands": 20,
+    "font_families": 3,
+    "platform": {
+      "architecture": "amd64",
+      "os": "linux",
+      "python": "3.11"
+    },
+    "python_modules": 13
+  },
+  "driver_changes": [
+    "probe scratch paths go to /work rather than /tmp, because the rootfs is mounted read-only by policy",
+    "HOME and TMPDIR are /work, because a probe with nowhere to write exits non-zero exactly like an absent command"
+  ],
+  "guest": {
+    "command_exit_status": 0,
+    "deadline_seconds": 1200.0,
+    "init_reached_the_end": true,
+    "kernel": "6.1.141",
+    "outcome": "booted",
+    "plan_sha256": "e99a45bf8bd3295419bcfd826bd4a8a3bd3355bb6033b566a47dbde7b8306107",
+    "policy_is_the_required_one": true,
+    "policy_sha256": "6a5e665d3253c80302f001e8fd624b77838c38f92add1af63024277c5215888e",
+    "ran_for_seconds": 11.775,
+    "stopped_by_the_deadline": false,
+    "teardown": {
+      "all_gone": true,
+      "removed": {
+        "/srv/jailer/firecracker/declared-sweep/root": true
+      }
+    },
+    "uid": "0",
+    "uid_note": "root inside the guest is the ordinary arrangement for a microVM: the boundary is the machine, and the host-side process runs as host.jailed_to_uid",
+    "vm_id": "declared-sweep"
+  },
+  "host": {
+    "cgroup_version": 2,
+    "firecracker_version": "Firecracker v1.13.1",
+    "jailed_to_uid": 999,
+    "kernel": "6.17.0-1022-azure",
+    "machine": "x86_64",
+    "system": "Linux"
+  },
+  "image": {
+    "credential_used": "none \u2014 anonymous pull token for a public repository",
+    "layer_count": 10,
+    "layers": [
+      {
+        "digest": "sha256:68629629b516c3cd6f5e71ffbe18e32afb1ae5b4926c92d058c0f11ef1fd58a3",
+        "media_type": "application/vnd.oci.image.layer.v1.tar+gzip",
+        "path": "/var/tmp/gdpval-c2/oci/blobs/sha256/68629629b516c3cd6f5e71ffbe18e32afb1ae5b4926c92d058c0f11ef1fd58a3",
+        "size_bytes": 28237639
+      },
+      {
+        "digest": "sha256:9465a3b5326202cdeda1f1439e4aaadfe4f4527dd8f9d020ef76b8a8432e5816",
+        "media_type": "application/vnd.oci.image.layer.v1.tar+gzip",
+        "path": "/var/tmp/gdpval-c2/oci/blobs/sha256/9465a3b5326202cdeda1f1439e4aaadfe4f4527dd8f9d020ef76b8a8432e5816",
+        "size_bytes": 3520822
+      },
+      {
+        "digest": "sha256:3ea3516015d200ef3f1407147986285b706de588d42b96b2cd33c6380e1ff0f1",
+        "media_type": "application/vnd.oci.image.layer.v1.tar+gzip",
+        "path": "/var/tmp/gdpval-c2/oci/blobs/sha256/3ea3516015d200ef3f1407147986285b706de588d42b96b2cd33c6380e1ff0f1",
+        "size_bytes": 15990074
+      },
+      {
+        "digest": "sha256:c3a88133a8c61d848bb024e0392659b2e45433e836462906b04884dd326a01d2",
+        "media_type": "application/vnd.oci.image.layer.v1.tar+gzip",
+        "path": "/var/tmp/gdpval-c2/oci/blobs/sha256/c3a88133a8c61d848bb024e0392659b2e45433e836462906b04884dd326a01d2",
+        "size_bytes": 249
+      },
+      {
+        "digest": "sha256:e6c539ae3e58fd1b55f481bdfc5fa9f18c77e2bdb29c759b0c86f99195eab661",
+        "media_type": "application/vnd.oci.image.layer.v1.tar+gzip",
+        "path": "/var/tmp/gdpval-c2/oci/blobs/sha256/e6c539ae3e58fd1b55f481bdfc5fa9f18c77e2bdb29c759b0c86f99195eab661",
+        "size_bytes": 828406215
+      },
+      {
+        "digest": "sha256:0b5c91a253a39038b53c1fd4d4b21349beacdbd92bc959687e6fb1d15a2f3d1e",
+        "media_type": "application/vnd.oci.image.layer.v1.tar+gzip",
+        "path": "/var/tmp/gdpval-c2/oci/blobs/sha256/0b5c91a253a39038b53c1fd4d4b21349beacdbd92bc959687e6fb1d15a2f3d1e",
+        "size_bytes": 1370
+      },
+      {
+        "digest": "sha256:aa76a4f5622059cff46430efef5311aa99365d1056fe62cde6268e87abdfdf23",
+        "media_type": "application/vnd.oci.image.layer.v1.tar+gzip",
+        "path": "/var/tmp/gdpval-c2/oci/blobs/sha256/aa76a4f5622059cff46430efef5311aa99365d1056fe62cde6268e87abdfdf23",
+        "size_bytes": 1516991400
+      },
+      {
+        "digest": "sha256:1acaebe50d44b5446d5e3d43480c829386b6453558886cb8e97625a65a390782",
+        "media_type": "application/vnd.oci.image.layer.v1.tar+gzip",
+        "path": "/var/tmp/gdpval-c2/oci/blobs/sha256/1acaebe50d44b5446d5e3d43480c829386b6453558886cb8e97625a65a390782",
+        "size_bytes": 14335
+      },
+      {
+        "digest": "sha256:30c4d4e9cb5bf0c30aa016d634edcbe8ec9880077386e85b2ed3faf17d87e2bf",
+        "media_type": "application/vnd.oci.image.layer.v1.tar+gzip",
+        "path": "/var/tmp/gdpval-c2/oci/blobs/sha256/30c4d4e9cb5bf0c30aa016d634edcbe8ec9880077386e85b2ed3faf17d87e2bf",
+        "size_bytes": 94
+      },
+      {
+        "digest": "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+        "media_type": "application/vnd.oci.image.layer.v1.tar+gzip",
+        "path": "/var/tmp/gdpval-c2/oci/blobs/sha256/4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+        "size_bytes": 32
+      }
+    ],
+    "manifest_digest": "sha256:91b524c7dc8f21d653f829d19a283ea269a36cc85e0569ca38c85bfac92d0fe2",
+    "pinned_digest": "sha256:ee6ef798631d3c3aeaed28658c640e6f5d021677449852bf2e1f18be5bd24edb",
+    "pinned_digest_is_an_index": true,
+    "platform": "linux/amd64",
+    "repository": "ghcr.io/hyeonsangjeon/gdpval-sandbox"
+  },
+  "images_checked": {
+    "kernel": {
+      "path": "/var/tmp/gdpval-c2/vmlinux",
+      "sha256": "b36a4a1b10f33b9cfdcde3d1a787d9c090556a3edb211cd06d1f3f9a6c7e8724"
+    },
+    "rehashed": true,
+    "rootfs": {
+      "path": "/var/tmp/gdpval-c2/rootfs.ext4",
+      "sha256": "489188004ad4eb8a90191b3b5f58eb9fb246d158535d0bc655001f438a7a32ea"
+    }
+  },
+  "is_not": [
+    "a capability receipt",
+    "a signature or provenance verification",
+    "a vulnerability scan",
+    "an isolation or containment measurement"
+  ],
+  "manifest_path": "/var/tmp/gdpval-stage-d/batch-runner/sandbox/agentic_v2_capabilities.json",
+  "manifest_sha256": "fa76625f3fc9bb46c595f7c542132facb91c824bb5e51c7db9ea2d4fcb345a1f",
+  "present": 34,
+  "probes_answered": 40,
+  "probes_declared": 40,
+  "records": [
+    {
+      "answered": true,
+      "argv": [
+        "python",
+        "--version"
+      ],
+      "capability": "runtime",
+      "first_line": "Python 3.11.15",
+      "grounds": "the probe exited 0",
+      "kind": "command",
+      "name": "python",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "python3",
+        "--version"
+      ],
+      "capability": "runtime",
+      "first_line": "Python 3.11.15",
+      "grounds": "the probe exited 0",
+      "kind": "command",
+      "name": "python3",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "sh",
+        "-c",
+        "echo ok"
+      ],
+      "capability": "runtime",
+      "first_line": "ok",
+      "grounds": "the probe exited 0",
+      "kind": "command",
+      "name": "sh",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "uname",
+        "-srm"
+      ],
+      "capability": "runtime",
+      "first_line": "Linux 6.1.141 x86_64",
+      "grounds": "the probe exited 0",
+      "kind": "command",
+      "name": "uname",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "Rscript",
+        "--version"
+      ],
+      "capability": "data-science",
+      "first_line": "/work/in/command.sh: 42: Rscript: not found",
+      "grounds": "the probe exited 127",
+      "kind": "command",
+      "name": "Rscript",
+      "present": false,
+      "returncode": 127,
+      "stderr": "/work/in/command.sh: 42: Rscript: not found"
+    },
+    {
+      "answered": true,
+      "argv": [
+        "bash",
+        "--version"
+      ],
+      "capability": "shell",
+      "first_line": "GNU bash, version 5.2.15(1)-release (x86_64-pc-linux-gnu)",
+      "grounds": "the probe exited 0",
+      "kind": "command",
+      "name": "bash",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "chromium",
+        "--version"
+      ],
+      "capability": "browser-local",
+      "first_line": "/work/in/command.sh: 60: chromium: not found",
+      "grounds": "the probe exited 127",
+      "kind": "command",
+      "name": "chromium",
+      "present": false,
+      "returncode": 127,
+      "stderr": "/work/in/command.sh: 60: chromium: not found"
+    },
+    {
+      "answered": true,
+      "argv": [
+        "cmake",
+        "--version"
+      ],
+      "capability": "compilers",
+      "first_line": "/work/in/command.sh: 69: cmake: not found",
+      "grounds": "the probe exited 127",
+      "kind": "command",
+      "name": "cmake",
+      "present": false,
+      "returncode": 127,
+      "stderr": "/work/in/command.sh: 69: cmake: not found"
+    },
+    {
+      "answered": true,
+      "argv": [
+        "ffmpeg",
+        "-version"
+      ],
+      "capability": "media",
+      "first_line": "ffmpeg version 5.1.9-0+deb12u1 Copyright (c) 2000-2026 the FFmpeg developers",
+      "grounds": "the probe exited 0",
+      "kind": "command",
+      "name": "ffmpeg",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "ffprobe",
+        "-version"
+      ],
+      "capability": "media",
+      "first_line": "ffprobe version 5.1.9-0+deb12u1 Copyright (c) 2007-2026 the FFmpeg developers",
+      "grounds": "the probe exited 0",
+      "kind": "command",
+      "name": "ffprobe",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "g++",
+        "--version"
+      ],
+      "capability": "compilers",
+      "first_line": "g++ (Debian 12.2.0-14+deb12u1) 12.2.0",
+      "grounds": "the probe exited 0",
+      "kind": "command",
+      "name": "g++",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "gcc",
+        "--version"
+      ],
+      "capability": "compilers",
+      "first_line": "gcc (Debian 12.2.0-14+deb12u1) 12.2.0",
+      "grounds": "the probe exited 0",
+      "kind": "command",
+      "name": "gcc",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "gdalinfo",
+        "--version"
+      ],
+      "capability": "gis",
+      "first_line": "GDAL 3.6.2, released 2023/01/02",
+      "grounds": "the probe exited 0",
+      "kind": "command",
+      "name": "gdalinfo",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "gfortran",
+        "--version"
+      ],
+      "capability": "compilers",
+      "first_line": "GNU Fortran (Debian 12.2.0-14+deb12u1) 12.2.0",
+      "grounds": "the probe exited 0",
+      "kind": "command",
+      "name": "gfortran",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "libreoffice",
+        "--version"
+      ],
+      "capability": "documents",
+      "first_line": "LibreOffice 7.4.7.2 40(Build:2)",
+      "grounds": "the probe exited 0",
+      "kind": "command",
+      "name": "libreoffice",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "make",
+        "--version"
+      ],
+      "capability": "compilers",
+      "first_line": "GNU Make 4.3",
+      "grounds": "the probe exited 0",
+      "kind": "command",
+      "name": "make",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "node",
+        "--version"
+      ],
+      "capability": "programming",
+      "first_line": "/work/in/command.sh: 150: node: not found",
+      "grounds": "the probe exited 127",
+      "kind": "command",
+      "name": "node",
+      "present": false,
+      "returncode": 127,
+      "stderr": "/work/in/command.sh: 150: node: not found"
+    },
+    {
+      "answered": true,
+      "argv": [
+        "npm",
+        "--version"
+      ],
+      "capability": "programming",
+      "first_line": "/work/in/command.sh: 159: npm: not found",
+      "grounds": "the probe exited 127",
+      "kind": "command",
+      "name": "npm",
+      "present": false,
+      "returncode": 127,
+      "stderr": "/work/in/command.sh: 159: npm: not found"
+    },
+    {
+      "answered": true,
+      "argv": [
+        "ogr2ogr",
+        "--version"
+      ],
+      "capability": "gis",
+      "first_line": "GDAL 3.6.2, released 2023/01/02",
+      "grounds": "the probe exited 0",
+      "kind": "command",
+      "name": "ogr2ogr",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "pandoc",
+        "--version"
+      ],
+      "capability": "documents",
+      "first_line": "pandoc 2.17.1.1",
+      "grounds": "the probe exited 0",
+      "kind": "command",
+      "name": "pandoc",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "pdftoppm",
+        "-v"
+      ],
+      "capability": "pdf",
+      "first_line": "pdftoppm version 22.12.0",
+      "grounds": "the probe exited 0",
+      "kind": "command",
+      "name": "pdftoppm",
+      "present": true,
+      "returncode": 0,
+      "stderr": "pdftoppm version 22.12.0\nCopyright 2005-2022 The Poppler Developers - http://poppler.freedesktop.org\nCopyright 1996-2011, 2022 Glyph & Cog, LLC"
+    },
+    {
+      "answered": true,
+      "argv": [
+        "pdftotext",
+        "-v"
+      ],
+      "capability": "pdf",
+      "first_line": "pdftotext version 22.12.0",
+      "grounds": "the probe exited 0",
+      "kind": "command",
+      "name": "pdftotext",
+      "present": true,
+      "returncode": 0,
+      "stderr": "pdftotext version 22.12.0\nCopyright 2005-2022 The Poppler Developers - http://poppler.freedesktop.org\nCopyright 1996-2011, 2022 Glyph & Cog, LLC"
+    },
+    {
+      "answered": true,
+      "argv": [
+        "python",
+        "--version"
+      ],
+      "capability": "programming",
+      "first_line": "Python 3.11.15",
+      "grounds": "the probe exited 0",
+      "kind": "command",
+      "name": "python",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "tesseract",
+        "--version"
+      ],
+      "capability": "ocr",
+      "first_line": "tesseract 5.3.0",
+      "grounds": "the probe exited 0",
+      "kind": "command",
+      "name": "tesseract",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "python3",
+        "-c",
+        "import PIL as m; print(getattr(m, '__version__', 'no __version__'))"
+      ],
+      "capability": "documents",
+      "first_line": "12.3.0",
+      "grounds": "the probe exited 0",
+      "kind": "python_module",
+      "name": "python3:PIL",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "python3",
+        "-c",
+        "import av as m; print(getattr(m, '__version__', 'no __version__'))"
+      ],
+      "capability": "media",
+      "first_line": "18.0.0",
+      "grounds": "the probe exited 0",
+      "kind": "python_module",
+      "name": "python3:av",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "python3",
+        "-c",
+        "import ezdxf as m; print(getattr(m, '__version__', 'no __version__'))"
+      ],
+      "capability": "cad-dxf",
+      "first_line": "Traceback (most recent call last):",
+      "grounds": "the probe exited 1",
+      "kind": "python_module",
+      "name": "python3:ezdxf",
+      "present": false,
+      "returncode": 1,
+      "stderr": "Traceback (most recent call last):\n  File \"<string>\", line 1, in <module>\nModuleNotFoundError: No module named 'ezdxf'"
+    },
+    {
+      "answered": true,
+      "argv": [
+        "python3",
+        "-c",
+        "import geopandas as m; print(getattr(m, '__version__', 'no __version__'))"
+      ],
+      "capability": "gis",
+      "first_line": "1.1.4",
+      "grounds": "the probe exited 0",
+      "kind": "python_module",
+      "name": "python3:geopandas",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "python3",
+        "-c",
+        "import matplotlib as m; print(getattr(m, '__version__', 'no __version__'))"
+      ],
+      "capability": "data-science",
+      "first_line": "3.11.0",
+      "grounds": "the probe exited 0",
+      "kind": "python_module",
+      "name": "python3:matplotlib",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "python3",
+        "-c",
+        "import numpy as m; print(getattr(m, '__version__', 'no __version__'))"
+      ],
+      "capability": "data-science",
+      "first_line": "2.4.6",
+      "grounds": "the probe exited 0",
+      "kind": "python_module",
+      "name": "python3:numpy",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "python3",
+        "-c",
+        "import openpyxl as m; print(getattr(m, '__version__', 'no __version__'))"
+      ],
+      "capability": "spreadsheets",
+      "first_line": "3.1.5",
+      "grounds": "the probe exited 0",
+      "kind": "python_module",
+      "name": "python3:openpyxl",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "python3",
+        "-c",
+        "import pandas as m; print(getattr(m, '__version__', 'no __version__'))"
+      ],
+      "capability": "data-science",
+      "first_line": "3.0.3",
+      "grounds": "the probe exited 0",
+      "kind": "python_module",
+      "name": "python3:pandas",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "python3",
+        "-c",
+        "import pptx as m; print(getattr(m, '__version__', 'no __version__'))"
+      ],
+      "capability": "presentations",
+      "first_line": "1.0.2",
+      "grounds": "the probe exited 0",
+      "kind": "python_module",
+      "name": "python3:pptx",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "python3",
+        "-c",
+        "import reportlab as m; print(getattr(m, '__version__', 'no __version__'))"
+      ],
+      "capability": "pdf",
+      "first_line": "5.0.0",
+      "grounds": "the probe exited 0",
+      "kind": "python_module",
+      "name": "python3:reportlab",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "python3",
+        "-c",
+        "import scipy as m; print(getattr(m, '__version__', 'no __version__'))"
+      ],
+      "capability": "data-science",
+      "first_line": "1.17.1",
+      "grounds": "the probe exited 0",
+      "kind": "python_module",
+      "name": "python3:scipy",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "python3",
+        "-c",
+        "import sklearn as m; print(getattr(m, '__version__', 'no __version__'))"
+      ],
+      "capability": "machine-learning",
+      "first_line": "1.9.0",
+      "grounds": "the probe exited 0",
+      "kind": "python_module",
+      "name": "python3:sklearn",
+      "present": true,
+      "returncode": 0,
+      "stderr": "/usr/local/lib/python3.11/site-packages/joblib/_multiprocessing_helpers.py:44: UserWarning: [Errno 2] No such file or directory.  joblib will operate in serial mode\n  warnings.warn(\"%s.  joblib will operate in serial mode\" % (e,))"
+    },
+    {
+      "answered": true,
+      "argv": [
+        "python3",
+        "-c",
+        "import weasyprint as m; print(getattr(m, '__version__', 'no __version__'))"
+      ],
+      "capability": "documents",
+      "first_line": "69.0",
+      "grounds": "the probe exited 0",
+      "kind": "python_module",
+      "name": "python3:weasyprint",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "fc-match",
+        "-f",
+        "%{family}|%{file}",
+        "DejaVu Sans"
+      ],
+      "capability": "fonts",
+      "first_line": "DejaVu Sans|/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+      "grounds": "the probe exited 0",
+      "kind": "font_family",
+      "name": "font:DejaVu Sans",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "fc-match",
+        "-f",
+        "%{family}|%{file}",
+        "Liberation Sans"
+      ],
+      "capability": "fonts",
+      "first_line": "Liberation Sans|/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+      "grounds": "the probe exited 0",
+      "kind": "font_family",
+      "name": "font:Liberation Sans",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    },
+    {
+      "answered": true,
+      "argv": [
+        "fc-match",
+        "-f",
+        "%{family}|%{file}",
+        "Noto Sans CJK KR"
+      ],
+      "capability": "fonts",
+      "first_line": "Noto Sans CJK KR|/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+      "grounds": "the probe exited 0",
+      "kind": "font_family",
+      "name": "font:Noto Sans CJK KR",
+      "present": true,
+      "returncode": 0,
+      "stderr": ""
+    }
+  ],
+  "supersedes_nothing": "the container sweeps stand as what they are: measurements of the same image somewhere else. This one answers the question they recorded that they could not",
+  "sweep_seconds": 41.41,
+  "taken": "inside a Firecracker guest, on the execution host, under the required microVM policy",
+  "transcript_bytes": 13163
+}


### PR DESCRIPTION
## What this answers

`sandbox/v2/probe_declared_commands` answers *what is in this image*. Both sweeps it has produced so far were taken with docker, on a cgroup v1 host running a 3.10 kernel — and the artefact says so itself, and asks to be re-taken where tasks will actually run.

This is that re-take. Same probes, same framing, same reader. The only thing that changes is the machine: the rootfs C2 booted, in a Firecracker microVM under `REQUIRED_MICROVM_POLICY`, on the execution host.

## What came back

Committed at `tasks/0822_saturday/guest_declared_command_sweep.json`:

| | |
|---|---|
| probes answered | **40 / 40** |
| present / absent | 34 / 6 |
| absent | `Rscript`, `chromium`, `cmake`, `node`, `npm`, `python3:ezdxf` |
| guest kernel | `6.1.141` |
| host kernel | `6.17.0-1022-azure`, cgroup v2, Firecracker v1.13.1 |
| ran for | 11.775 s of a 1200 s deadline, exit 0 |
| policy | confirmed the required one; teardown complete |
| images | kernel and rootfs re-hashed against C2's record before the boot |

## The two driver changes, and why they are in the artefact

Probe scratch paths move to the work disk, because policy mounts the rootfs read-only. `HOME` and `TMPDIR` follow — not tidiness: a probe that fails for want of somewhere to write exits non-zero *exactly* like a probe whose command is absent, and the artefact would record the wrong reason.

The substitution is a textual one on a generated string, which is worth being uneasy about, so it is asserted rather than trusted. If the shared driver stops writing to `/tmp/probe.`, `guest_driver` refuses instead of silently reporting every command in the image as missing.

## The test that carries the claim

```python
def test_it_was_taken_in_a_guest_and_not_on_the_host(self, real):
    assert real["guest"]["kernel"] and real["host"]["kernel"]
    assert real["guest"]["kernel"] != real["host"]["kernel"]
```

Running the driver on the host would produce a plausible-looking sweep with the same probe names in it. That one comparison is what separates the two.

## What it is not

Asserted, not just written: not a capability receipt — `validate_capability_receipt` rejects it, and a test says so. Not a signature or provenance verification; those remain `not_run`. Not an isolation measurement — C3 made that one, separately, by attacking.

`guest_uid` is `0`, and that is not a containment failure: the boundary is the machine, and the host-side process runs as the unprivileged jail account C2 recorded. Both numbers sit side by side in the artefact so no reader has to take it on trust.

## Also here

The task document gains its stage D and stage E sections. Stage E's records that the three-way retry taxonomy (`core/execution_environment_readiness.py`) and the per-task cost ledger (`core/cost_receipts.py`) **already exist**, so stage E is wiring rather than invention — written down so the next window does not rebuild them.

A bare claim about GitHub-hosted runners is replaced with a citation to `RECORDED_FINDINGS[0]` in `core/agentic_v2_containment_readiness.py`, which is where that finding actually lives, dated and carrying its source URL.

## Cost

Nothing here spends. No model was called in the window that produced it; the sweep ran on a host that was already up for C2 and C3.

## Checks

- `pytest tests/test_sweep_in_guest.py tests/test_run_agentic_stage_d_probe.py` — 51 passed
- `mypy` — no error naming `sweep_in_guest.py`