### PR TITLE
fix(relay): 이어달리기 다리를 첫 다리의 파이프라인에 고정

### DIFF
--- a/.github/workflows/batch-run.yml
+++ b/.github/workflows/batch-run.yml
@@ -98,7 +98,32 @@ jobs:
             [[ -z "$SANDBOX_IMAGE_DIGEST" ]]
           else
             [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
-            [[ "$SOURCE_SHA" == "$EVENT_SHA" ]]
+            # What used to stand here was `SOURCE_SHA == EVENT_SHA`, and it is
+            # gone on purpose. The two are only equal while nothing has landed
+            # on main since the first leg started, and `gh workflow run
+            # --ref main` resolves main afresh at every handover, so a single
+            # unrelated commit -- a README line -- ended the run. That is not
+            # theoretical: run 34540053904 started at a21eec3 and main had
+            # moved twice before its first leg was over.
+            #
+            # The assertion was protecting something real, which is that a
+            # relay leg must run the same pipeline as the leg it is continuing.
+            # Commit identity was a proxy for that, and a coarse one: it fails
+            # on every commit, including the ones that change nothing this run
+            # can reach. The guarantee now comes from `Pin pipeline source to
+            # the first leg` in the batch-run job, which checks out this exact
+            # `SOURCE_SHA`'s `batch-runner/` tree instead of main's. That is
+            # stronger than what commit equality bought -- equality let the leg
+            # run main's newer code as long as nobody had pushed yet, which was
+            # luck rather than a guarantee.
+            #
+            # Two things the pin cannot cover are checked in `Verify relay
+            # source lineage` below, immediately after the checkout that gives
+            # it a git history to read: that `SOURCE_SHA` is an ancestor of
+            # this event (so a leg cannot be pointed at a commit that was never
+            # on main), and that the workflow file itself has not changed
+            # between them (GitHub runs the dispatch ref's copy of this file,
+            # so it is the one thing a checkout cannot pin).
             [[ "$RELAY_LINEAGE_ID" =~ ^[A-Za-z0-9._:-]{1,256}$ ]]
             if [[ -n "$SANDBOX_IMAGE_DIGEST" ]]; then
               [[ "$SANDBOX_IMAGE_DIGEST" =~ ^ghcr\.io/hyeonsangjeon/gdpval-sandbox@sha256:[0-9a-f]{64}$ ]]
@@ -109,11 +134,57 @@ jobs:
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
+          # A relay leg needs history: the two things checked below are both
+          # comparisons against a commit that is no longer the tip.
+          #
+          # Unconditional rather than conditional on `relay_run`, because the
+          # obvious conditional is wrong in a way that is hard to see.
+          # `${{ inputs.relay_run > 0 && 0 || 1 }}` always renders 1: Actions'
+          # `a && b || c` returns `c` whenever `b` is falsy, and 0 is falsy. A
+          # relay leg would then get the shallow clone, fail `merge-base
+          # --is-ancestor`, and die -- safely, but hours into a paid run. The
+          # whole history is a few seconds against a leg that runs for hours.
+          fetch-depth: 0
 
       - name: Verify exact config checkout
         run: |
           set -euo pipefail
           [[ "$(git rev-parse HEAD)" == "$GITHUB_SHA" ]]
+
+      - name: Verify relay source lineage
+        if: inputs.relay_run > 0
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          set -euo pipefail
+          # An ancestor, not merely a commit that exists. The checkpoint is
+          # addressed by `sha256(source_sha, lineage_id)`, so a caller who
+          # could name any commit could also name one that was never reviewed
+          # onto main and have the leg run it. `main` only moves forward here
+          # -- no force-push, no rewritten history -- so leg zero's sha is an
+          # ancestor of every later tip, and anything that is not is either a
+          # mistake or somebody else's branch.
+          git merge-base --is-ancestor "$SOURCE_SHA" "$GITHUB_SHA"
+          # The one file the pin below cannot reach. GitHub runs the copy of
+          # this workflow that lives at the dispatch ref, and the dispatch ref
+          # has to be main -- checked above, and not something to relax. So if
+          # this file changed between the first leg and now, the leg would be
+          # orchestrated by steps the first leg never ran, and no amount of
+          # checking out `batch-runner/` fixes that. Blob ids rather than
+          # hashing the bytes: git has already hashed them.
+          source_workflow="$(git rev-parse "$SOURCE_SHA:.github/workflows/batch-run.yml")"
+          event_workflow="$(git rev-parse "$GITHUB_SHA:.github/workflows/batch-run.yml")"
+          if [[ "$source_workflow" != "$event_workflow" ]]; then
+            echo "::error::batch-run.yml changed since the first leg" \
+                 "($SOURCE_SHA -> $GITHUB_SHA). A relay leg runs main's copy of" \
+                 "this file, so it cannot be pinned; the run stops here rather" \
+                 "than continue under different orchestration. The completed" \
+                 "work is in the checkpoint. Revert the workflow change, or" \
+                 "start the experiment again."
+            exit 1
+          fi
+          echo "Relay source $SOURCE_SHA is an ancestor of $GITHUB_SHA" \
+               "and batch-run.yml is unchanged between them."
 
       - name: Inspect execution mode without credentials
         id: mode
@@ -256,11 +327,53 @@ jobs:
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
+          # History, so the pin below has a `SOURCE_SHA` to read. Unconditional
+          # for the reason spelled out on the inspect-mode checkout: the
+          # conditional form of this line is silently always-shallow.
+          fetch-depth: 0
 
       - name: Verify exact checkout
         run: |
           set -euo pipefail
           [[ "$(git rev-parse HEAD)" == "$GITHUB_SHA" ]]
+
+      - name: Pin pipeline source to the first leg
+        if: inputs.relay_run > 0
+        run: |
+          set -euo pipefail
+          # HEAD stays on main's tip -- the step above has already asserted
+          # that, and the result pull request created at the end of the final
+          # leg is branched from it. Only the *contents* of `batch-runner/` are
+          # rolled back, to exactly what the first leg ran.
+          #
+          # Why this is not paranoia about other people's merges: the relay
+          # hands a half-finished run from one runner to the next. Before this
+          # step the next leg picked up main's current `batch-runner/`, so a
+          # merge landing mid-run silently changed the pipeline between task 40
+          # and task 41 of the same experiment, and the record would have said
+          # one experiment ran one way. Nothing announced it.
+          #
+          # Deleting the files added since matters as much as restoring the
+          # ones that changed. `git checkout <sha> -- <path>` writes and
+          # overwrites but never removes, so without this a module that did not
+          # exist in the first leg would still be importable in the next one.
+          added="$(git diff --name-only --diff-filter=A \
+                     "$SOURCE_SHA_INPUT" "$GITHUB_SHA" -- batch-runner)"
+          if [[ -n "$added" ]]; then
+            while IFS= read -r path; do
+              rm -f -- "$path"
+            done <<< "$added"
+          fi
+          git checkout "$SOURCE_SHA_INPUT" -- batch-runner
+          # Unstage. `git checkout <sha> -- <path>` stages what it wrote, and
+          # create-pull-request commits the index it finds. Leaving these
+          # staged would put a rollback of everyone else's `batch-runner/`
+          # work into the results pull request. The working tree keeps the
+          # first leg's files; the index goes back to matching HEAD.
+          git reset -q HEAD -- batch-runner
+          changed="$(git diff --name-only -- batch-runner | wc -l)"
+          echo "Pinned batch-runner/ to $SOURCE_SHA_INPUT:" \
+               "$changed file(s) differ from $GITHUB_SHA."
 
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/batch-runner/tests/test_a_relay_leg_runs_the_source_it_started_with.py
+++ b/batch-runner/tests/test_a_relay_leg_runs_the_source_it_started_with.py
@@ -1,0 +1,422 @@
+"""A relay leg runs the pipeline its first leg ran, and says so or stops.
+
+The relay hands a half-finished experiment from one runner to the next. Until
+now the only thing keeping the legs on the same code was the dispatch
+contract's `SOURCE_SHA == EVENT_SHA`, and that is a proxy for the wrong thing
+in both directions.
+
+It is too strict, and measurably so. The retrigger is `gh workflow run
+batch-run.yml --ref main`, which resolves main again at every handover, so one
+unrelated commit ends the run. Run `34540053904` started at `a21eec3` and main
+had moved twice before its first leg finished; the eleven `batch-runner/` files
+that changed in between were a probe, an analysis script and their tests, none
+of them on the execution path that run was using. Its second leg would have
+died at a `[[ ]]` for that.
+
+It is also too loose. When it passed, it passed because nobody had pushed yet
+-- and the leg then checked out main's tip, so the guarantee was luck. A commit
+landing one second after the dispatch was resolved would have been picked up
+silently, changing the pipeline between task 40 and task 41 of one experiment
+with nothing in the record to say so.
+
+What replaces it is the thing the proxy stood for: the leg checks out the first
+leg's `batch-runner/` tree. Two residues cannot be covered that way and are
+checked instead -- that `SOURCE_SHA` is an ancestor of this event, and that
+`batch-run.yml` itself has not changed, since Actions runs the dispatch ref's
+copy of the workflow and a checkout cannot reach it.
+
+These tests run the steps rather than reading them. A guard that is present but
+inverted, or shadowed by an earlier `exit`, passes any assertion made against
+the text of a `run:` block. For the two git-reading steps that means building a
+real repository in `tmp_path` and handing the step two real commits, which is
+also the only way to find out whether the commands do what their names suggest
+-- `git checkout <sha> -- <path>` writes and overwrites but never deletes, and
+that asymmetry is a test below rather than a comment.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+BATCH_WORKFLOW = ROOT / ".github" / "workflows" / "batch-run.yml"
+WORKFLOW_PATH_IN_REPO = ".github/workflows/batch-run.yml"
+
+
+def _document() -> dict:
+    return yaml.safe_load(BATCH_WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _step(job: str, name: str) -> dict:
+    steps = _document()["jobs"][job]["steps"]
+    return next(item for item in steps if item.get("name") == name)
+
+
+def _run_step(
+    job: str, name: str, *, cwd: Path, env: dict[str, str]
+) -> subprocess.CompletedProcess:
+    """Execute a step's `run:` block as bash, with exactly `env` in scope."""
+    script = cwd / f"_{name.replace(' ', '_')}.sh"
+    script.write_text(_step(job, name)["run"], encoding="utf-8")
+    return subprocess.run(
+        ["bash", str(script)],
+        cwd=cwd,
+        env={"PATH": "/usr/bin:/bin:/usr/local/bin", "HOME": str(cwd), **env},
+        capture_output=True,
+        text=True,
+    )
+
+
+# --- the dispatch contract, which no longer pins the commit -----------------
+
+
+CONTRACT_BASE = {
+    "EVENT_NAME": "workflow_dispatch",
+    "EVENT_REF": "refs/heads/main",
+    "EVENT_SHA": "a" * 40,
+    "WORKFLOW_SHA": "a" * 40,
+    "WALL_TIMEOUT": "290",
+    "RELAY_RUN": "1",
+    "RELAY_LINEAGE_ID": "exp035:1:1",
+    "SOURCE_SHA": "a" * 40,
+    "SANDBOX_IMAGE_DIGEST": "",
+}
+
+
+def _contract(tmp_path: Path, **overrides: str) -> subprocess.CompletedProcess:
+    return _run_step(
+        "inspect-mode",
+        "Verify dispatch contract",
+        cwd=tmp_path,
+        env={**CONTRACT_BASE, **overrides},
+    )
+
+
+def test_a_relay_leg_is_no_longer_refused_because_main_moved(tmp_path):
+    """The change itself, stated as the case that used to fail.
+
+    Measured against the unmodified workflow this combination exited 1, which
+    is why run 34540053904 could not have relayed.
+    """
+    result = _contract(tmp_path, EVENT_SHA="b" * 40, WORKFLOW_SHA="b" * 40)
+    assert result.returncode == 0, result.stderr
+
+
+def test_the_first_leg_still_may_not_name_a_source(tmp_path):
+    """Leg zero has nothing to continue, so a forwarded sha there is a bug."""
+    result = _contract(
+        tmp_path, RELAY_RUN="0", RELAY_LINEAGE_ID="", SOURCE_SHA="a" * 40
+    )
+    assert result.returncode != 0
+
+
+@pytest.mark.parametrize("value", ["", "main", "A" * 40, "a" * 39, "a" * 41])
+def test_a_relay_leg_still_needs_a_real_sha(tmp_path, value):
+    """The sha is the checkpoint's address, not a label.
+
+    `_lineage_root` hashes it to find the run's files on the hub, so a
+    malformed one does not degrade to a slow path -- it addresses nothing.
+    """
+    result = _contract(tmp_path, SOURCE_SHA=value)
+    assert result.returncode != 0
+
+
+def test_the_dispatch_ref_is_still_main_only(tmp_path):
+    """Nothing here loosens where a credentialed run may be launched from.
+
+    Pinning by tag would have been the other way to solve this, and it would
+    have meant accepting `refs/tags/...` as a dispatch ref. That trade was not
+    made.
+    """
+    result = _contract(tmp_path, EVENT_REF="refs/tags/relay-34540053904")
+    assert result.returncode != 0
+
+
+# --- the lineage check, against real commits --------------------------------
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "HOME": str(cwd),
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@example.invalid",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@example.invalid",
+        },
+    ).stdout.strip()
+
+
+def _repo(tmp_path: Path) -> Path:
+    """A repository with a workflow file and one `batch-runner/` module."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    (repo / ".github" / "workflows" / "batch-run.yml").write_text(
+        "name: batch-run\n", encoding="utf-8"
+    )
+    (repo / "batch-runner").mkdir()
+    (repo / "batch-runner" / "runner.py").write_text("V = 1\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "first")
+    return repo
+
+
+def _commit(repo: Path, message: str) -> str:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _lineage(
+    repo: Path, *, source_sha: str, github_sha: str
+) -> subprocess.CompletedProcess:
+    return _run_step(
+        "inspect-mode",
+        "Verify relay source lineage",
+        cwd=repo,
+        env={"SOURCE_SHA": source_sha, "GITHUB_SHA": github_sha},
+    )
+
+
+def test_an_unrelated_commit_on_main_does_not_end_the_run(tmp_path):
+    """The live case: somebody merged something that is not this pipeline."""
+    repo = _repo(tmp_path)
+    source = _git(repo, "rev-parse", "HEAD")
+    (repo / "README.md").write_text("a line\n", encoding="utf-8")
+    event = _commit(repo, "docs")
+
+    result = _lineage(repo, source_sha=source, github_sha=event)
+    assert result.returncode == 0, result.stderr
+    assert "unchanged between them" in result.stdout
+
+
+def test_a_changed_batch_runner_does_not_end_the_run_either(tmp_path):
+    """Because the pin rolls it back rather than the lineage refusing it.
+
+    This is the eleven files of the live case. Refusing here would have left
+    the freeze exactly where it was, just with a longer explanation.
+    """
+    repo = _repo(tmp_path)
+    source = _git(repo, "rev-parse", "HEAD")
+    (repo / "batch-runner" / "runner.py").write_text("V = 2\n", encoding="utf-8")
+    event = _commit(repo, "someone else's module")
+
+    assert _lineage(repo, source_sha=source, github_sha=event).returncode == 0
+
+
+def test_a_commit_that_was_never_on_main_is_refused(tmp_path):
+    """A sibling branch is not a leg of this run.
+
+    The checkpoint is addressed by `sha256(source_sha, lineage_id)`, so a
+    caller free to name any commit could have a credentialed leg run code that
+    was never reviewed onto main.
+    """
+    repo = _repo(tmp_path)
+    base = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "checkout", "-q", "-b", "side")
+    (repo / "batch-runner" / "runner.py").write_text("V = 9\n", encoding="utf-8")
+    sibling = _commit(repo, "side")
+    _git(repo, "checkout", "-q", "main")
+    (repo / "README.md").write_text("main moved\n", encoding="utf-8")
+    event = _commit(repo, "main")
+
+    assert base != sibling
+    assert _lineage(repo, source_sha=sibling, github_sha=event).returncode != 0
+
+
+def test_a_changed_workflow_file_is_refused_and_named(tmp_path):
+    """The one file the pin cannot reach, so the run stops instead.
+
+    Actions runs the dispatch ref's copy of this workflow, and the dispatch ref
+    has to be main. A leg orchestrated by steps the first leg never ran is a
+    different experiment, and no checkout of `batch-runner/` changes that.
+    """
+    repo = _repo(tmp_path)
+    source = _git(repo, "rev-parse", "HEAD")
+    (repo / WORKFLOW_PATH_IN_REPO).write_text(
+        "name: batch-run\n# and a new step\n", encoding="utf-8"
+    )
+    event = _commit(repo, "workflow")
+
+    result = _lineage(repo, source_sha=source, github_sha=event)
+    assert result.returncode != 0
+    assert "batch-run.yml changed since the first leg" in result.stdout + result.stderr
+    # The reader is told the work is not lost, because the reflex on seeing a
+    # relay leg fail is to start the experiment again from zero.
+    assert "checkpoint" in result.stdout + result.stderr
+
+
+def test_the_same_commit_twice_is_still_the_ordinary_case(tmp_path):
+    """Nothing landed between the legs. A commit is its own ancestor."""
+    repo = _repo(tmp_path)
+    sha = _git(repo, "rev-parse", "HEAD")
+    assert _lineage(repo, source_sha=sha, github_sha=sha).returncode == 0
+
+
+# --- the pin, against real commits ------------------------------------------
+
+
+def _pin(repo: Path, *, source_sha: str, github_sha: str):
+    return _run_step(
+        "batch-run",
+        "Pin pipeline source to the first leg",
+        cwd=repo,
+        env={"SOURCE_SHA_INPUT": source_sha, "GITHUB_SHA": github_sha},
+    )
+
+
+def test_a_module_that_changed_is_rolled_back_to_the_first_leg(tmp_path):
+    repo = _repo(tmp_path)
+    source = _git(repo, "rev-parse", "HEAD")
+    (repo / "batch-runner" / "runner.py").write_text("V = 2\n", encoding="utf-8")
+    event = _commit(repo, "changed")
+
+    result = _pin(repo, source_sha=source, github_sha=event)
+    assert result.returncode == 0, result.stderr
+    assert (repo / "batch-runner" / "runner.py").read_text(encoding="utf-8") == "V = 1\n"
+
+
+def test_a_module_added_since_is_removed_rather_than_left_importable(tmp_path):
+    """`git checkout <sha> -- <path>` writes and overwrites but never deletes.
+
+    Without the removal the next leg would carry a module the first leg never
+    had. Nothing would import it today, which is exactly why the omission would
+    have gone unnoticed until something did.
+    """
+    repo = _repo(tmp_path)
+    source = _git(repo, "rev-parse", "HEAD")
+    (repo / "batch-runner" / "newcomer.py").write_text("V = 3\n", encoding="utf-8")
+    event = _commit(repo, "added")
+
+    assert _pin(repo, source_sha=source, github_sha=event).returncode == 0
+    assert not (repo / "batch-runner" / "newcomer.py").exists()
+
+
+def test_a_file_outside_batch_runner_is_left_alone(tmp_path):
+    """The pin is about the pipeline, not about undoing the repository.
+
+    HEAD is main's tip and the results pull request is branched from it, so
+    rolling back the tree wholesale would be a rollback of everyone else's work
+    wearing an experiment's title.
+    """
+    repo = _repo(tmp_path)
+    source = _git(repo, "rev-parse", "HEAD")
+    (repo / "README.md").write_text("newer\n", encoding="utf-8")
+    event = _commit(repo, "docs")
+
+    assert _pin(repo, source_sha=source, github_sha=event).returncode == 0
+    assert (repo / "README.md").read_text(encoding="utf-8") == "newer\n"
+    assert _git(repo, "rev-parse", "HEAD") == event
+
+
+def test_the_rollback_is_not_staged_for_the_results_pull_request(tmp_path):
+    """create-pull-request commits the index it finds.
+
+    `git checkout <sha> -- <path>` stages what it writes. Left staged, the
+    results pull request -- which is supposed to carry one report file --
+    would also carry a revert of every `batch-runner/` change merged during the
+    run. The step unstages, so the working tree keeps the first leg's files
+    while the index still matches HEAD.
+    """
+    repo = _repo(tmp_path)
+    source = _git(repo, "rev-parse", "HEAD")
+    (repo / "batch-runner" / "runner.py").write_text("V = 2\n", encoding="utf-8")
+    (repo / "batch-runner" / "newcomer.py").write_text("V = 3\n", encoding="utf-8")
+    event = _commit(repo, "changed and added")
+
+    assert _pin(repo, source_sha=source, github_sha=event).returncode == 0
+    assert _git(repo, "diff", "--cached", "--name-only") == ""
+    # ...and the working tree really is the first leg's, so the unstaging did
+    # not also undo the pin.
+    assert (repo / "batch-runner" / "runner.py").read_text(encoding="utf-8") == "V = 1\n"
+
+
+def test_nothing_having_changed_is_not_an_error(tmp_path):
+    """The common case once a freeze is actually held."""
+    repo = _repo(tmp_path)
+    sha = _git(repo, "rev-parse", "HEAD")
+    result = _pin(repo, source_sha=sha, github_sha=sha)
+    assert result.returncode == 0, result.stderr
+    assert "0 file(s) differ" in result.stdout
+
+
+# --- the wiring the two steps depend on -------------------------------------
+
+
+@pytest.mark.parametrize(
+    "job,step",
+    [
+        ("inspect-mode", "Checkout config only"),
+        ("batch-run", "Checkout"),
+    ],
+)
+def test_both_checkouts_fetch_the_whole_history(job, step):
+    """`fetch-depth: 0`, written out, and not as a conditional.
+
+    The conditional anybody would reach for is wrong in a way that reads as
+    correct: `${{ inputs.relay_run > 0 && 0 || 1 }}` always renders 1, because
+    Actions' `a && b || c` yields `c` whenever `b` is falsy and 0 is falsy. A
+    relay leg would get the shallow clone, fail `merge-base --is-ancestor`, and
+    stop -- safely, but hours into a paid run. This asserts the literal.
+    """
+    with_block = _step(job, step)["with"]
+    assert with_block["fetch-depth"] == 0
+    assert with_block["persist-credentials"] is False
+
+
+@pytest.mark.parametrize(
+    "job,step",
+    [
+        ("inspect-mode", "Verify relay source lineage"),
+        ("batch-run", "Pin pipeline source to the first leg"),
+    ],
+)
+def test_neither_new_step_touches_the_first_leg(job, step):
+    """Leg zero has no source to pin and no ancestry to check.
+
+    Both steps would fail on an empty `SOURCE_SHA`, which is the right
+    behaviour for a relay leg and the wrong behaviour for every ordinary
+    dispatch in the repository.
+    """
+    assert _step(job, step)["if"] == "inputs.relay_run > 0"
+
+
+def test_the_pin_runs_before_anything_reads_the_pipeline():
+    """A pin applied after the first `cd batch-runner` would pin nothing.
+
+    Naming the steps rather than counting them, so inserting an unrelated step
+    does not fail this.
+    """
+    names = [s.get("name") for s in _document()["jobs"]["batch-run"]["steps"]]
+    pin = names.index("Pin pipeline source to the first leg")
+    assert pin < names.index("Setup Python")
+    assert pin < names.index("Validate experiment YAML exists")
+    assert pin < names.index("Step 2a: Run inference (condition_a)")
+    # And after the checkout it depends on, which is the only ordering that
+    # could be got backwards without the file looking wrong.
+    assert pin > names.index("Checkout")
+
+
+def test_the_retrigger_still_forwards_the_first_legs_sha():
+    """The pin reads `SOURCE_SHA_INPUT`, so the handover has to keep sending it.
+
+    It is also the checkpoint's address. If a later edit made each leg forward
+    its own `GITHUB_SHA` -- which would make the deleted equality assertion
+    true again, and is the obvious wrong fix -- the next leg would look for its
+    checkpoint under a key nothing had written.
+    """
+    retrigger = _step("batch-run", "Retrigger relay run")["run"]
+    assert '-f source_sha="$SOURCE_SHA"' in retrigger
+    assert 'SOURCE_SHA="$SOURCE_SHA_INPUT"' in retrigger

--- a/scripts/__tests__/onboarding-contract.test.mjs
+++ b/scripts/__tests__/onboarding-contract.test.mjs
@@ -344,6 +344,22 @@ test('workflow input tables mirror defaults and watchdog delegation', async () =
       SANDBOX_IMAGE_DIGEST: `ghcr.io/hyeonsangjeon/gdpval-sandbox@sha256:${'c'.repeat(64)}`,
     },
   })
+  // A relay leg whose source is no longer main's tip, which is the ordinary
+  // case rather than an attack: the retrigger is `gh workflow run --ref main`
+  // and it resolves main again at every handover, so any commit landing during
+  // a multi-hour run puts the leg here. This used to be asserted as a
+  // rejection. It is not one, and the guarantee it stood for -- that a leg runs
+  // the pipeline its first leg ran -- now comes from `Pin pipeline source to
+  // the first leg`, with the two residues a checkout cannot cover asserted in
+  // `Verify relay source lineage` below.
+  await execFileAsync('bash', ['-c', dispatchStep.run], {
+    env: {
+      ...validEnv,
+      RELAY_RUN: '1',
+      RELAY_LINEAGE_ID: 'experiment:run:attempt',
+      SOURCE_SHA: 'b'.repeat(40),
+    },
+  })
   for (const invalid of [
     { EVENT_NAME: 'push' },
     { EVENT_REF: 'refs/heads/feature' },
@@ -357,7 +373,14 @@ test('workflow input tables mirror defaults and watchdog delegation', async () =
     { RELAY_RUN: '-1' },
     { RELAY_RUN: '11' },
     { RELAY_RUN: '999999999999999999999999999999' },
-    { RELAY_RUN: '1', SOURCE_SHA: 'b'.repeat(40) },
+    // Not `SOURCE_SHA: 'b'.repeat(40)`, which is now accepted above. What is
+    // still refused is a sha that cannot address a checkpoint: `_lineage_root`
+    // hashes this value to find the run's uploaded work, so a malformed one
+    // does not degrade to a slow path, it points at nothing. The lineage id is
+    // spelled out on these two so they fail for the reason they are named
+    // after rather than incidentally on the empty one inherited from validEnv.
+    { RELAY_RUN: '1', SOURCE_SHA: 'Z'.repeat(40), RELAY_LINEAGE_ID: 'lineage' },
+    { RELAY_RUN: '1', SOURCE_SHA: 'b'.repeat(39), RELAY_LINEAGE_ID: 'lineage' },
     { RELAY_RUN: '1', SOURCE_SHA: '' },
     { RELAY_RUN: '0', SOURCE_SHA: sha },
     { RELAY_RUN: '0', RELAY_LINEAGE_ID: 'injected-lineage' },
@@ -378,10 +401,33 @@ test('workflow input tables mirror defaults and watchdog delegation', async () =
   assert.match(configCheckout.run, /"\$\(git rev-parse HEAD\)" == "\$GITHUB_SHA"/)
   const inspectSteps = workflow.jobs['inspect-mode'].steps
   assert.ok(inspectSteps.indexOf(dispatchStep) < inspectSteps.findIndex((step) => step.name === 'Checkout config only'))
+  // The two steps that took over from the deleted equality assertion. Ordering
+  // only here -- what they do is executed against real commits in
+  // batch-runner/tests/test_a_relay_leg_runs_the_source_it_started_with.py.
+  // Both read git history, so both have to come after a checkout that fetched
+  // some, and both are meaningless on a first leg.
+  const lineage = inspectSteps.find((step) => step.name === 'Verify relay source lineage')
+  assert.ok(lineage, 'missing workflow step: Verify relay source lineage')
+  assert.equal(lineage.if, 'inputs.relay_run > 0')
+  assert.ok(inspectSteps.indexOf(lineage) > inspectSteps.findIndex((step) => step.name === 'Checkout config only'))
   const exactCheckout = findStep(workflow, 'Verify exact checkout')
   assert.match(exactCheckout.run, /"\$\(git rev-parse HEAD\)" == "\$GITHUB_SHA"/)
   const batchSteps = workflow.jobs['batch-run'].steps
   assert.ok(batchSteps.indexOf(exactCheckout) < batchSteps.findIndex((step) => step.name === 'Setup Python'))
+  const pin = findStep(workflow, 'Pin pipeline source to the first leg')
+  assert.equal(pin.if, 'inputs.relay_run > 0')
+  assert.ok(batchSteps.indexOf(pin) < batchSteps.findIndex((step) => step.name === 'Setup Python'))
+  // `fetch-depth: 0` as a literal zero. The conditional form of this line,
+  // `${{ inputs.relay_run > 0 && 0 || 1 }}`, always renders 1 -- Actions'
+  // `a && b || c` yields `c` whenever `b` is falsy, and 0 is falsy -- which
+  // would give every relay leg a shallow clone and kill it at `merge-base
+  // --is-ancestor`, hours into a paid run.
+  for (const step of [
+    inspectSteps.find((candidate) => candidate.name === 'Checkout config only'),
+    findStep(workflow, 'Checkout'),
+  ]) {
+    assert.equal(step.with['fetch-depth'], 0)
+  }
   const relayStep = findStep(workflow, 'Retrigger relay run')
   assert.match(relayStep.run, /gh workflow run batch-run\.yml --ref main/)
   assert.match(relayStep.run, /-f source_sha="\$SOURCE_SHA"/)


### PR DESCRIPTION
## 문제

이어달리기(relay) 다리는 `gh workflow run batch-run.yml --ref main`으로 다음 다리를 부릅니다. `--ref main`은 넘겨줄 때마다 main을 **다시 해석**합니다. 그런데 발송 계약(`Verify dispatch contract`)에는 이런 줄이 있었습니다.

```bash
[[ "$SOURCE_SHA" == "$EVENT_SHA" ]]
```

두 값은 첫 다리가 시작한 뒤 main에 아무것도 올라오지 않은 동안에만 같습니다. 즉 **실행 중에 누가 무엇이든 병합하면 다음 다리가 죽습니다.** README 한 줄이라도 마찬가지입니다.

추측이 아니라 측정입니다. 이 단계의 `run:` 블록을 그대로 꺼내 합성 환경에서 실행했습니다.

| 상황 | 종료 코드 |
|---|---|
| 첫 다리 (relay_run=0) | 0 |
| 이어달리기 다리, main 그대로 | 0 |
| **이어달리기 다리, main 이동** | **1** |

지금 돌고 있는 exp034 실행 `34540053904`가 정확히 그 상태입니다. 첫 다리는 `a21eec3`에서 출발했고, 그 뒤로 다섯 개가 main에 올라왔습니다.

## 그 줄이 지키려던 것

버릴 수는 없는 보장이 하나 있습니다 — **이어받는 다리는 앞 다리가 돌린 것과 같은 파이프라인을 돌려야 한다.** 커밋 동일성은 그 보장의 대리물이었고, 두 방향 모두로 틀린 대리물입니다.

- **너무 엄격합니다.** 이 실행이 닿지도 않는 파일이 바뀌어도 실패합니다. 위 다섯 커밋 중 넷은 이 실행의 실행 경로에 없습니다.
- **너무 느슨합니다.** 통과했을 때 통과한 이유는 "아직 아무도 푸시하지 않아서"였고, 다리는 그다음 main의 tip을 checkout했습니다. 발송이 해석된 1초 뒤에 착륙한 커밋은 조용히 실려 들어옵니다. 같은 실험의 40번 과제와 41번 과제 사이에서 파이프라인이 바뀌고, 기록에는 한 실험이 한 방식으로 돌았다고 적힙니다.

실험 **입력**은 이미 내용으로 고정돼 있습니다. `_load_and_validate_progress`가 `prepared_fingerprint`와 `ordered_task_ids`를 비교하고 `progress checkpoint identity mismatch`로 멈춥니다. 커밋 동일성이 사던 것은 **코드** 동일성뿐이었습니다.

## 바뀐 것

대리물 대신 그 보장 자체를 만듭니다.

**`Pin pipeline source to the first leg`** (batch-run 잡, checkout 직후) — 이어달리기 다리에서 `batch-runner/` 트리를 첫 다리의 sha로 되돌립니다. HEAD는 main의 tip에 그대로 둡니다(결과 PR이 거기서 갈라져 나오므로). `batch-runner/` 밖은 건드리지 않습니다.

`git checkout <sha> -- <path>`는 쓰고 덮어쓰지만 **지우지는 않습니다.** 그래서 그 뒤에 추가된 파일은 따로 지웁니다 — 안 그러면 첫 다리에 없던 모듈이 다음 다리에서 import 가능한 상태로 남습니다. 그리고 `git reset -q HEAD -- batch-runner`로 인덱스를 되돌립니다. checkout이 쓴 내용은 스테이징되고 `create-pull-request`는 발견한 인덱스를 커밋하므로, 이게 없으면 결과 PR에 **실행 중 병합된 남의 `batch-runner/` 작업을 전부 되돌리는 diff**가 실려 갑니다.

checkout 앞에 두었으므로 `requirements.txt`도 첫 다리의 것이 설치됩니다.

**`Verify relay source lineage`** (inspect-mode 잡) — 고정이 덮을 수 없는 두 가지만 검사합니다.

1. `SOURCE_SHA`가 이 이벤트의 **조상**인가. 체크포인트 주소가 `sha256(source_sha, lineage_id)`이므로, 아무 커밋이나 지명할 수 있으면 main에 리뷰된 적 없는 코드를 자격증명 붙은 다리에서 돌릴 수 있습니다.
2. `batch-run.yml` **자신**이 바뀌지 않았는가. Actions는 발송 ref에 있는 이 파일의 사본을 실행하고 발송 ref는 main이어야 하므로, 이 파일만은 checkout으로 고정할 수 없습니다.

두 checkout 모두 `fetch-depth: 0`입니다. 조건부로 쓰고 싶어지는 `${{ inputs.relay_run > 0 && 0 || 1 }}`는 **항상 1로 렌더됩니다** — Actions의 `a && b || c`는 `b`가 falsy면 `c`를 주고 0은 falsy입니다. 이어달리기 다리가 얕은 clone을 받아 `merge-base --is-ancestor`에서, 유료 실행 몇 시간째에, 안전하게 죽습니다. 주석에 남겨 두었습니다.

## 이 실행(34540053904)에는 어떻게 적용되나

솔직하게: **이 실행은 새 규칙으로도 이어지지 않습니다.** 다섯 커밋 중 `e7dc4b0`(#514)이 `batch-run.yml`을 바꿨기 때문에 blob 비교에서 멈춥니다.

차이는 멈추는 *이유*입니다. 지금은 조용한 `[[ ]]` 실패이고, 바뀐 뒤에는 오케스트레이션이 실제로 달라졌다는 사실과 **완료분은 체크포인트에 있다**는 안내가 함께 나옵니다. 그리고 나머지 넷 같은 커밋 — 앞으로 훨씬 흔할 쪽 — 은 이제 실행을 죽이지 않습니다.

## 220개 실행에 필요한 조건이 줄어듭니다

exp034의 30개가 step 2a에서만 2시간을 넘겼으므로 220개는 15~18시간, 290분 감시 시계로 3~4번 넘겨주기입니다. 전에는 **그 시간 내내 main 전체가 얼어 있어야** 했습니다. 이제는 **`.github/workflows/batch-run.yml` 하나만** 얼면 됩니다. 이건 B와 합의 가능한 조건입니다.

## 테스트

`batch-runner/tests/test_a_relay_leg_runs_the_source_it_started_with.py` (24개). 읽지 않고 **실행합니다** — 두 git 단계는 `tmp_path`에 진짜 저장소를 만들어 진짜 커밋 두 개를 건넵니다. 반전되었거나 앞선 `exit`에 가려진 가드는 `run:` 문자열에 대한 어떤 assertion도 통과하기 때문입니다.

첫 실행에 전부 초록인 것은 증거가 아니므로, 워크플로를 일부러 망가뜨려 각 테스트가 잡는지 확인했습니다(확인 후 바이트 단위로 복원).

| 변형 | 결과 |
|---|---|
| 커밋 동일성 assertion 복원 | 잡음 |
| 조상 검사 삭제 | 잡음 |
| workflow blob 비교 삭제 | 잡음 |
| 추가된 파일 삭제 블록 제거 | 잡음 |
| unstage 제거 | 잡음 |
| falsy-middle 삼항 재도입 | 잡음 |
| 첫 다리에서도 고정이 돌게 변경 | 잡음 |

`scripts/__tests__/onboarding-contract.test.mjs`도 고쳤습니다. 거기 거부 목록의 `{ RELAY_RUN: '1', SOURCE_SHA: 'b'.repeat(40) }`은 이제 허용되는 경우인데, `validEnv`의 빈 `RELAY_LINEAGE_ID` 때문에 **다른 이유로** 여전히 거부되어 통과합니다 — 실패가 아니라 조용히 공허해진 assertion이라 더 나쁩니다. 허용 쪽으로 옮기고, 거부 쪽에는 이유가 분명한 잘못된 sha 두 개를 넣었습니다. Node 쪽 변형 검사도 3건 모두 잡습니다.
