### PR TITLE
feat(agentic): ask whether the model's subscription could hold a boot host

### DIFF
--- a/.github/workflows/azure-boot-host-survey.yml
+++ b/.github/workflows/azure-boot-host-survey.yml
@@ -1,0 +1,137 @@
+# Ask whether a Firecracker host could go in the subscription the model is in,
+# and do nothing about the answer.
+#
+# Stage D needs a GPT deployment and a machine that can boot a guest in one
+# place, and this repository has them in two: the model is a Foundry deployment
+# in one subscription and tenant, and the only host shown to boot a guest is a
+# VM in a different subscription in a different tenant. Booting the guest on the
+# runner that already holds the model credential is recorded as closed --
+# RECORDED_FINDINGS[0] in core/agentic_v2_containment_readiness.py, citing
+# GitHub's own documentation calling nested virtualisation on hosted runners
+# technically possible but not officially supported. That leaves one route: put
+# a host where the model already is. This measures whether that is possible
+# under permissions that already exist.
+#
+# Every call is an ARM control-plane READ. It creates no resource, registers no
+# provider, requests no role, and calls no model endpoint, so running it changes
+# nothing and spends nothing. That is the point rather than a detail: creating a
+# machine and granting a role are access changes, and those get reported
+# exactly, not performed quietly. A survey that fixed what it found would be the
+# failure mode.
+#
+# This is also the only place the question can be asked. The script reads
+# whatever subscription the `az` session holds, and a login taken on a
+# development box is a different one: the Foundry subscription is not the one
+# such a login reaches. The survey then reports `not_measured` and says nothing
+# was learned -- which is the truth, and is not evidence that anything is
+# absent. Run it here, or do not run it.
+name: Azure Boot Host Survey
+
+on:
+  workflow_dispatch:
+    inputs:
+      location:
+        description: Azure region to ask about (defaults to the model's region)
+        required: false
+        default: eastus2
+        type: string
+      emit_json:
+        description: Emit the redacted report as JSON instead of prose
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: azure-boot-host-survey
+  cancel-in-progress: false
+
+jobs:
+  survey:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      PYTHONDONTWRITEBYTECODE: "1"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+
+      # The same pinned action, client id, tenant and subscription the paid runs
+      # authenticate with. Surveying a different identity's reach would answer a
+      # question nobody asked: what matters is what *this* identity can do.
+      - name: Azure Login (OIDC)
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Verify Azure OIDC session identity
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_AI_EXPECTED_CLIENT_ID: ${{ vars.AZURE_AI_EXPECTED_CLIENT_ID }}
+          AZURE_AI_EXPECTED_TENANT_ID: ${{ vars.AZURE_AI_EXPECTED_TENANT_ID }}
+          AZURE_AI_EXPECTED_SUBSCRIPTION_ID: ${{ vars.AZURE_AI_EXPECTED_SUBSCRIPTION_ID }}
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          python3 scripts/azure_oidc_identity_preflight.py --verify-session
+
+      # No model credential is passed in, and no Foundry account or project name
+      # either. GitHub does not mask a repository variable the way it masks a
+      # secret -- whatever a step lists under env: is reprinted verbatim in the
+      # step header, and this repository's logs are public. The survey does not
+      # need those names: it asks about the subscription, not the account.
+      - name: Survey the subscription for a host
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          SURVEY_LOCATION: ${{ inputs.location }}
+          EMIT_JSON: ${{ inputs.emit_json }}
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          ARGS=(--location "${SURVEY_LOCATION:-eastus2}")
+          if [ "${EMIT_JSON}" = "true" ]; then
+            ARGS+=(--json)
+          fi
+          # No --require flag of any kind. Reporting that a host cannot go here
+          # is the point of the run, not a failure of it, and a red job would
+          # invite somebody to make it green by granting something.
+          python3 scripts/azure_boot_host_survey.py "${ARGS[@]}"
+
+      - name: Confirm nothing was created, granted, or called
+        if: always()
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          # A grep, not a promise. If a future edit reaches for a write or for
+          # the inference path from this survey, this step is what says so. The
+          # unit tests assert the same properties; this catches the edit that
+          # lands without them.
+          if grep -nE 'vm create|group create|provider register|role assignment create|deployment group create' \
+              scripts/azure_boot_host_survey.py; then
+            echo "FATAL: the survey references a control-plane write"
+            exit 1
+          fi
+          if grep -nE 'responses\.create|chat\.completions|AzureOpenAI|llm_client|code_interpreter' \
+              scripts/azure_boot_host_survey.py; then
+            echo "FATAL: the survey references a model call path"
+            exit 1
+          fi
+          echo "reads-only=confirmed"

--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,17 @@ batch-runner/scripts/*
 # fails collection loudly instead of skipping the tests in silence.
 !batch-runner/scripts/analyze_codex_run.py
 
+# Asks whether a Firecracker host could go in the subscription the model
+# deployment is already in, under permissions that already exist. Committed
+# because the question cannot be asked from a checkout: a local `az` session
+# reaches a different subscription entirely, so run here it reports that
+# nothing was measured, which is true and useless. The only place it answers is
+# a workflow job holding the federated token -- and that job runs what the
+# repository contains. Every call it makes is a control-plane read; it creates
+# nothing and grants nothing, and both the workflow and
+# tests/test_azure_boot_host_survey.py hold it to that.
+!batch-runner/scripts/azure_boot_host_survey.py
+
 
 # Experiment report HTML (skews GitHub language stats)
 batch-runner/results/*/report/report.html

--- a/batch-runner/scripts/azure_boot_host_survey.py
+++ b/batch-runner/scripts/azure_boot_host_survey.py
@@ -1,0 +1,622 @@
+#!/usr/bin/env python3
+"""Ask whether the subscription the model lives in could already host a guest.
+
+Stage D needs two things in one place: a GPT deployment to call, and a machine
+that can boot a Firecracker microVM to run what the model decides. This
+repository has both, and they are not in one place.
+
+* The model is a deployment on a Foundry account in one subscription and one
+  tenant, reachable from CI by the federated identity.
+* The only host shown to boot a guest -- C2 booted one on it, C3 attacked it --
+  is a VM in a *different* subscription in a *different* tenant, reachable from
+  a development box by an interactive login.
+
+Two routes close that gap. The first, boot the guest on the GitHub-hosted
+runner that already holds the model credential, is recorded as closed:
+``RECORDED_FINDINGS[0]`` in :mod:`core.agentic_v2_containment_readiness` cites
+GitHub's own documentation calling nested virtualisation on hosted runners
+technically possible but not officially supported, and a boundary offered with
+no guarantee is not a boundary. The second is this one: put a host in the
+subscription the model is already in.
+
+**What this script does about that: nothing.** It measures. Every call it makes
+is an ARM control-plane read. It creates no resource, registers no provider,
+requests no role, and calls no model endpoint, so running it changes nothing
+and spends nothing. That matters beyond tidiness -- creating a machine and
+granting a role are access changes, and the standing instruction on this task is
+that those get reported exactly, not performed quietly. A survey that quietly
+fixed what it found would be the failure mode, not the feature.
+
+So the output is one of four answers, and only the first two are good news:
+
+``host_already_exists``
+    There is already a virtual machine in this subscription. Nothing needs
+    creating, and the next question is whether *that* machine can boot a guest
+    -- which is C2's question, not this one's.
+``creation_is_within_existing_permissions``
+    The identity holds a role permitting the writes, the Compute provider is
+    registered, and the region has quota. A host could be deployed under
+    permissions that already exist, with no access change at all.
+``blocked_and_the_change_is_named``
+    One or more of those three is missing. The report names which, in the exact
+    terms somebody would need to approve it. It does not ask for it.
+``not_measured``
+    ``az`` did not answer. Nothing was learned, and in particular this is *not*
+    evidence that anything is absent. A local login reaches a different
+    subscription entirely and will land here; that is correct behaviour, not a
+    bug. Run it in CI, or do not run it.
+
+Usage:
+
+    python scripts/azure_boot_host_survey.py
+    python scripts/azure_boot_host_survey.py --json
+    python scripts/azure_boot_host_survey.py --location koreacentral
+
+Exit status:
+
+    0   the survey completed and reported an answer, whatever that answer was
+    1   the survey could not run, or a redaction check failed
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+BATCH_ROOT = SCRIPTS_DIR.parent
+RBAC_DIAGNOSTIC = SCRIPTS_DIR / "azure_rbac_diagnostic.py"
+
+if str(BATCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_ROOT))
+
+
+RBAC_MODULE_NAME = "azure_rbac_diagnostic"
+
+
+def _rbac_module() -> Any:
+    """Load the RBAC diagnostic for its redaction and az-read helpers.
+
+    By path because ``scripts`` is not a package, which is how
+    :mod:`run_agentic_stage_d_probe` and the tests already load these. Shared
+    rather than reimplemented on purpose: redaction that is copied is redaction
+    that drifts, and the failure mode of drifted redaction is a subscription id
+    in a public log.
+
+    An already-loaded copy is reused rather than loaded again, and the module is
+    registered before it is executed. Both are needed. Registering is not
+    optional -- ``dataclasses`` resolves field annotations through
+    ``sys.modules[cls.__module__]``, so a frozen dataclass in a module loaded by
+    path and left unregistered raises on definition. Reusing matters because two
+    live copies would define two different ``AzureReadFailure`` classes, and the
+    ``except`` clauses below would stop catching the one actually raised.
+    """
+    existing = sys.modules.get(RBAC_MODULE_NAME)
+    if existing is not None:
+        return existing
+    spec = importlib.util.spec_from_file_location(RBAC_MODULE_NAME, RBAC_DIAGNOSTIC)
+    if spec is None or spec.loader is None:  # pragma: no cover - a missing file
+        raise SurveyRefused(f"the RBAC diagnostic is not at {RBAC_DIAGNOSTIC}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[RBAC_MODULE_NAME] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class SurveyRefused(RuntimeError):
+    """The survey did not run, and the reason is not a fact about Azure."""
+
+
+# -------------------------------------------------------------------------
+# What a host would need
+# -------------------------------------------------------------------------
+
+#: The three control-plane writes that deploying ``infra/dev-host/main.bicep``
+#: into a subscription would perform. Listed as actions rather than as a role
+#: name because the question is what the identity *can do*, and two identities
+#: holding different roles can both be able to do this.
+REQUIRED_ACTIONS: tuple[tuple[str, str], ...] = (
+    ("Microsoft.Compute/virtualMachines/write", "create the machine itself"),
+    ("Microsoft.Network/networkInterfaces/write", "give it a network interface"),
+    (
+        "Microsoft.Resources/subscriptions/resourceGroups/write",
+        "put it in a resource group",
+    ),
+)
+
+#: Without this registered, no virtual machine can be created in the
+#: subscription however the roles read. Registering it is itself a write, so it
+#: is measured here and never performed.
+COMPUTE_PROVIDER = "Microsoft.Compute"
+
+#: The size the repository's own dev-host definition names, and the quota family
+#: Azure counts it under. Taken from ``infra/dev-host/main.bicep`` rather than
+#: chosen here, so that a survey saying "there is room" is saying it about the
+#: machine this repository would actually deploy.
+HOST_VM_SIZE = "Standard_D8as_v5"
+HOST_QUOTA_FAMILY = "standardDASv5Family"
+HOST_VCPUS = 8
+
+#: Where a host would go by default: the region the model deployment is in, so
+#: that the model-to-host hop does not cross one. Overridable, because the
+#: existing definition names ``koreacentral`` and comparing the two is a fair
+#: question.
+DEFAULT_LOCATION = "eastus2"
+
+VERDICT_HOST_EXISTS = "host_already_exists"
+VERDICT_WITHIN_PERMISSIONS = "creation_is_within_existing_permissions"
+VERDICT_BLOCKED = "blocked_and_the_change_is_named"
+VERDICT_NOT_MEASURED = "not_measured"
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One thing that was asked, and what came back.
+
+    ``measured`` is the field that carries the weight. ``False`` means az never
+    answered, and a reader must not turn that into an absence: not knowing
+    whether there is quota and knowing there is none are different facts that
+    support different decisions.
+    """
+
+    question: str
+    measured: bool
+    answer: Any
+    note: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "question": self.question,
+            "measured": self.measured,
+            "answer": self.answer,
+            "note": self.note,
+        }
+
+
+# -------------------------------------------------------------------------
+# The reads
+# -------------------------------------------------------------------------
+
+
+def _permits(definitions: Sequence[Mapping[str, Any]], action: str, rbac: Any) -> bool:
+    """Whether any of these definitions grants ``action``.
+
+    Evaluated the way Azure evaluates it -- ``actions`` matches and
+    ``notActions`` does not -- by reusing the diagnostic's own matcher, so a
+    wildcard is read the same way in both places.
+    """
+    for definition in definitions:
+        if not isinstance(definition, Mapping):
+            continue
+        for permission in definition.get("permissions") or ():
+            if not isinstance(permission, Mapping):
+                continue
+            allowed = any(
+                rbac._action_matches(entry, action)
+                for entry in permission.get("actions") or ()
+            )
+            if not allowed:
+                continue
+            denied = any(
+                rbac._action_matches(entry, action)
+                for entry in permission.get("notActions") or ()
+            )
+            if not denied:
+                return True
+    return False
+
+
+def read_session(runner: Callable[[Sequence[str]], Any], rbac: Any) -> Finding:
+    """Which subscription and tenant this session is actually in.
+
+    Asked first because every answer below is only about the place it was asked.
+    The ids themselves are never reported -- they are secrets in CI and get
+    redacted anyway -- so what comes back is their shape and whether the session
+    is where it was expected to be.
+    """
+    try:
+        account = runner(["account", "show"])
+    except rbac.AzureReadFailure as failure:
+        return Finding(
+            "which subscription is this session in",
+            measured=False,
+            answer=None,
+            note=(
+                "az could not answer, so nothing below was measured either. A "
+                "login taken outside CI reaches a different subscription and "
+                f"lands here ({failure.what})"
+            ),
+        )
+    if not isinstance(account, Mapping):
+        return Finding(
+            "which subscription is this session in",
+            measured=False,
+            answer=None,
+            note="az returned something that was not an account record",
+        )
+    expected = (os.environ.get("AZURE_SUBSCRIPTION_ID") or "").strip().lower()
+    found = str(account.get("id") or "").strip().lower()
+    return Finding(
+        "which subscription is this session in",
+        measured=True,
+        answer={
+            "is_the_expected_subscription": bool(expected) and found == expected,
+            "subscription_id_was_read": bool(found),
+            "state": str(account.get("state") or ""),
+        },
+        note=(
+            "the id is deliberately not reported; only whether it is the one "
+            "the model credential names"
+        ),
+    )
+
+
+def read_provider(runner: Callable[[Sequence[str]], Any], rbac: Any) -> Finding:
+    """Whether ``Microsoft.Compute`` is registered in this subscription."""
+    question = f"is {COMPUTE_PROVIDER} registered here"
+    try:
+        provider = runner(["provider", "show", "--namespace", COMPUTE_PROVIDER])
+    except rbac.AzureReadFailure as failure:
+        return Finding(
+            question, measured=False, answer=None, note=f"az did not answer ({failure.what})"
+        )
+    if not isinstance(provider, Mapping):
+        return Finding(
+            question, measured=False, answer=None, note="not a provider record"
+        )
+    state = str(provider.get("registrationState") or "")
+    return Finding(
+        question,
+        measured=True,
+        answer={"registration_state": state, "registered": state == "Registered"},
+        note=(
+            ""
+            if state == "Registered"
+            else (
+                "registering a provider is itself a write, so this survey "
+                "reports the state and does not change it"
+            )
+        ),
+    )
+
+
+def read_existing_hosts(runner: Callable[[Sequence[str]], Any], rbac: Any) -> Finding:
+    """How many virtual machines already exist here.
+
+    A count, never a name. A VM name is free text somebody chose and can carry
+    a project or customer in it; the count is the whole answer to "does anything
+    need creating".
+    """
+    question = "are there already virtual machines in this subscription"
+    try:
+        machines = runner(["vm", "list"])
+    except rbac.AzureReadFailure as failure:
+        return Finding(
+            question,
+            measured=False,
+            answer=None,
+            note=(
+                "az did not answer, which is also what a missing read role looks "
+                f"like from here ({failure.what})"
+            ),
+        )
+    listed = rbac._as_mappings(machines)
+    return Finding(
+        question,
+        measured=True,
+        answer={"count": len(listed)},
+        note="names withheld; the count is what the verdict turns on",
+    )
+
+
+def read_quota(
+    runner: Callable[[Sequence[str]], Any], rbac: Any, *, location: str
+) -> Finding:
+    """Whether the region has room for the size the dev-host definition names."""
+    question = f"is there {HOST_VM_SIZE} quota in {location}"
+    try:
+        usage = runner(["vm", "list-usage", "--location", location])
+    except rbac.AzureReadFailure as failure:
+        return Finding(
+            question, measured=False, answer=None, note=f"az did not answer ({failure.what})"
+        )
+    for entry in rbac._as_mappings(usage):
+        name = entry.get("name")
+        value = name.get("value") if isinstance(name, Mapping) else None
+        if str(value or "").strip().lower() != HOST_QUOTA_FAMILY.lower():
+            continue
+        try:
+            limit = int(entry.get("limit", 0))
+            current = int(entry.get("currentValue", 0))
+        except (TypeError, ValueError):
+            return Finding(
+                question,
+                measured=False,
+                answer=None,
+                note="the quota entry did not carry readable numbers",
+            )
+        return Finding(
+            question,
+            measured=True,
+            answer={
+                "family": HOST_QUOTA_FAMILY,
+                "limit_vcpus": limit,
+                "in_use_vcpus": current,
+                "free_vcpus": limit - current,
+                "enough_for_one_host": (limit - current) >= HOST_VCPUS,
+            },
+        )
+    return Finding(
+        question,
+        measured=True,
+        answer={"family": HOST_QUOTA_FAMILY, "enough_for_one_host": False},
+        note=(
+            "the family is not in this subscription's usage list at all, which "
+            "Azure reports for a family with no allocation in the region"
+        ),
+    )
+
+
+def read_permissions(
+    runner: Callable[[Sequence[str]], Any], rbac: Any, *, principal: str
+) -> Finding:
+    """Which of the three writes this identity's roles already permit."""
+    question = "can this identity already perform the writes a host needs"
+    if not principal:
+        return Finding(
+            question,
+            measured=False,
+            answer=None,
+            note="no principal id was available to ask about",
+        )
+    try:
+        assignments = rbac._as_mappings(
+            runner(["role", "assignment", "list", "--all", "--assignee", principal])
+        )
+    except rbac.AzureReadFailure as failure:
+        return Finding(
+            question, measured=False, answer=None, note=f"az did not answer ({failure.what})"
+        )
+
+    definitions: list[Mapping[str, Any]] = []
+    for definition_id in sorted(
+        {rbac._definition_id_of(item) for item in assignments} - {""}
+    ):
+        try:
+            definitions.extend(
+                rbac._as_mappings(
+                    runner(["role", "definition", "list", "--name", definition_id])
+                )
+            )
+        except rbac.AzureReadFailure:
+            # One unreadable definition is not the whole answer, but it does
+            # mean a "no" below could be wrong, so it is recorded as such.
+            return Finding(
+                question,
+                measured=False,
+                answer=None,
+                note=(
+                    "at least one role definition could not be read, so an "
+                    "answer here would be a guess about what the role allows"
+                ),
+            )
+
+    permitted = {
+        action: _permits(definitions, action, rbac) for action, _ in REQUIRED_ACTIONS
+    }
+    return Finding(
+        question,
+        measured=True,
+        answer={
+            "assignments_held": len(assignments),
+            "permits": permitted,
+            "permits_all_three": all(permitted.values()),
+        },
+    )
+
+
+# -------------------------------------------------------------------------
+# The verdict
+# -------------------------------------------------------------------------
+
+
+def decide(findings: Mapping[str, Finding]) -> dict[str, Any]:
+    """Turn the findings into one of four answers, and say why.
+
+    The ordering is deliberate. An unmeasured read outranks every conclusion,
+    because a survey that could not see is not a survey that saw nothing. An
+    existing machine outranks the permission question, because if a host is
+    already there then nothing needs creating and the roles to create one are
+    beside the point.
+    """
+    unmeasured = sorted(name for name, f in findings.items() if not f.measured)
+    if unmeasured:
+        return {
+            "verdict": VERDICT_NOT_MEASURED,
+            "because": (
+                "these reads did not complete, so nothing here is evidence of "
+                "absence: " + ", ".join(unmeasured)
+            ),
+            "what_would_have_to_change": [],
+        }
+
+    hosts = findings["existing_hosts"].answer or {}
+    if int(hosts.get("count", 0)) > 0:
+        return {
+            "verdict": VERDICT_HOST_EXISTS,
+            "because": (
+                f"{hosts['count']} virtual machine(s) already exist in this "
+                "subscription, so no machine needs creating. Whether one of "
+                "them can boot a guest is C2's question, not this one's"
+            ),
+            "what_would_have_to_change": [],
+        }
+
+    missing: list[str] = []
+    provider = findings["provider"].answer or {}
+    if not provider.get("registered"):
+        missing.append(
+            f"{COMPUTE_PROVIDER} is {provider.get('registration_state') or 'unknown'} "
+            "in this subscription and would have to be registered"
+        )
+    quota = findings["quota"].answer or {}
+    if not quota.get("enough_for_one_host"):
+        missing.append(
+            f"the region has {quota.get('free_vcpus', 0)} free vCPUs in "
+            f"{HOST_QUOTA_FAMILY} and one host needs {HOST_VCPUS}, so a quota "
+            "increase would have to be requested"
+        )
+    permissions = findings["permissions"].answer or {}
+    denied = sorted(
+        action for action, allowed in (permissions.get("permits") or {}).items()
+        if not allowed
+    )
+    if denied:
+        missing.append(
+            "this identity's roles do not permit: " + ", ".join(denied)
+        )
+
+    if missing:
+        return {
+            "verdict": VERDICT_BLOCKED,
+            "because": (
+                "a host could not be created here under the permissions and "
+                "capacity that exist today"
+            ),
+            "what_would_have_to_change": missing,
+            "and_note": (
+                "this is a report, not a request. Each item above is an access "
+                "or capacity change and belongs to whoever owns the "
+                "subscription, so it is named here and left undone"
+            ),
+        }
+
+    return {
+        "verdict": VERDICT_WITHIN_PERMISSIONS,
+        "because": (
+            "the provider is registered, the region has room for one "
+            f"{HOST_VM_SIZE}, and this identity's existing roles permit all "
+            "three writes. No access change is needed to put a host here"
+        ),
+        "what_would_have_to_change": [],
+    }
+
+
+def survey(
+    *,
+    runner: Callable[[Sequence[str]], Any] | None = None,
+    rbac: Any = None,
+    location: str = DEFAULT_LOCATION,
+    env: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Ask every question once and report the answers with a verdict."""
+    rbac = rbac or _rbac_module()
+    run = runner or rbac._default_runner
+    environment = env if env is not None else os.environ
+    principal = (environment.get("AZURE_CLIENT_ID") or "").strip()
+
+    findings = {
+        "session": read_session(run, rbac),
+        "provider": read_provider(run, rbac),
+        "existing_hosts": read_existing_hosts(run, rbac),
+        "quota": read_quota(run, rbac, location=location),
+        "permissions": read_permissions(run, rbac, principal=principal),
+    }
+    report: dict[str, Any] = {
+        "artifact": "agentic-v2-boot-host-survey",
+        "artifact_version": "1.0",
+        "question": (
+            "could the subscription the model deployment lives in host a "
+            "Firecracker guest, under permissions that already exist"
+        ),
+        "is_not": [
+            "a deployment",
+            "a role request",
+            "a measurement that any machine here can actually boot a guest",
+        ],
+        "reads_only": True,
+        "location_asked_about": location,
+        "host_definition": {
+            "from": "infra/dev-host/main.bicep",
+            "vm_size": HOST_VM_SIZE,
+            "vcpus": HOST_VCPUS,
+            "quota_family": HOST_QUOTA_FAMILY,
+        },
+        "findings": {name: f.as_dict() for name, f in findings.items()},
+    }
+    report.update(decide(findings))
+    return report
+
+
+# -------------------------------------------------------------------------
+# Output
+# -------------------------------------------------------------------------
+
+
+def render(report: Mapping[str, Any]) -> str:
+    lines = [
+        "Boot-host survey of the subscription the model deployment lives in",
+        "=" * 66,
+        f"verdict   {report['verdict']}",
+        f"because   {report['because']}",
+        "",
+        f"asked about {report['location_asked_about']}, for one "
+        f"{report['host_definition']['vm_size']} as "
+        f"{report['host_definition']['from']} defines it",
+        "",
+    ]
+    for name, finding in report["findings"].items():
+        mark = "ok " if finding["measured"] else "?? "
+        lines.append(f"  {mark}{name:<18} {finding['question']}")
+        lines.append(f"       {json.dumps(finding['answer'], sort_keys=True)}")
+        if finding["note"]:
+            lines.append(f"       note: {finding['note']}")
+    if report["what_would_have_to_change"]:
+        lines.append("")
+        lines.append("What would have to change, reported and not performed:")
+        for item in report["what_would_have_to_change"]:
+            lines.append(f"  - {item}")
+        lines.append(f"  {report.get('and_note', '')}")
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Survey, never deploy.")
+    parser.add_argument("--location", default=DEFAULT_LOCATION)
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    parser.add_argument("--out", default="")
+    args = parser.parse_args(argv)
+
+    try:
+        rbac = _rbac_module()
+        report = survey(rbac=rbac, location=args.location)
+    except SurveyRefused as refused:
+        print(f"The survey did not run: {refused}")
+        return 1
+
+    secrets = rbac.collect_secrets(os.environ)
+    text = rbac.redact(
+        json.dumps(report, indent=2, sort_keys=True) if args.as_json else render(report),
+        secrets,
+    )
+    leaked = rbac.leaked_placeholders(text, secrets)
+    if leaked:
+        # Printing the report anyway would be the one unrecoverable mistake this
+        # script can make, so it prints nothing at all.
+        print(f"FATAL: redaction failed for {', '.join(leaked)}; nothing printed")
+        return 1
+
+    print(text)
+    if args.out:
+        Path(args.out).write_text(text + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/batch-runner/tests/test_azure_boot_host_survey.py
+++ b/batch-runner/tests/test_azure_boot_host_survey.py
@@ -1,0 +1,408 @@
+"""The boot-host survey, exercised without an Azure subscription.
+
+:mod:`scripts.azure_boot_host_survey` exists to answer one question -- could a
+Firecracker host go in the subscription the model deployment already lives in,
+under permissions that already exist -- and to answer it without doing anything
+about the answer. Three properties carry that, and each has a way of quietly
+breaking:
+
+**An unmeasured read must never become an absence.** If ``az`` does not answer
+the quota question, "there is no quota" and "nobody looked" are different facts
+that justify different decisions, and only one of them is true. A survey that
+collapsed them would report a block that does not exist and send somebody to
+ask for a quota increase they already have. Asserted first and asserted hardest.
+
+**It must have no write path.** The whole justification for running this freely
+is that it creates nothing and grants nothing. That is a property of the source,
+so it is checked against the source rather than promised in a docstring.
+
+**A blocked answer must report rather than request.** Creating a machine and
+granting a role are access changes. The script's job ends at naming them.
+
+Nothing here contacts Azure, calls a model, or spends anything. Every ``az``
+read is injected.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+REPOSITORY_ROOT = BATCH_RUNNER_ROOT.parent
+SCRIPT = BATCH_RUNNER_ROOT / "scripts" / "azure_boot_host_survey.py"
+WORKFLOW = REPOSITORY_ROOT / ".github" / "workflows" / "azure-boot-host-survey.yml"
+
+SPEC = importlib.util.spec_from_file_location("azure_boot_host_survey", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+module = importlib.util.module_from_spec(SPEC)
+# Registered before execution, not after: ``dataclasses`` resolves a field's
+# annotation through ``sys.modules[cls.__module__]``, so a frozen dataclass in a
+# by-path module that is not yet registered raises while the class is defined.
+sys.modules["azure_boot_host_survey"] = module
+SPEC.loader.exec_module(module)
+
+rbac = module._rbac_module()
+
+
+# ── a fake subscription that answers ──────────────────────────────────────
+
+
+CONTRIBUTOR = {
+    "roleName": "Contributor",
+    "permissions": [{"actions": ["*"], "notActions": ["Microsoft.Authorization/*/Write"]}],
+}
+READER = {"roleName": "Reader", "permissions": [{"actions": ["*/read"], "notActions": []}]}
+
+
+def az(
+    *,
+    account=None,
+    provider="Registered",
+    machines=0,
+    free_vcpus=96,
+    definitions=(CONTRIBUTOR,),
+    fails=(),
+):
+    """A runner that answers the five reads, and fails whichever are named."""
+
+    def run(arguments):
+        head = " ".join(arguments[:2])
+        for failing in fails:
+            if head.startswith(failing):
+                raise rbac.AzureReadFailure(head, exit_code=1)
+        if head == "account show":
+            return account if account is not None else {
+                "id": "s" * 36, "state": "Enabled"
+            }
+        if head == "provider show":
+            return {"registrationState": provider}
+        if head == "vm list":
+            return [{"name": f"vm{i}"} for i in range(machines)]
+        if head == "vm list-usage":
+            return [
+                {
+                    "name": {"value": module.HOST_QUOTA_FAMILY},
+                    "limit": free_vcpus,
+                    "currentValue": 0,
+                }
+            ]
+        if head == "role assignment":
+            return [
+                {"roleDefinitionId": f"/x/{i}", "scope": "/subscriptions/x"}
+                for i, _ in enumerate(definitions)
+            ]
+        if head == "role definition":
+            return [definitions[0]] if definitions else []
+        raise AssertionError(f"the survey asked something unexpected: {head}")
+
+    return run
+
+
+def surveyed(**kwargs):
+    return module.survey(
+        runner=az(**kwargs), rbac=rbac, env={"AZURE_CLIENT_ID": "p" * 36}
+    )
+
+
+# ── the property that matters most ────────────────────────────────────────
+
+
+class TestAnUnmeasuredReadIsNotAnAbsence:
+    @pytest.mark.parametrize(
+        "failing_read", ["provider show", "vm list-usage", "role assignment", "vm list"]
+    )
+    def test_any_read_that_did_not_complete_stops_the_verdict(self, failing_read):
+        report = surveyed(fails=(failing_read,))
+        assert report["verdict"] == module.VERDICT_NOT_MEASURED
+        assert report["what_would_have_to_change"] == []
+
+    def test_it_says_which_read_was_missing_rather_than_that_something_failed(self):
+        report = surveyed(fails=("vm list-usage",))
+        assert "quota" in report["because"]
+        assert "evidence of absence" in report["because"]
+
+    def test_a_session_az_cannot_describe_is_not_a_blocked_subscription(self):
+        # The shape a local login produces. Reporting a block from here would be
+        # reporting on a subscription nobody looked at.
+        report = surveyed(fails=("account show",))
+        assert report["verdict"] == module.VERDICT_NOT_MEASURED
+        assert "outside CI" in report["findings"]["session"]["note"]
+
+    def test_a_role_definition_that_would_not_read_does_not_become_a_denial(self):
+        # The subtle one: the assignments listed fine, so it would be easy to
+        # evaluate the permissions against an incomplete set of definitions and
+        # report a denial the identity does not have.
+        report = surveyed(fails=("role definition",))
+        assert report["verdict"] == module.VERDICT_NOT_MEASURED
+        assert report["findings"]["permissions"]["measured"] is False
+
+    def test_a_quota_family_azure_does_not_list_is_measured_and_is_zero(self):
+        # Distinct from the above: Azure answered, and the family was not in the
+        # answer. That *is* an absence, and it is allowed to be one.
+        def run(arguments):
+            if " ".join(arguments[:2]) == "vm list-usage":
+                return [{"name": {"value": "standardOtherFamily"}, "limit": 9, "currentValue": 0}]
+            return az()(arguments)
+
+        report = module.survey(
+            runner=run, rbac=rbac, env={"AZURE_CLIENT_ID": "p" * 36}
+        )
+        assert report["findings"]["quota"]["measured"] is True
+        assert report["verdict"] == module.VERDICT_BLOCKED
+
+
+# ── the four answers ──────────────────────────────────────────────────────
+
+
+class TestTheVerdict:
+    def test_a_subscription_that_could_take_a_host_today(self):
+        report = surveyed()
+        assert report["verdict"] == module.VERDICT_WITHIN_PERMISSIONS
+        assert report["what_would_have_to_change"] == []
+
+    def test_an_existing_machine_outranks_the_permission_question(self):
+        # If a host is already there, the roles to create one are beside the
+        # point -- and answering "you may not create one" would be true and
+        # useless.
+        report = surveyed(machines=2, definitions=(READER,))
+        assert report["verdict"] == module.VERDICT_HOST_EXISTS
+        assert report["findings"]["existing_hosts"]["answer"]["count"] == 2
+
+    def test_an_existing_machine_is_not_a_claim_that_it_can_boot_a_guest(self):
+        report = surveyed(machines=1)
+        assert "C2's question" in report["because"]
+        assert "a measurement that any machine here can actually boot a guest" in (
+            report["is_not"]
+        )
+
+    def test_a_reader_role_is_blocked_and_the_three_writes_are_named(self):
+        report = surveyed(definitions=(READER,))
+        assert report["verdict"] == module.VERDICT_BLOCKED
+        named = " ".join(report["what_would_have_to_change"])
+        for action, _ in module.REQUIRED_ACTIONS:
+            assert action in named
+
+    def test_an_unregistered_provider_blocks_and_is_not_registered_by_the_survey(self):
+        report = surveyed(provider="NotRegistered")
+        assert report["verdict"] == module.VERDICT_BLOCKED
+        assert "would have to be registered" in " ".join(
+            report["what_would_have_to_change"]
+        )
+        assert "itself a write" in report["findings"]["provider"]["note"]
+
+    def test_a_region_with_no_room_blocks_on_capacity_not_on_permission(self):
+        report = surveyed(free_vcpus=4)
+        assert report["verdict"] == module.VERDICT_BLOCKED
+        changes = " ".join(report["what_would_have_to_change"])
+        assert "quota increase" in changes
+        assert "do not permit" not in changes
+
+    def test_being_blocked_is_reported_and_not_requested(self):
+        report = surveyed(definitions=(READER,))
+        assert "a report, not a request" in report["and_note"]
+        assert "left undone" in report["and_note"]
+
+
+class TestReadingTheRoles:
+    def test_a_wildcard_role_permits_all_three_writes(self):
+        report = surveyed()
+        assert report["findings"]["permissions"]["answer"]["permits_all_three"] is True
+
+    def test_a_not_action_takes_a_permission_back(self):
+        narrowed = {
+            "roleName": "Almost",
+            "permissions": [
+                {"actions": ["*"], "notActions": ["Microsoft.Compute/*/write"]}
+            ],
+        }
+        report = surveyed(definitions=(narrowed,))
+        permits = report["findings"]["permissions"]["answer"]["permits"]
+        assert permits["Microsoft.Compute/virtualMachines/write"] is False
+        assert permits["Microsoft.Network/networkInterfaces/write"] is True
+
+    def test_no_principal_to_ask_about_is_unmeasured_rather_than_denied(self):
+        report = module.survey(runner=az(), rbac=rbac, env={})
+        assert report["verdict"] == module.VERDICT_NOT_MEASURED
+
+
+# ── what it must not do, or say ───────────────────────────────────────────
+
+
+class TestItOnlyReads:
+    @pytest.fixture
+    def source(self):
+        return SCRIPT.read_text(encoding="utf-8")
+
+    @pytest.mark.parametrize(
+        "verb",
+        ["vm create", "deployment group create", "provider register",
+         "role assignment create", "vm start", "group create"],
+    )
+    def test_no_mutating_az_command_appears_in_the_source(self, source, verb):
+        # A grep, not a promise: if a future edit reaches for a write from the
+        # survey, this is the thing that says so.
+        assert verb not in source
+
+    def test_it_never_calls_a_model(self, source):
+        for path in (
+            "responses.create", "chat.completions", "AzureOpenAI",
+            "llm_client", "code_interpreter",
+        ):
+            assert path not in source
+
+    def test_every_az_argument_list_starts_with_a_read(self):
+        seen = []
+
+        def watching(arguments):
+            seen.append(" ".join(arguments))
+            return az()(arguments)
+
+        module.survey(runner=watching, rbac=rbac, env={"AZURE_CLIENT_ID": "p" * 36})
+        assert seen, "a survey that asked nothing would pass every check above"
+        for call in seen:
+            assert any(
+                call.endswith(tail) or f" {tail} " in f" {call} "
+                for tail in ("show", "list")
+            ) or "list" in call, call
+
+
+class TestItSaysNothingItShouldNot:
+    def test_the_subscription_id_is_not_in_the_report(self):
+        report = surveyed()
+        assert "s" * 36 not in json.dumps(report)
+        assert report["findings"]["session"]["answer"]["subscription_id_was_read"] is True
+
+    def test_machine_names_are_counted_and_not_listed(self):
+        report = surveyed(machines=3)
+        text = json.dumps(report)
+        assert "vm0" not in text and "vm1" not in text
+        assert report["findings"]["existing_hosts"]["answer"]["count"] == 3
+
+    def test_the_host_it_sizes_for_is_the_one_this_repository_defines(self):
+        # If the bicep changes size and this does not, the survey would report
+        # room for a machine nobody would deploy.
+        bicep = (BATCH_RUNNER_ROOT.parent / "infra" / "dev-host" / "main.bicep")
+        if not bicep.is_file():  # pragma: no cover - it is committed
+            pytest.skip("the dev-host definition is not committed here")
+        assert f"'{module.HOST_VM_SIZE}'" in bicep.read_text(encoding="utf-8")
+
+    def test_it_renders_without_raising_for_every_verdict(self):
+        for report in (
+            surveyed(),
+            surveyed(machines=1),
+            surveyed(definitions=(READER,)),
+            surveyed(fails=("vm list",)),
+        ):
+            assert module.render(report).startswith("Boot-host survey")
+
+
+# ── the workflow that runs it ─────────────────────────────────────────────
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+class TestTheWorkflow:
+    def test_it_loads_at_all(self):
+        # An unloadable workflow does not fail visibly: GitHub reports a run
+        # with zero jobs, named after the file path, which is easy to read as
+        # "nothing happened" rather than "this is broken".
+        workflow = _workflow()
+        assert isinstance(workflow, dict) and workflow["jobs"]
+
+    def test_it_can_only_be_started_by_hand(self):
+        # PyYAML reads a bare `on` key as the boolean True.
+        assert list(_workflow()[True]) == ["workflow_dispatch"]
+
+    def test_it_asks_for_no_more_than_it_needs(self):
+        assert _workflow()["permissions"] == {"contents": "read", "id-token": "write"}
+
+    def test_it_runs_as_the_identity_the_paid_runs_use(self):
+        text = WORKFLOW.read_text(encoding="utf-8")
+        batch_run = (REPOSITORY_ROOT / ".github/workflows/batch-run.yml").read_text(
+            encoding="utf-8"
+        )
+        login = "azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca"
+        assert login in text
+        assert login in batch_run, "the pinned login action moved; re-pin this one"
+        for name in ("AZURE_CLIENT_ID", "AZURE_TENANT_ID", "AZURE_SUBSCRIPTION_ID"):
+            assert f"secrets.{name}" in text
+
+    def test_every_action_it_uses_is_pinned_to_a_commit(self):
+        for line in WORKFLOW.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if stripped.startswith("uses:"):
+                assert re.search(r"@[0-9a-f]{40}\b", stripped), stripped
+
+    def test_it_carries_no_credential_that_could_spend(self):
+        text = WORKFLOW.read_text(encoding="utf-8")
+        for name in (
+            "AZURE_OPENAI_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
+            "HF_TOKEN", "AZURE_CLIENT_SECRET", "FOUNDRY_PROJECT_ENDPOINT",
+        ):
+            assert name not in text, name
+
+    def test_the_identity_is_checked_before_anything_is_read(self):
+        # Surveying whatever identity happens to be signed in would answer a
+        # question nobody asked, and could answer it about somebody else's
+        # subscription.
+        steps = _workflow()["jobs"]["survey"]["steps"]
+        names = [step.get("name", "") for step in steps]
+        verify = next(i for i, n in enumerate(names) if "OIDC session identity" in n)
+        read = next(i for i, n in enumerate(names) if "Survey the subscription" in n)
+        assert verify < read
+        env = steps[verify]["env"]
+        for name in (
+            "AZURE_AI_EXPECTED_CLIENT_ID",
+            "AZURE_AI_EXPECTED_TENANT_ID",
+            "AZURE_AI_EXPECTED_SUBSCRIPTION_ID",
+        ):
+            assert name in env
+
+    def test_the_step_that_prints_the_report_names_no_repository_variable(self):
+        """A variable is not a secret, and this job's logs are public.
+
+        GitHub reprints whatever a step lists under `env:` in the step header,
+        and it masks secrets there but not variables. The Foundry account and
+        project names are stored as variables, so naming one here would publish
+        it in the header of a job whose whole point is to report without naming
+        the resource. This survey does not need them -- it asks about the
+        subscription, not the account.
+        """
+        steps = _workflow()["jobs"]["survey"]["steps"]
+        printing = next(
+            step for step in steps
+            if "scripts/azure_boot_host_survey.py" in (step.get("run") or "")
+        )
+        assert "vars." not in json.dumps(printing.get("env") or {})
+
+    def test_the_survey_is_not_allowed_to_fail_the_job_for_reporting_a_block(self):
+        # A red job invites somebody to make it green, and the only way to make
+        # this one green would be to grant something. Reporting a block is the
+        # result, not an error.
+        steps = _workflow()["jobs"]["survey"]["steps"]
+        invocation = next(
+            step["run"] for step in steps
+            if "scripts/azure_boot_host_survey.py" in (step.get("run") or "")
+        )
+        # The command line, not the whole block: the comment above it says the
+        # word "--require" on purpose, and matching that would pass forever.
+        command = next(
+            line for line in invocation.splitlines()
+            if "scripts/azure_boot_host_survey.py" in line
+        )
+        assert "--require" not in command
+
+    def test_a_final_step_greps_for_writes_and_model_calls(self):
+        steps = _workflow()["jobs"]["survey"]["steps"]
+        last = steps[-1]
+        assert last.get("if") == "always()"
+        assert "vm create" in last["run"] and "responses" in last["run"]


### PR DESCRIPTION
## Why

Stage D needs two things in one place: a GPT deployment, and a machine that boots a guest. This repository has them in two places.

| | where it lives | reached by |
|---|---|---|
| the host that boots a guest | subscription `4b7c60a5…`, tenant `6d93cc9b…` | a local `az` session |
| the GPT deployment | subscription `d372e9cf…`, tenant `16b3c013…` | the GitHub OIDC identity |

Booting the guest on the runner that already holds the model credential is **recorded as closed** — `RECORDED_FINDINGS[0]` in `core/agentic_v2_containment_readiness.py`, citing GitHub's own documentation calling nested virtualisation on hosted runners technically possible but not officially supported. The objection is to support status, not to hardware, so measuring `/dev/kvm` does not reopen it.

That leaves one route: put a host where the model already is. **This PR measures whether that is possible under permissions that already exist, and does nothing about the answer.**

## What it does

Five ARM control-plane **reads**:

1. the session — is there one, and what subscription is it on
2. `Microsoft.Compute` registration state
3. how many machines are already in the subscription (a **count**; no names)
4. regional quota for `Standard_D8as_v5` — the size `infra/dev-host/main.bicep` defines, asserted against the bicep by a test
5. what the run identity's role assignments actually permit, for the three writes a host needs

It creates nothing, registers nothing, requests no role, and calls no model. Running it is free and changes nothing.

## Four answers

| verdict | meaning |
|---|---|
| `host_already_exists` | a machine is already there; the permission question is moot |
| `creation_is_within_existing_permissions` | a host could go here today, with no access change |
| `blocked_and_the_change_is_named` | it could not, and the exact change is named — **not requested** |
| `not_measured` | a read did not complete, so nothing here is evidence of anything |

## Three properties, held against the source

**An unmeasured read never becomes an absence.** If `az` does not answer the quota question, *"there is no quota"* and *"nobody looked"* are different facts that justify different decisions, and only one of them is true. Collapsing them would report a block that does not exist and send somebody to ask for a quota increase they already have. Any incomplete read stops the verdict at `not_measured`, and `what_would_have_to_change` comes back empty. This is asserted first and hardest — including the subtle case where the role *assignments* list fine but a *definition* fails to read, which would otherwise evaluate permissions against an incomplete set and report a denial the identity does not have.

The converse is also tested: a quota family Azure answers about and simply does not list **is** a real absence, and is allowed to be one.

**There is no write path.** Checked by grep over the source — in the unit tests, and again as the workflow's final `always()` step — so an edit that reaches for a control-plane write or an inference path from here is visible without depending on a docstring staying honest.

**A blocked answer is reported, not requested.** Creating a machine and granting a role are access changes. The script's job ends at naming the exact one. The workflow passes **no `--require` flag of any kind**: a red job would invite somebody to make it green by granting something, and reporting a block is the result of the run, not a failure of it.

## Why it has to be a workflow

The script reads whatever subscription the `az` session holds, and a login taken on a development box is a different one — the Foundry subscription is not reachable from there. Run locally it reports `not_measured`, which is true and useless. The federated token only exists in a job, and that job runs what the repository contains.

The workflow carries no credential that could spend, and **no Foundry account or project name**: GitHub reprints whatever a step lists under `env:` in the public step header, and masks secrets there but not variables. The survey asks about the subscription, not the account, so it does not need them.

## What this is not

It is not a claim that any machine in that subscription can boot a guest — that is C2's question, answered separately and on a different host. An existing machine here means the *permission* question is moot, nothing more.

## Checks

- 40 new tests, all passing
- `mypy scripts/azure_boot_host_survey.py` clean
- no model call, no Azure spend, nothing created

The `.gitignore` negation is required: `batch-runner/scripts/*` is blanket-ignored, and the comment above the negation says why this one file is committed.