### PR TITLE
fix(relay): refuse a relay budget that has no watchdog to spend it

### DIFF
--- a/.github/workflows/batch-run.yml
+++ b/.github/workflows/batch-run.yml
@@ -427,6 +427,52 @@ jobs:
             raise SystemExit("execution.wall_timeout is invalid")
           if type(relay_max_runs) is not int or not 0 <= relay_max_runs <= 10:
             raise SystemExit("execution.relay_max_runs is invalid")
+          # Those two are checked independently and independently both pass: a
+          # zero watchdog is the documented way to turn the clock off, and a
+          # relay budget is the documented way to permit more legs. Together
+          # they are a trap, because the watchdog is the thing that ends a leg
+          # early enough to hand over. With it off, condition_a runs until the
+          # 350 minute step cap kills the shell, `echo "exit_code=..."` never
+          # runs, and `relay_checkpoint.py status --exit-code ''` exits
+          # non-zero -- measured, not assumed. `needs_relay` is then unset, and
+          # the checkpoint upload step is gated on it, so every task the leg
+          # finished dies with the runner. The budget buys nothing and costs a
+          # run.
+          #
+          # Only an *explicit* budget is refused. `relay_max_runs` defaults to
+          # three with nobody having asked for it, so firing on the default
+          # would reject all thirty-six experiments the moment someone used the
+          # documented `wall_timeout=0`. The author who typed the number is the
+          # one expecting a handover that cannot happen.
+          wall_timeout_input = os.environ.get("WALL_TIMEOUT_INPUT", "")
+          if not re.fullmatch(r"[0-9]+", wall_timeout_input):
+            raise SystemExit(
+              "wall_timeout dispatch input is not a decimal integer: "
+              + repr(wall_timeout_input)
+            )
+          # Mirrors step 2a's resolution exactly -- a non-zero input wins, zero
+          # falls back to the YAML. Restating it here rather than importing it
+          # is this guard's weak point, so the test that covers it executes
+          # this script instead of reading it: a divergence shows up as a
+          # failing assertion rather than as a comment that quietly went stale.
+          effective_wall_timeout = int(wall_timeout_input) or wall_timeout
+          if (
+            "relay_max_runs" in execution
+            and relay_max_runs > 0
+            and effective_wall_timeout == 0
+          ):
+            raise SystemExit(
+              "execution.relay_max_runs is {} but the effective step 2a "
+              "watchdog is 0 minutes (dispatch input {}, execution."
+              "wall_timeout {}). Nothing would end a leg in time to hand "
+              "over, and a leg killed by the 350 minute step cap uploads no "
+              "checkpoint, so the budget is unspendable and the leg's work is "
+              "lost. Pass the wall_timeout dispatch input (290 is its "
+              "default), or declare execution.wall_timeout, or set "
+              "execution.relay_max_runs to 0.".format(
+                relay_max_runs, wall_timeout_input, wall_timeout
+              )
+            )
           mode = execution.get("mode")
           hardened = sandbox.get("hardened_substrate") is True
 

--- a/batch-runner/tests/test_a_relay_budget_needs_a_watchdog_to_spend_it.py
+++ b/batch-runner/tests/test_a_relay_budget_needs_a_watchdog_to_spend_it.py
@@ -15,17 +15,23 @@ never set; and the checkpoint upload step is gated on `needs_relay == 'true'`.
 Every task the leg completed dies with the runner. The budget is unspendable
 and the run is lost.
 
-These tests **execute** the workflow step rather than reading it. The repo's
-existing workflow tests -- `test_agentic_workflows.py`, and
-`test_a_batch_dispatch_can_open_the_codex_gate.py` -- pull the `run:` string
-out and assert that substrings appear in it, which proves a spelling and not a
-behaviour: a guard that is present but inverted, or shadowed by an earlier
-`raise`, passes every one of those assertions. Here the inline `python3`
-heredoc is extracted, dedented, and run in a synthetic checkout with a
-synthetic dispatch environment, and the assertion is on its exit status. The
-script turns out to be entirely offline -- YAML, `ExperimentConfig`, a repo-id
-validator, a route table, and a write to `GITHUB_OUTPUT` -- so this costs
-nothing and reaches nothing.
+These tests **execute** the workflow step rather than reading it. The Python
+side of the repo has not done that before: `test_agentic_workflows.py` and
+`test_a_batch_dispatch_can_open_the_codex_gate.py` pull the `run:` string out
+and assert that substrings appear in it, which proves a spelling and not a
+behaviour -- a guard that is present but inverted, or shadowed by an earlier
+`raise`, passes every one of those assertions. The technique itself is not new
+here: `scripts/__tests__/onboarding-contract.test.mjs` already extracts this
+same heredoc and runs it, and finding that out is how the guard's first draft
+was caught breaking a second caller. That file is the contract's home on the
+Node side and gained the guard's cases too; this file is its home on the
+Python side, where the rest of the relay machinery is tested.
+
+The inline `python3` heredoc is extracted, dedented, and run in a synthetic
+checkout with a synthetic dispatch environment, and the assertion is on its
+exit status. The script turns out to be entirely offline -- YAML,
+`ExperimentConfig`, a repo-id validator, a route table, and a write to
+`GITHUB_OUTPUT` -- so this costs nothing and reaches nothing.
 
 That matters most for one line in particular. The guard restates step 2a's
 resolution rule (a non-zero dispatch input wins, zero falls back to the YAML)
@@ -237,6 +243,26 @@ def test_an_uninterpretable_input_is_refused_rather_than_read_as_zero(
     )
     assert result.returncode != 0
     assert "not a decimal integer" in result.stderr
+
+
+def test_the_job_supplies_the_variable_the_guard_refuses_to_do_without():
+    """Refusing an empty value is only safe while the job always sets one.
+
+    The empty case above is not hypothetical: the first draft of this guard
+    broke `scripts/__tests__/onboarding-contract.test.mjs`, which runs the same
+    heredoc without this variable. The fix was to give that harness the
+    environment the workflow has rather than to soften the guard -- which is
+    the right call only for as long as the workflow really does have it. If a
+    later edit drops it from the job env, every dispatch dies at this step, so
+    the assertion belongs next to the guard that depends on it.
+    """
+    document = yaml.safe_load(BATCH_WORKFLOW.read_text(encoding="utf-8"))
+    job = document["jobs"]["batch-run"]
+    assert job["env"]["WALL_TIMEOUT_INPUT"] == "${{ inputs.wall_timeout }}"
+    # And the input it reads has a non-zero default, so the ordinary dispatch
+    # arms the watchdog without anyone typing a number.
+    on = document.get("on") or document.get(True)
+    assert on["workflow_dispatch"]["inputs"]["wall_timeout"]["default"] == 290
 
 
 # --- the step still does its original job --------------------------------

--- a/batch-runner/tests/test_a_relay_budget_needs_a_watchdog_to_spend_it.py
+++ b/batch-runner/tests/test_a_relay_budget_needs_a_watchdog_to_spend_it.py
@@ -1,0 +1,299 @@
+"""A relay budget with no watchdog to spend it is refused at dispatch.
+
+`batch-run.yml` validates `execution.wall_timeout` and
+`execution.relay_max_runs` separately, and separately each is fine. A zero
+watchdog is the documented way to turn the clock off; a relay budget is the
+documented way to permit more legs. The combination is a trap, and because
+nothing looks at the pair, it passes.
+
+What the trap costs was measured rather than argued. The watchdog is what ends
+a leg early enough to save its work and hand over. With it off, condition_a
+runs until GitHub's 350 minute step cap kills the shell; `echo "exit_code=..."`
+never runs, so the step output is empty; `relay_checkpoint.py status
+--exit-code ''` exits non-zero on an empty value; `needs_relay` is therefore
+never set; and the checkpoint upload step is gated on `needs_relay == 'true'`.
+Every task the leg completed dies with the runner. The budget is unspendable
+and the run is lost.
+
+These tests **execute** the workflow step rather than reading it. The repo's
+existing workflow tests -- `test_agentic_workflows.py`, and
+`test_a_batch_dispatch_can_open_the_codex_gate.py` -- pull the `run:` string
+out and assert that substrings appear in it, which proves a spelling and not a
+behaviour: a guard that is present but inverted, or shadowed by an earlier
+`raise`, passes every one of those assertions. Here the inline `python3`
+heredoc is extracted, dedented, and run in a synthetic checkout with a
+synthetic dispatch environment, and the assertion is on its exit status. The
+script turns out to be entirely offline -- YAML, `ExperimentConfig`, a repo-id
+validator, a route table, and a write to `GITHUB_OUTPUT` -- so this costs
+nothing and reaches nothing.
+
+That matters most for one line in particular. The guard restates step 2a's
+resolution rule (a non-zero dispatch input wins, zero falls back to the YAML)
+instead of importing it, because the two live in different languages. A
+restatement can drift from the thing it restates. Executing both sides of the
+matrix here means a drift fails an assertion instead of ageing quietly into a
+comment.
+
+What this does not test: whether the relay itself works. That is
+`test_relay_duration.py` and the checkpoint tests. This is only about refusing
+a dispatch that has asked for legs it could never take.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+BATCH_WORKFLOW = ROOT / ".github" / "workflows" / "batch-run.yml"
+CORE = ROOT / "batch-runner" / "core"
+# The documented minimal experiment, used as a known-valid base so the fixture
+# below changes one thing at a time. Its mode is irrelevant: the watchdog and
+# the relay budget are not mode-specific.
+BASE_EXPERIMENT = (
+    ROOT / "batch-runner" / "experiments" / "exp998_smoke_baseline_sample.yaml"
+)
+
+
+def _config_script() -> str:
+    """The inline python from the `Read experiment config flags` step."""
+    document = yaml.safe_load(BATCH_WORKFLOW.read_text(encoding="utf-8"))
+    steps = document["jobs"]["batch-run"]["steps"]
+    step = next(
+        item
+        for item in steps
+        if item.get("name") == "Read experiment config flags"
+    )
+    lines = step["run"].splitlines()
+    start = next(
+        index
+        for index, line in enumerate(lines)
+        if line.strip().startswith("python3 <<")
+    )
+    end = next(
+        index
+        for index in range(len(lines) - 1, start, -1)
+        if lines[index].strip() == "PY"
+    )
+    body = textwrap.dedent("\n".join(lines[start + 1 : end]))
+    assert body.strip(), "the step's heredoc did not extract"
+    return body
+
+
+def dispatch(
+    tmp_path: Path,
+    *,
+    wall_timeout_input: str,
+    relay_max_runs: object = "absent",
+    wall_timeout: object = "absent",
+) -> subprocess.CompletedProcess:
+    """Run the step against a synthetic checkout and dispatch environment.
+
+    ``"absent"`` means the key is not written at all, which is a different
+    input from writing a zero -- the whole point of the guard is that an
+    explicit number and an unrequested default are treated differently.
+
+    ``core`` is symlinked rather than copied so the script's
+    ``sys.path.insert(0, "batch-runner")`` resolves, and so nothing is ever
+    written inside the real tree.
+    """
+    (tmp_path / "batch-runner" / "experiments").mkdir(parents=True)
+    os.symlink(CORE, tmp_path / "batch-runner" / "core")
+
+    config = yaml.safe_load(BASE_EXPERIMENT.read_text(encoding="utf-8"))
+    execution = config.setdefault("execution", {})
+    for key, value in (
+        ("relay_max_runs", relay_max_runs),
+        ("wall_timeout", wall_timeout),
+    ):
+        if value == "absent":
+            execution.pop(key, None)
+        else:
+            execution[key] = value
+    (tmp_path / "batch-runner" / "experiments" / "fixture.yaml").write_text(
+        yaml.safe_dump(config), encoding="utf-8"
+    )
+
+    script = tmp_path / "read_config.py"
+    script.write_text(_config_script(), encoding="utf-8")
+    github_output = tmp_path / "github_output"
+    github_output.write_text("", encoding="utf-8")
+
+    return subprocess.run(
+        [sys.executable, script.name],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "EXPERIMENT_YAML_INPUT": "fixture",
+            "WALL_TIMEOUT_INPUT": wall_timeout_input,
+            "GITHUB_OUTPUT": str(github_output),
+        },
+        capture_output=True,
+        text=True,
+    )
+
+
+# --- the combination that is refused ------------------------------------
+
+
+def test_an_explicit_budget_with_no_watchdog_either_side_is_refused(tmp_path):
+    """The trap itself: six legs asked for, nothing able to end a leg."""
+    result = dispatch(
+        tmp_path, wall_timeout_input="0", relay_max_runs=6, wall_timeout=0
+    )
+    assert result.returncode != 0
+    assert "execution.relay_max_runs is 6" in result.stderr
+    assert "watchdog is 0 minutes" in result.stderr
+    # The reader has to be told which of the two to change, because either
+    # will do and the right one depends on what they meant.
+    assert "wall_timeout dispatch input" in result.stderr
+    assert "execution.relay_max_runs to 0" in result.stderr
+
+
+def test_the_yaml_being_silent_is_not_a_watchdog(tmp_path):
+    """Thirty-six of thirty-six experiments declare no `wall_timeout`.
+
+    So the fallback the dispatch input falls back *to* is, in practice,
+    always absent. An omitted key must read the same as a zero here.
+    """
+    result = dispatch(tmp_path, wall_timeout_input="0", relay_max_runs=6)
+    assert result.returncode != 0
+    assert "execution.wall_timeout 0" in result.stderr
+
+
+# --- the combinations that are not ---------------------------------------
+
+
+def test_the_dispatch_default_arms_the_watchdog_and_the_budget_stands(tmp_path):
+    """290 is the input's declared default, so this is the ordinary case.
+
+    exp034 carries `relay_max_runs: 6` and no `wall_timeout`, and it must keep
+    dispatching. A guard that rejected this would block every real run.
+    """
+    result = dispatch(
+        tmp_path, wall_timeout_input="290", relay_max_runs=6, wall_timeout=0
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_an_unrequested_default_budget_does_not_block_a_disabled_watchdog(
+    tmp_path,
+):
+    """`relay_max_runs` defaults to three with nobody having typed it.
+
+    Turning the watchdog off is documented -- the input's own description says
+    "disabled only when both are 0". Firing on the default would make that
+    documented path impossible for every experiment in the tree, which is a
+    larger breakage than the one being prevented.
+    """
+    result = dispatch(tmp_path, wall_timeout_input="0", wall_timeout=0)
+    assert result.returncode == 0, result.stderr
+
+
+def test_a_yaml_watchdog_satisfies_the_guard_when_the_input_is_zero(tmp_path):
+    """This is the fallback working as designed, and it must not be refused.
+
+    It is also the case that pins the restated resolution rule: if the guard
+    read the input alone it would refuse here, and step 2a would then have
+    armed a watchdog for a run that was never allowed to start.
+    """
+    result = dispatch(
+        tmp_path, wall_timeout_input="0", relay_max_runs=6, wall_timeout=120
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_declining_the_budget_outright_is_allowed_with_no_watchdog(tmp_path):
+    """Zero legs and no clock is coherent: one leg, and it either finishes
+    inside the step cap or it does not."""
+    result = dispatch(
+        tmp_path, wall_timeout_input="0", relay_max_runs=0, wall_timeout=0
+    )
+    assert result.returncode == 0, result.stderr
+
+
+# --- the input itself -----------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["", "29O", "290.0", "-1", " 290"])
+def test_an_uninterpretable_input_is_refused_rather_than_read_as_zero(
+    tmp_path, value
+):
+    """Reading an unparseable input as 0 would arm nothing and refuse nothing.
+
+    Step 2a already applies exactly this test (`^[0-9]+$`) and exits 1 on a
+    miss, so nothing new is rejected here -- the rejection just moves earlier,
+    to before the job has installed anything or touched a credential, which is
+    the direction it should move in.
+    """
+    result = dispatch(
+        tmp_path, wall_timeout_input=value, relay_max_runs=6, wall_timeout=0
+    )
+    assert result.returncode != 0
+    assert "not a decimal integer" in result.stderr
+
+
+# --- the step still does its original job --------------------------------
+
+
+def test_the_step_still_emits_the_outputs_the_rest_of_the_job_reads(tmp_path):
+    """A guard inserted mid-script can truncate what follows it.
+
+    Nothing downstream would notice immediately: the outputs would simply be
+    empty strings, and several consumers treat empty as false.
+    """
+    (tmp_path / "batch-runner" / "experiments").mkdir(parents=True)
+    os.symlink(CORE, tmp_path / "batch-runner" / "core")
+    config = yaml.safe_load(BASE_EXPERIMENT.read_text(encoding="utf-8"))
+    config.setdefault("execution", {})["relay_max_runs"] = 6
+    (tmp_path / "batch-runner" / "experiments" / "fixture.yaml").write_text(
+        yaml.safe_dump(config), encoding="utf-8"
+    )
+    script = tmp_path / "read_config.py"
+    script.write_text(_config_script(), encoding="utf-8")
+    github_output = tmp_path / "github_output"
+    github_output.write_text("", encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, script.name],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "EXPERIMENT_YAML_INPUT": "fixture",
+            "WALL_TIMEOUT_INPUT": "290",
+            "GITHUB_OUTPUT": str(github_output),
+        },
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+    emitted = dict(
+        line.split("=", 1)
+        for line in github_output.read_text(encoding="utf-8").splitlines()
+        if "=" in line
+    )
+    for key in (
+        "install_libreoffice",
+        "wall_timeout",
+        "relay_max_runs",
+        "source_repo",
+        "uses_sandbox",
+        "sandbox_image",
+        "uses_agentic",
+        "uses_code_interpreter",
+        "uses_codex_foundry",
+        "azure_ai_workloads_json",
+    ):
+        assert key in emitted, f"{key} stopped being emitted"
+    # `wall_timeout` is still the YAML's value, not the resolved one. Step 2a
+    # resolves; this step reports what the file said, and changing that would
+    # change the meaning of an output other steps already consume.
+    assert emitted["relay_max_runs"] == "6"
+    assert emitted["wall_timeout"] == "0"

--- a/scripts/__tests__/onboarding-contract.test.mjs
+++ b/scripts/__tests__/onboarding-contract.test.mjs
@@ -433,6 +433,10 @@ test('workflow input tables mirror defaults and watchdog delegation', async () =
         ...process.env,
         PYTHONPATH: batchRunnerPath,
         EXPERIMENT_YAML_INPUT: 'fixture',
+        // The job declares this at job level from an input whose default is
+        // 290, so the step never sees it absent. A harness that omits it is
+        // not running the step the workflow runs.
+        WALL_TIMEOUT_INPUT: '290',
         GITHUB_OUTPUT: outputPath,
       },
     })
@@ -451,10 +455,46 @@ test('workflow input tables mirror defaults and watchdog delegation', async () =
           ...process.env,
           PYTHONPATH: batchRunnerPath,
           EXPERIMENT_YAML_INPUT: 'fixture',
+          WALL_TIMEOUT_INPUT: '290',
           GITHUB_OUTPUT: outputPath,
         },
       }),
     )
+    // A relay budget the run could never spend. `wall_timeout` and
+    // `relay_max_runs` are each valid alone; together, with nothing left to
+    // end a leg early enough to hand over, the leg is killed by the 350
+    // minute step cap and uploads no checkpoint, so every task it finished is
+    // lost. Refused here rather than six hours into a run.
+    await writeFile(
+      fixturePath,
+      `${config(0)}  relay_max_runs: 6\n`,
+      'utf8',
+    )
+    await assert.rejects(
+      execFileAsync('python3', ['-c', readConfigPython], {
+        cwd: fixtureRoot,
+        env: {
+          ...process.env,
+          PYTHONPATH: batchRunnerPath,
+          EXPERIMENT_YAML_INPUT: 'fixture',
+          WALL_TIMEOUT_INPUT: '0',
+          GITHUB_OUTPUT: outputPath,
+        },
+      }),
+      /relay_max_runs is 6/,
+    )
+    // The same file with the watchdog armed is accepted, so the refusal above
+    // is about the pair and not about the budget.
+    await execFileAsync('python3', ['-c', readConfigPython], {
+      cwd: fixtureRoot,
+      env: {
+        ...process.env,
+        PYTHONPATH: batchRunnerPath,
+        EXPERIMENT_YAML_INPUT: 'fixture',
+        WALL_TIMEOUT_INPUT: '290',
+        GITHUB_OUTPUT: outputPath,
+      },
+    })
   } finally {
     await rm(fixtureRoot, { recursive: true, force: true })
   }


### PR DESCRIPTION
## What passes today that should not

`Read experiment config flags` checks `execution.wall_timeout` and
`execution.relay_max_runs` independently, and independently each is fine.
Nothing looks at the pair. Demonstrated by executing the step unchanged:

```
trap-explicit6-input0-yaml0    rc=0     <- relay_max_runs: 6, watchdog 0
```

## Why the pair is a trap

The watchdog is the thing that ends a leg early enough to save its work and
hand over. With it off:

1. condition_a runs until GitHub's 350 minute step cap kills the shell
2. `echo "exit_code=..."` never runs, so the step output is empty
3. `relay_checkpoint.py status --exit-code ''` exits non-zero on an empty
   value — measured, not assumed
4. `needs_relay` is therefore never set
5. the checkpoint upload step is gated on `needs_relay == 'true'`, so it does
   not run

Every task the leg completed dies with the runner. The budget is unspendable
and the run is lost.

## What is refused, and what is not

Only an **explicit** `relay_max_runs > 0`. The key defaults to three with
nobody having typed it, so firing on the default would reject all thirty-six
experiments the moment someone used `wall_timeout=0` — which the input's own
description documents ("disabled only when both are 0"). That would be a
larger breakage than the one being prevented.

| dispatch input | YAML `wall_timeout` | `relay_max_runs` | result |
|---|---|---|---|
| 0 | 0 | 6 (explicit) | **refused** |
| 0 | absent | 6 (explicit) | **refused** |
| 290 | 0 | 6 (explicit) | accepted — the ordinary case, exp034 |
| 0 | 0 | absent (default 3) | accepted — documented disable path |
| 0 | 120 | 6 (explicit) | accepted — the YAML fallback arming it |
| 0 | 0 | 0 (explicit) | accepted — no budget claimed |
| `""` / `29O` / `290.0` / `-1` / `" 290"` | — | 6 | refused as uninterpretable |

The last row is not new behaviour: step 2a already applies `^[0-9]+$` and
exits 1 on a miss. The rejection just moves earlier, to before the job has
installed anything or touched a credential.

## The first draft broke a caller I did not know about

`validate` failed in 39 seconds with the guard's own message. The step has a
**second consumer**: `scripts/__tests__/onboarding-contract.test.mjs` extracts
this same heredoc and runs it, and it did not set `WALL_TIMEOUT_INPUT`.

Fixed by giving that harness the environment the workflow has, not by
softening the guard. A harness running the step under an environment the job
never produces is testing something that does not happen, and an empty value
is precisely the state that should fail closed — it means nobody resolved the
watchdog, and reading it as zero would arm nothing while refusing nothing.
A Python test now asserts the job really does declare `WALL_TIMEOUT_INPUT`
and that the input's default is 290, since the strictness is only safe while
that holds.

That same Node file gained the guard's cases, because it is where this
contract already lives on the Node side: the trap combination is rejected with
`relay_max_runs is 6`, and the identical file with the watchdog armed is
accepted — so the refusal is demonstrably about the pair, not the budget.

## Tests execute the step rather than reading it

New to the **Python** side. `test_agentic_workflows.py` and
`test_a_batch_dispatch_can_open_the_codex_gate.py` pull the `run:` string out
and assert substrings appear in it, which proves a spelling, not a behaviour —
a guard present but inverted, or shadowed by an earlier `raise`, passes every
one of those assertions.

The technique is not new to the repo, and an earlier draft of this PR said it
was. `onboarding-contract.test.mjs` has been doing it all along; not knowing
that is exactly what produced the break above.

The new Python file extracts the heredoc, dedents it, and runs it in a
synthetic checkout with a synthetic dispatch environment, asserting on exit
status. The script is entirely offline (YAML, `ExperimentConfig`, a repo-id
validator, a route table, a write to `GITHUB_OUTPUT`), so it reaches nothing
and costs nothing.

That matters for one line: the guard **restates** step 2a's resolution rule
(non-zero input wins, zero falls back to the YAML) rather than importing it,
because the two live in different languages. Executing both sides of the
matrix means a drift fails an assertion instead of ageing quietly into a
comment.

One test asserts the step still emits all ten outputs the rest of the job
reads, since a guard inserted mid-script can truncate what follows it and
nothing downstream would notice — the outputs would just be empty strings, and
several consumers treat empty as false.

## Verification

- new Python file with the guard: 13 passed
- against the pre-guard workflow: **7 failed / 5 passed** (the five are the
  acceptance cases, which must hold on both sides)
- `test_agentic_workflows.py`, `test_a_batch_dispatch_can_open_the_codex_gate.py`,
  `test_relay_duration.py` alongside it: 40 passed, 6 skipped
- `node --test scripts/__tests__/*.test.mjs`: 487 passed, 0 failed (after
  `npm run aggregate`; without it 20 unrelated files fail on the missing
  `public/generated`)

## Scope

Owner: A. Touches `.github/workflows/batch-run.yml` (shared CI), one new test
file, and the Node contract test that runs the same step. No overlap with
#513, which adds a new workflow file.

Does not change relay behaviour, the watchdog value, or anything about how a
leg hands over — only which dispatches are allowed to start.