### PR TITLE
fix(agentic): let the run record describe the backend that ran

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,6 +220,12 @@ tasks/0822_saturday/*
 # tests assert against this file directly, so it is also the thing that would
 # fail if the module and the artefact ever stopped agreeing.
 !tasks/0822_saturday/guest_declared_command_sweep.json
+# The boot-host survey's answer. This one is a transcription rather than a
+# machine-written artefact -- the survey prints prose and the run's log is the
+# original -- but logs age out, and the named access change it reports is the
+# thing stage D is waiting on. Keeping it in the tree means the block can be
+# read, and re-read, without a run id that still resolves.
+!tasks/0822_saturday/boot_host_survey.json
 !tasks/0828_friday/
 tasks/0828_friday/*
 !tasks/0828_friday/TASK_PER_TASK_COST_RECEIPTS.md

--- a/batch-runner/core/agentic_v2_runner.py
+++ b/batch-runner/core/agentic_v2_runner.py
@@ -465,11 +465,31 @@ class AgenticV2ScriptedRunner:
             startup_data = startup.get("data") or {}
             identity = startup_data.get("backend_identity") or {}
             expected_implementation_sha = foundation_implementation_fingerprint()
-            if identity != {
-                "backend_id": FOUNDATION_BACKEND_ID,
-                "foundation_only": True,
-                "implementation_sha256": expected_implementation_sha,
-            }:
+            # The admitted set, written as a set of one.
+            #
+            # There is a second backend in this repository --
+            # core/agentic_v2_microvm_backend.py, which boots a real guest and
+            # reports an identity derived from the image rather than from its
+            # own source text. It does not appear here, and this change does
+            # not put it here.
+            #
+            # What the shape buys is that admitting it later is an edit to a
+            # named list rather than a loosened comparison, so it shows up in a
+            # diff as what it is. It is also not the only thing that would have
+            # to change: the semantic verifier in agentic_v2_provenance.py
+            # re-simulates every executed tool call against the fixture's known
+            # behaviour, and a command run in a real guest cannot be
+            # re-simulated. Admitting a second identity without answering that
+            # would produce runs this code calls verified while checking
+            # strictly less than the word implies.
+            admitted_identities = (
+                {
+                    "backend_id": FOUNDATION_BACKEND_ID,
+                    "foundation_only": True,
+                    "implementation_sha256": expected_implementation_sha,
+                },
+            )
+            if identity not in admitted_identities:
                 lifecycle.transition(LifecycleState.FAILED)
                 return finish(_failure(
                     "compute_start_failed", lifecycle, audit_chain, public_chain,
@@ -634,7 +654,14 @@ class AgenticV2ScriptedRunner:
                 substrate_manifest_sha256=substrate_sha,
                 package_snapshot_sha256=package_snapshot_sha,
                 browser_build_sha256=browser_build_sha,
-                backend_implementation_sha256=expected_implementation_sha,
+                # The identity's own digest, not the one it was checked
+                # against. The guard above has already established they are
+                # equal, so this changes nothing today -- which is the point of
+                # doing it now rather than later. A run record should describe
+                # the backend that ran, and reading the expected value here is
+                # only incidentally right: it is right because a second backend
+                # cannot get this far, not because the field means "expected".
+                backend_implementation_sha256=identity["implementation_sha256"],
                 capabilities_sha256=canonical_sha256(capabilities),
                 budget_caps=self.budget_caps,
             )
@@ -644,7 +671,14 @@ class AgenticV2ScriptedRunner:
                 "schema_version": "2.0",
                 "tool_contract_version": self.profile.tool_contract_version,
                 "policy_profile_id": self.profile.policy_profile_id,
-                "foundation_only": True,
+                # Reported by the backend, not asserted by this line. The same
+                # reasoning, and here it mattered more: the literal that stood
+                # here sat two lines above a real backend_identity carrying its
+                # own foundation_only, read from a substrate manifest. Nothing
+                # made the two agree. Today the guard does, so the value is
+                # unchanged; the difference is that a disagreement would now be
+                # impossible rather than silent.
+                "foundation_only": identity["foundation_only"],
                 "lifecycle_state": lifecycle.state.value,
                 "backend_identity": deepcopy(identity),
                 "capabilities_sha256": canonical_sha256(capabilities),

--- a/batch-runner/tests/test_agentic_v2_foundation.py
+++ b/batch-runner/tests/test_agentic_v2_foundation.py
@@ -3511,3 +3511,153 @@ def _append_trace_pair_tool_event(metadata, request, envelope):
     metadata["trace_pair_sha256"] = trace_pair_fingerprint(
         metadata["private_audit"], metadata["public_trace"]
     )
+
+# ---------------------------------------------------------------------------
+# The run record describes the backend that ran
+#
+# Two fields in the success envelope used to be written as constants next to a
+# backend_identity that carries the same facts from the backend itself:
+# ``foundation_only`` as the literal ``True``, and the runtime fingerprint's
+# implementation digest as the value the guard compared *against* rather than
+# the value the backend *reported*. Nothing made the pairs agree; the startup
+# guard did, one screen earlier, and so both constants were right by
+# consequence rather than by construction.
+#
+# The tests below pin the constructed version. They pass against the constants
+# too -- there is one admitted backend, so the two readings cannot differ
+# today. That is the reason to do it while they cannot: the moment a second
+# identity is admitted, a constant here would start describing the wrong run,
+# and it would do it silently, in the field a reader would use to tell which
+# run they were looking at.
+# ---------------------------------------------------------------------------
+
+
+_SUCCESSFUL_CALLS = [
+    {
+        "call_id": "write-1",
+        "name": "workspace_apply",
+        "arguments": {
+            "operation": "write",
+            "path": "draft.txt",
+            "content": "hello",
+        },
+    },
+    {
+        "call_id": "exec-1",
+        "name": "exec_run",
+        "arguments": {
+            "argv": ["fixture-upper", "draft.txt", "report.txt"],
+            "cwd": ".",
+            "timeout_seconds": 30,
+        },
+    },
+    {
+        "call_id": "final-1",
+        "name": "finalize",
+        "arguments": {"deliverables": ["report.txt"], "summary": "done"},
+    },
+]
+
+
+def _successful_run(tmp_path, backend_class=AgenticV2FixtureBackend):
+    return AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: backend_class(root=tmp_path, **kwargs),
+        scripted_calls=deepcopy(_SUCCESSFUL_CALLS),
+        profile=PROFILE,
+    ).run("Create report", task_id="task-1")
+
+
+def test_reported_foundation_only_comes_from_the_backend_not_the_runner(
+    tmp_path,
+):
+    result = _successful_run(tmp_path)
+    metadata = result["agentic_v2"]
+    started = metadata["private_audit"]["events"][0]["payload"]
+
+    assert result["success"] is True
+    # The envelope's claim and the backend's claim are the same object's
+    # value, not two independently-written Trues that happen to match.
+    assert (
+        metadata["foundation_only"]
+        == started["backend_identity"]["foundation_only"]
+        == metadata["backend_identity"]["foundation_only"]
+    )
+    verify_agentic_v2_result(result)
+
+
+def test_runtime_fingerprint_is_taken_over_the_identity_that_was_recorded(
+    tmp_path,
+):
+    result = _successful_run(tmp_path)
+    metadata = result["agentic_v2"]
+    runtime = metadata["private_audit"]["events"][0]["payload"]["runtime"]
+
+    recomputed = runtime_fingerprint(
+        policy_profile_id=metadata["policy_profile_id"],
+        substrate_manifest_sha256=runtime["substrate_manifest_sha256"],
+        package_snapshot_sha256=runtime["package_snapshot_sha256"],
+        browser_build_sha256=runtime["browser_build_sha256"],
+        # The recorded identity's own digest. If the runner ever fingerprints
+        # a run with the digest it *expected* while recording an identity
+        # carrying a different one, this is the assertion that says so.
+        backend_implementation_sha256=metadata["backend_identity"][
+            "implementation_sha256"
+        ],
+        capabilities_sha256=metadata["capabilities_sha256"],
+        budget_caps=runtime["budget_caps"],
+    )
+
+    assert metadata["runtime_fingerprint"] == recomputed
+
+
+class _ClaimsItIsNotFoundationOnly(AgenticV2FixtureBackend):
+    """The fixture, reporting one field differently, and nothing else.
+
+    A backend that lied about its whole identity would be caught by the
+    implementation digest, which is computed over the foundation's source and
+    cannot be produced by anything that is not it. This one does not lie about
+    that: its digest is correct, its backend id is correct, and the single
+    field it changes is the one the runner used to supply from a constant. It
+    exists to show that the guard reads all three fields rather than the two
+    that are hashes.
+    """
+
+    def start(self, timeout_seconds: float):
+        startup = dict(super().start(timeout_seconds))
+        data = dict(startup["data"])
+        identity = dict(data["backend_identity"])
+        identity["foundation_only"] = False
+        data["backend_identity"] = identity
+        startup["data"] = data
+        return startup
+
+
+def test_an_identity_differing_only_in_foundation_only_is_refused(tmp_path):
+    result = _successful_run(tmp_path, _ClaimsItIsNotFoundationOnly)
+
+    assert result["success"] is False
+    assert result["error"] == "compute_start_failed"
+    verify_agentic_v2_failure_result(result)
+
+
+def test_the_admitted_set_holds_exactly_one_identity_and_names_the_fixture():
+    """The seam, asserted as a set of one.
+
+    There is a second backend in this repository -- the microVM one, which
+    boots a real guest -- and admitting it is a change somebody will want to
+    make. This asserts the shape that makes such a change legible: a named
+    tuple of complete identities, so an addition appears in a diff as a new
+    entry rather than as a comparison that quietly got weaker.
+
+    It is deliberately not a test that the microVM backend is *excluded by
+    name*. Excluding one thing by name would pass while admitting anything
+    else; requiring the set to be exactly one entry, and that entry to be the
+    foundation's, does not.
+    """
+    source = inspect.getsource(agentic_v2_runner)
+    start = source.index("admitted_identities = (")
+    body = source[start:source.index("if identity not in admitted_identities:")]
+
+    assert body.count('"backend_id":') == 1
+    assert "FOUNDATION_BACKEND_ID" in body
+    assert "agentic-v2-microvm-v1" not in source

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
@@ -2042,6 +2042,54 @@ workflow, five ARM control-plane reads, creating nothing and requesting
 nothing. Its answer decides whether stage D needs an access change at all. If
 it does, the exact change gets **named and reported**, not performed.
 
+##### It was asked, and the answer is permissions
+
+Run `34549220652` on `8cce9ab`, 2026-09-11T01:05:16Z, twenty-seven seconds,
+`success`. All five reads completed, so this is a block that was **observed**
+rather than one inferred from a read that failed — the distinction the survey's
+own first test exists to protect. Transcribed to
+`tasks/0822_saturday/boot_host_survey.json`, since the job log will age out and
+the block will not.
+
+| read | answer |
+|---|---|
+| session | the expected subscription, `Enabled` |
+| provider | `Microsoft.Compute` **registered** |
+| existing hosts | **0** |
+| quota | `standardDASv5Family`, **100 free vCPUs** of 100, 0 in use |
+| permissions | **2 assignments**, and **none** of the three writes permitted |
+
+Verdict `blocked_and_the_change_is_named`.
+
+**Four of the five came back favourable.** It is the right subscription, the
+provider is registered, and eastus2 has room for an 8-vCPU host more than ten
+times over. Exactly one thing is missing: the run identity holds two role
+assignments, and neither grants `Microsoft.Compute/virtualMachines/write`,
+`Microsoft.Network/networkInterfaces/write`, or
+`Microsoft.Resources/subscriptions/resourceGroups/write`.
+
+That narrowness is the useful part. A quota increase would not help, a region
+change would not help, and registering the provider would not help, because
+none of those is what is stopping it — and each would have been a plausible
+thing to go and ask for. The survey's value was in ruling them out, not in
+finding the block.
+
+So the named change is a role assignment on this identity in the model's
+subscription, and per the standing instruction that access expansion is
+separate from cost approval, it is **named here and left undone**. It is not
+requested, and nothing in this repository moves toward it.
+
+Two things it is not. It is not a claim that a host placed here would boot a
+guest — that is C2's question, answered on a different machine in a different
+subscription, and it would have to be answered again. And it is not a reason to
+fall back to Docker, V1 or a host subprocess, which would answer a question
+nobody asked.
+
+What it does not block is the code. The second verification standard the
+microVM backend needs, and the stage E ledger and retry wiring, need no host and
+no access change, so they are where the work continues while this sits with
+whoever owns the subscription.
+
 ### Stage E — not yet run
 
 Before any of it is written, what the repository already has. Two searches this

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
@@ -1970,6 +1970,78 @@ box** — the local `az` tenant is not the one that bills these workflows — so
 window is recorded as `partial` and **not** as zero. **Zero model calls were
 made in this window; the only spend is the host.**
 
+##### The guard, measured: it is eight places, not one
+
+Earlier notes in this document, and the project card, described the remaining
+code gate as one comparison — `core/agentic_v2_runner.py`, the startup check
+that a backend's identity is exactly the foundation fixture's. That was
+counted, and it is wrong. The foundation identity is pinned in **eight**
+places across two modules:
+
+| module | what it pins |
+|---|---|
+| `agentic_v2_runner.py` ×4 | the worker's profile, the startup guard, and two constants in the success envelope |
+| `agentic_v2_provenance.py` ×6 | `foundation_fixture_identity`, and five callers that reconstruct a whole expected startup payload from it |
+
+That is not sprawl to be tidied up. It is the property that no single edit can
+turn a fixture run into a claimed real one, and it should stay that way.
+
+**What it means for the shape of the change.** The provenance module does not
+merely compare an identity. `foundation_fixture_identity()` *manufactures* the
+startup payload a run must match — capabilities `["fixture-upper"]`, runtimes
+`["fixture"]`, a fixed package record set, a fixed browser-build digest — and
+`_verify_fixture_result_semantics()` goes further and **re-simulates every
+executed tool call** against the fixture's known behaviour, comparing the
+result envelope and the state digest either side of it.
+
+A command run in a real guest cannot be re-simulated. Its output is not a
+function of anything the verifier holds. So admitting a second identity is not
+a matter of loosening a comparison: it requires a **second verification
+standard** — structure, digests, chain integrity, budget accounting and state
+continuity, but not output equality — and that standard has to be recorded in
+the run, by name, so a reader can tell which one was applied. Admitting the
+identity without that would produce runs this code calls verified while
+checking strictly less than the word implies. That is the failure this whole
+stage is arranged to avoid, and it is why the gate is still shut.
+
+**What was done now, and why only this.** Two constants in the success
+envelope were replaced by the values the backend reported:
+
+- the runtime fingerprint's implementation digest, which read the digest the
+  guard compared *against* rather than the one the backend *reported*
+- `foundation_only`, which was the literal `True` two lines above a
+  `backend_identity` carrying its own `foundation_only`, read from a substrate
+  manifest, with nothing making the two agree
+
+Both were right today, by consequence: there is one admitted backend, so the
+readings cannot differ. Doing it while they cannot differ is the point — the
+moment a second identity is admitted, a constant there would describe the
+wrong run, silently, in the field a reader would use to tell the runs apart.
+
+The startup guard's inline dict also became a named tuple of complete
+identities, `admitted_identities`, holding exactly one entry. Nothing is
+admitted that was not admitted before. What the shape buys is that admitting
+something later is an addition to a named list rather than a comparison that
+got weaker, so it appears in a diff as what it is. A test asserts the set has
+exactly one entry and that it is the foundation's — not that the microVM
+backend is excluded *by name*, which would pass while admitting anything else.
+
+**What is still shut, deliberately:** the admitted set has one member, the
+second verification standard is not written, and `exec_run` on a real guest
+reaches nothing through this path. None of that changed here.
+
+##### And the other half of it is not code
+
+Even with the gate open, there is nowhere to run: the GPT deployment and the
+machine that boots a guest are in different subscriptions in different
+tenants, and the runner-as-host route is closed on support status rather than
+hardware. Whether a host could go in the model's own subscription under
+permissions that already exist is a question that can be asked for free and
+read-only — `batch-runner/scripts/azure_boot_host_survey.py`, run from its own
+workflow, five ARM control-plane reads, creating nothing and requesting
+nothing. Its answer decides whether stage D needs an access change at all. If
+it does, the exact change gets **named and reported**, not performed.
+
 ### Stage E — not yet run
 
 Before any of it is written, what the repository already has. Two searches this

--- a/tasks/0822_saturday/boot_host_survey.json
+++ b/tasks/0822_saturday/boot_host_survey.json
@@ -1,0 +1,69 @@
+{
+  "what_this_is": "The answer to the question stage D was stuck on: could a Firecracker host go in the subscription the GPT deployment already lives in, under permissions that already exist. Five ARM control-plane reads, no writes, no model call, no cost. Transcribed from the public job log of the run named below; the survey withholds the subscription id and machine names by design, so neither appears here either.",
+  "run": {
+    "workflow": ".github/workflows/azure-boot-host-survey.yml",
+    "run_id": "34549220652",
+    "head_sha": "8cce9abbf0d9397cee52680f1a97d7e46c317868",
+    "started_at": "2026-09-11T01:05:16Z",
+    "finished_at": "2026-09-11T01:05:43Z",
+    "conclusion": "success",
+    "asked_about": {
+      "location": "eastus2",
+      "host_size": "Standard_D8as_v5",
+      "sized_from": "infra/dev-host/main.bicep"
+    }
+  },
+  "verdict": "blocked_and_the_change_is_named",
+  "because": "a host could not be created here under the permissions and capacity that exist today",
+  "all_five_reads_completed": true,
+  "why_that_matters": "The survey's first rule is that an unmeasured read must never become an absence. Every finding below is measured: true, so this is a block that was observed, not a block inferred from a read that failed.",
+  "findings": {
+    "session": {
+      "measured": true,
+      "is_the_expected_subscription": true,
+      "state": "Enabled",
+      "subscription_id_was_read": true,
+      "note": "the id is deliberately not reported; only whether it is the one the model credential names"
+    },
+    "provider": {
+      "measured": true,
+      "registered": true,
+      "registration_state": "Registered"
+    },
+    "existing_hosts": {
+      "measured": true,
+      "count": 0,
+      "note": "names withheld; the count is what the verdict turns on"
+    },
+    "quota": {
+      "measured": true,
+      "family": "standardDASv5Family",
+      "limit_vcpus": 100,
+      "in_use_vcpus": 0,
+      "free_vcpus": 100,
+      "enough_for_one_host": true
+    },
+    "permissions": {
+      "measured": true,
+      "assignments_held": 2,
+      "permits": {
+        "Microsoft.Compute/virtualMachines/write": false,
+        "Microsoft.Network/networkInterfaces/write": false,
+        "Microsoft.Resources/subscriptions/resourceGroups/write": false
+      },
+      "permits_all_three": false
+    }
+  },
+  "the_shape_of_the_block": "Permissions only. Four of the five reads came back favourable -- it is the right subscription, Microsoft.Compute is registered, and eastus2 has 100 free vCPUs against an 8-vCPU host, which is room for one many times over. The single thing missing is that the run identity holds two role assignments and neither grants any of the three writes a host needs. No quota increase, no provider registration and no region change would help, because none of those is what is stopping it.",
+  "what_would_have_to_change": [
+    "this identity's roles do not permit: Microsoft.Compute/virtualMachines/write, Microsoft.Network/networkInterfaces/write, Microsoft.Resources/subscriptions/resourceGroups/write"
+  ],
+  "and_note": "this is a report, not a request. Each item above is an access change and belongs to whoever owns the subscription, so it is named here and left undone.",
+  "what_this_is_not": [
+    "not a request for a role assignment, and not a step toward one",
+    "not a claim that a host in this subscription would boot a guest -- that is C2's question, already answered on a different machine in a different subscription, and it would have to be answered again here",
+    "not a reason to fall back to Docker, V1, or a host subprocess",
+    "not a reason to re-open the GitHub-runner-as-host route, which is closed on documented support status rather than on hardware"
+  ],
+  "what_is_unblocked_regardless": "Everything on the code side. The second verification standard the microVM backend needs (D4/D5) and the stage E ledger and retry wiring require no access change and no host, so they continue while this sits with the owner."
+}


### PR DESCRIPTION
Two things, both about the same question — what would it actually take to run the 220 tasks in a real guest — and neither of which opens anything.

## The bug: the run record describes a backend that may not be the one that ran

`agentic_v2_runner.py` checked the backend's reported identity against the expected one, and then, having checked it, **threw the identity away** and wrote constants into the success envelope instead: `backend_implementation_sha256=expected_implementation_sha` and `"foundation_only": True`.

Today those constants are correct, because the guard has just established that the identity equals the expected one. That is precisely why this is the right moment to fix it — the change is provably behaviour-preserving now, and stops being so the day a second backend is admitted. A run record that asserts `foundation_only: True` regardless of what the backend said is a record that would describe a real-guest run as a fixture run, and it would do it silently.

So both lines now read from the identity that was actually checked. Four tests cover it, including one that subclasses the fixture backend to flip **only** `foundation_only` and asserts the run is refused (`compute_start_failed`) rather than recorded with the wrong flag.

## The guard is eight places, not one

An earlier note in the task document said the gate was one line. It is not. Measured:

| module | pins |
|---|---|
| `agentic_v2_runner.py` | 4 — worker profile, startup guard, two success-envelope constants, failure literal |
| `agentic_v2_provenance.py` | 6 — `foundation_fixture_identity()` and five call sites |

That is a design, not an oversight. And the harder half is not the count: `_verify_fixture_result_semantics()` **re-simulates every executed tool call** against the fixture's known behaviour. A command run in a real guest cannot be re-simulated. Admitting a second identity without answering that would produce runs this code calls *verified* while checking strictly less than the word implies.

The startup guard is therefore reshaped into an **admitted set written as a set of one**, with a comment naming the microVM backend and saying explicitly that this change does not put it there. The point is that admitting it later becomes an edit to a named list — visible in a diff as what it is — rather than a loosened comparison. A test asserts the set holds exactly one entry and that `agentic-v2-microvm-v1` appears nowhere in the module.

**No gate is opened.** `foundation_only`, `production_activation` and the `exec_run` block are all exactly as they were.

## And the survey answered: the block is permissions

Run [`34549220652`](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/34549220652) on `8cce9ab`. All five ARM reads completed, so this is a block that was **observed**, not inferred from a read that failed.

| read | answer |
|---|---|
| session | the expected subscription, `Enabled` |
| provider | `Microsoft.Compute` **registered** |
| existing hosts | **0** |
| quota | **100 free vCPUs** of 100, 0 in use |
| permissions | **2 assignments**, **none** of the three writes permitted |

Four of five favourable. A quota increase, a region change and a provider registration were each a plausible thing to go and ask for, and the survey rules all three out. What remains is a role assignment on the run identity permitting `virtualMachines/write`, `networkInterfaces/write` and `resourceGroups/write` — an access change, so it is **named and left undone**, per the standing rule that access expansion is separate from cost approval.

Transcribed to `tasks/0822_saturday/boot_host_survey.json`; the log ages out, the block does not. Subscription id and machine names withheld, as the survey withholds them.

## Verification

- Full backend suite: **10,233 passed, 18 skipped, 46 deselected**, exit 0
- Agentic V2 foundation suite: 134 → **138 passed**
- mypy: **31 errors before and after** — identical baseline, confirmed by type-checking `origin/main`'s copy of the same module
- No model call, no Azure spend. The dev host has been deallocated since 2026-09-10T23:29:55Z.