### PR TITLE
feat(agentic): make the guest identity admissible, and refuse an unverifiable startup early

### DIFF
--- a/batch-runner/core/agentic_v2_contract.py
+++ b/batch-runner/core/agentic_v2_contract.py
@@ -17,6 +17,14 @@ from jsonschema import Draft202012Validator
 
 TOOL_CONTRACT_VERSION = "2.0"
 FOUNDATION_BACKEND_ID = "agentic-v2-fixture-v1"
+
+#: The backend that boots a real guest, named here rather than in its own
+#: module. Both identifiers belong in one place because the provenance code
+#: maps them to verification standards and the runner decides which of them it
+#: will admit: a backend id that exists in two files can drift in one of them,
+#: and the drift would show up as a run silently refused at startup rather than
+#: as anything a reader could name.
+MICROVM_BACKEND_ID = "agentic-v2-microvm-v1"
 POLICY_PROFILE_IDS = (
     "offline-full-v1",
     "package-broker-v1",

--- a/batch-runner/core/agentic_v2_microvm_backend.py
+++ b/batch-runner/core/agentic_v2_microvm_backend.py
@@ -28,13 +28,16 @@ added to the fixture years from now would silently become a production
 capability, and nothing would fail.
 
 **What this deliberately does not do.** ``core/agentic_v2_runner.py`` checks at
-startup that the backend's identity is exactly the foundation fixture's, and
-fails anything else with ``compute_start_failed``. This backend does not satisfy
-that check and this module does not change it. That is not an oversight — the
-guard is the thing that has to be opened as its own reviewable change, once the
-pieces underneath it have evidence, and opening it quietly from here would be
-the one move that makes every other honest thing in this file worthless. So the
-backend is proven directly by its tests, and the runner still refuses it.
+startup that the backend's identity is the one the runner was told to admit, and
+fails anything else with ``compute_start_failed``. Nothing admits this backend:
+the declaration defaults to the foundation fixture's identity, no caller in this
+repository passes anything else, and the substrate manifests still carry
+``production_activation: "disabled"``. The admission is deliberately a value a
+caller has to supply rather than a comparison someone can loosen, so that the
+day this backend does run, a diff says which identity was let in and who let it
+in. Opening it quietly from here would be the one move that makes every other
+honest thing in this file worthless. So the backend is proven directly by its
+tests, and no run admits it yet.
 
 **The capability gaps are gaps, and are reported as such.** ``environment_*``
 cannot work: the machine has no route off itself, which is stage C's fourth
@@ -54,7 +57,7 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import Any, Callable, Mapping
 
-from core.agentic_v2_contract import AgenticV2Profile
+from core.agentic_v2_contract import AgenticV2Profile, MICROVM_BACKEND_ID
 from core.agentic_v2_exec_boot import (
     EXEC_RECORD_DIR,
     INTERPRETERS,
@@ -69,7 +72,9 @@ from core.agentic_v2_substrate import AgenticV2SubstrateManifest
 from core.agentic_v2_provenance import canonical_sha256
 
 
-BACKEND_ID = "agentic-v2-microvm-v1"
+#: Re-exported so that the many uses below read as they always did, while the
+#: value itself lives beside the foundation's id in the contract.
+BACKEND_ID = MICROVM_BACKEND_ID
 
 MANIFEST_COMMAND_FOR_INTERPRETER = {
     "python": "python",

--- a/batch-runner/core/agentic_v2_provenance.py
+++ b/batch-runner/core/agentic_v2_provenance.py
@@ -16,6 +16,7 @@ from core.agentic_v2_contract import (
     ERROR_TYPES,
     EVENT_SCHEMA,
     FOUNDATION_BACKEND_ID,
+    MICROVM_BACKEND_ID,
     POLICY_PROFILE_IDS,
     PUBLIC_RESULT_COMMITMENT_SCHEMA,
     TOOL_CONTRACT_VERSION,
@@ -162,8 +163,22 @@ RESULT_STANDARD_COVERAGE: dict[str, dict[str, tuple[str, ...]]] = {
 # silently verifying a new backend less than its author intended is exactly the
 # failure this whole arrangement exists to prevent, and a KeyError at startup
 # is a much better outcome than a run record that overclaims.
+#
+# The microVM backend is mapped here, which is what makes it admissible at all
+# -- `core/agentic_v2_runner.py` refuses to admit an identity whose backend has
+# no entry in this table. Mapping it is not the same as running it: nothing in
+# this repository declares it as the identity to admit, and the substrate
+# manifests still say `production_activation: "disabled"`.
+#
+# One thing deliberately not done here: the name of the standard is *not* added
+# to the run metadata's key set. It is already determined by
+# `backend_identity.backend_id`, which every record carries and which the
+# runtime fingerprint covers, so a reader loses nothing; and widening an
+# exact-set schema is a change with a much larger blast radius than admitting
+# an identity, which is what this is for.
 _RESULT_STANDARD_BY_BACKEND: dict[str, str] = {
     FOUNDATION_BACKEND_ID: RESULT_STANDARD_FIXTURE_REPLAY,
+    MICROVM_BACKEND_ID: RESULT_STANDARD_ATTESTED_EXECUTION,
 }
 
 
@@ -180,6 +195,20 @@ def result_verification_standard(backend_id: Any) -> str:
         raise ValueError(
             "agentic v2 backend has no declared result verification standard"
         ) from None
+
+
+def startup_is_admissible(payload: Any) -> bool:
+    """Would a run record built on this startup event verify afterwards?
+
+    The same question `verify_event_chain` asks, asked early. Without it a
+    startup that no standard accepts is discovered at the end, by which point
+    the failure envelope being written *contains* the bad event and cannot be
+    verified either -- so a run that failed cleanly for a nameable reason
+    produces a record nothing downstream will accept, and the reason is lost.
+    Asking here lets the runner refuse before the event is appended and emit an
+    ordinary ``compute_start_failed`` that verifies like any other failure.
+    """
+    return _valid_started_payload(payload)
 
 
 def validate_failure_stage(error_type: Any, stage: Any) -> tuple[str, str]:
@@ -597,23 +626,33 @@ def verify_agentic_v2_metadata(value: Any) -> None:
     ):
         raise ValueError("agentic v2 metadata startup identity mismatch")
     runtime = started["runtime"]
-    canonical = foundation_fixture_identity(
-        started["policy_profile_id"], runtime["budget_caps"]
-    )
-    if (
-        started["backend_identity"] != canonical["backend_identity"]
-        or started["capabilities"] != canonical["capabilities"]
-        or runtime["substrate_manifest_sha256"] != canonical[
-            "substrate_manifest_sha256"
-        ]
-        or runtime["package_snapshot_sha256"] != canonical[
-            "package_snapshot_sha256"
-        ]
-        or runtime["browser_build_sha256"] != canonical[
-            "browser_build_sha256"
-        ]
-    ):
-        raise ValueError("agentic v2 canonical fixture identity mismatch")
+    # The canonical comparison belongs only to the standard that can make it.
+    # `verify_trace_pair` above has already run `_valid_started_payload`, which
+    # applies whichever standard the backend declares; repeating the fixture's
+    # re-derivation here for a guest would fail every honest run.
+    if result_verification_standard(
+        started["backend_identity"]["backend_id"]
+    ) == RESULT_STANDARD_FIXTURE_REPLAY:
+        canonical = foundation_fixture_identity(
+            started["policy_profile_id"], runtime["budget_caps"]
+        )
+        if (
+            started["backend_identity"] != canonical["backend_identity"]
+            or started["capabilities"] != canonical["capabilities"]
+            or runtime["substrate_manifest_sha256"] != canonical[
+                "substrate_manifest_sha256"
+            ]
+            or runtime["package_snapshot_sha256"] != canonical[
+                "package_snapshot_sha256"
+            ]
+            or runtime["browser_build_sha256"] != canonical[
+                "browser_build_sha256"
+            ]
+        ):
+            raise ValueError("agentic v2 canonical fixture identity mismatch")
+    # This part is arithmetic over what the record itself reports, so it holds
+    # for both standards: the fingerprint has to be the one its own inputs
+    # produce, whoever produced the inputs.
     actual_runtime = runtime_fingerprint(
         policy_profile_id=started["policy_profile_id"],
         substrate_manifest_sha256=runtime["substrate_manifest_sha256"],
@@ -740,6 +779,24 @@ def _terminal_finalize_event(private_trace: Mapping[str, Any]) -> dict:
 
 
 def _valid_started_payload(value: Any) -> bool:
+    """Is this a startup event a run record may be built on?
+
+    Two standards, and the split is not a relaxation dressed up as a branch.
+
+    Under ``fixture-replay-v1`` the whole identity is *re-derived* here and
+    compared for equality, because everything the fixture reports is a function
+    of code in this repository. Under ``attested-execution-v1`` it cannot be:
+    the commands a guest offers come from a substrate manifest, the
+    implementation hash covers an image rather than this file's source text, and
+    re-deriving any of it would mean this process inventing the answer it then
+    congratulates itself for matching. So the attested branch checks shape,
+    self-consistency, and the one thing equality was really buying -- that a
+    fixture run cannot be relabelled as a guest run to get the lighter check.
+
+    What does *not* differ between the two: the run must still be foundation
+    only. Admitting a second backend is not the same as lifting that brake, and
+    this is the line that keeps the two apart.
+    """
     if not isinstance(value, dict) or set(value) != {
         "run_id", "condition", "task_id", "backend_identity", "capabilities",
         "policy_profile_id", "runtime",
@@ -748,51 +805,80 @@ def _valid_started_payload(value: Any) -> bool:
     identity = value.get("backend_identity")
     capabilities = value.get("capabilities")
     runtime = value.get("runtime")
-    budget_caps = runtime.get("budget_caps") if isinstance(runtime, dict) else None
+    if not (
+        isinstance(identity, dict)
+        and isinstance(capabilities, dict)
+        and isinstance(runtime, dict)
+    ):
+        return False
+    budget_caps = runtime.get("budget_caps")
     structurally_valid = (
         all(
             isinstance(value.get(name), str) and bool(value[name])
             for name in ("run_id", "condition", "task_id", "policy_profile_id")
         )
-        and isinstance(identity, dict)
         and set(identity) == {
             "backend_id", "foundation_only", "implementation_sha256"
         }
-        and identity.get("backend_id") == FOUNDATION_BACKEND_ID
         and identity.get("foundation_only") is True
-        and identity.get("implementation_sha256") == (
-            foundation_implementation_fingerprint()
-        )
+        and isinstance(identity.get("implementation_sha256"), str)
+        and is_sha256(identity["implementation_sha256"])
         and value.get("policy_profile_id") in POLICY_PROFILE_IDS
-        and isinstance(capabilities, dict)
         and set(capabilities) == {
             "commands", "runtimes", "packages", "formats", "budgets"
         }
-        and capabilities.get("commands") == ["fixture-upper"]
-        and capabilities.get("runtimes") == ["fixture"]
-        and capabilities.get("formats") == ["html", "txt"]
-        and _valid_package_capabilities(
-            capabilities.get("packages"), value.get("policy_profile_id")
-        )
         and _valid_budget_capabilities(capabilities.get("budgets"), budget_caps)
-        and isinstance(runtime, dict)
         and set(runtime) == {
             "substrate_manifest_sha256",
             "package_snapshot_sha256",
             "browser_build_sha256",
             "budget_caps",
         }
-        and all(is_sha256(runtime.get(name)) for name in (
-            "substrate_manifest_sha256",
-            "package_snapshot_sha256",
-            "browser_build_sha256",
-        ))
+        and all(
+            isinstance(runtime.get(name), str) and is_sha256(runtime[name])
+            for name in (
+                "substrate_manifest_sha256",
+                "package_snapshot_sha256",
+                "browser_build_sha256",
+            )
+        )
     )
     if not structurally_valid:
         return False
     try:
+        standard = result_verification_standard(identity["backend_id"])
+    except ValueError:
+        # A backend nobody has assigned a standard to. Refusing is the point of
+        # the table: an unknown backend gets no verification, not the weakest.
+        return False
+    if standard == RESULT_STANDARD_FIXTURE_REPLAY:
+        return _valid_fixture_started_payload(value, identity, capabilities, runtime)
+    return _valid_attested_started_payload(capabilities, value["policy_profile_id"])
+
+
+def _valid_fixture_started_payload(
+    value: Mapping[str, Any],
+    identity: Any,
+    capabilities: Any,
+    runtime: Any,
+) -> bool:
+    """Everything the fixture reports, re-derived here and compared."""
+    if not (
+        identity.get("backend_id") == FOUNDATION_BACKEND_ID
+        and identity.get("implementation_sha256") == (
+            foundation_implementation_fingerprint()
+        )
+        and capabilities.get("commands") == ["fixture-upper"]
+        and capabilities.get("runtimes") == ["fixture"]
+        and capabilities.get("formats") == ["html", "txt"]
+        and _valid_package_capabilities(
+            capabilities.get("packages"), value.get("policy_profile_id")
+        )
+    ):
+        return False
+    try:
         canonical = foundation_fixture_identity(
-            value["policy_profile_id"], budget_caps
+            value["policy_profile_id"], runtime["budget_caps"]
         )
     except ValueError:
         return False
@@ -808,6 +894,39 @@ def _valid_started_payload(value: Any) -> bool:
         and runtime["browser_build_sha256"] == canonical[
             "browser_build_sha256"
         ]
+    )
+
+
+def _valid_attested_started_payload(
+    capabilities: Any,
+    policy_profile_id: str,
+) -> bool:
+    """What can be checked about a guest's declared capabilities from here.
+
+    Not much, honestly, and saying so is better than manufacturing more. The
+    lists have to be lists of real names in a stable order, ``commands`` has to
+    contain something -- a backend that can execute nothing has no business
+    claiming a standard with "execution" in its name -- and the pair that
+    identifies the fixture is refused outright, because the only way for a
+    startup event to carry it under this standard is for a fixture run to have
+    been relabelled into the lighter branch.
+
+    ``packages`` is checked for shape but not against the foundation's
+    catalogue: a guest's inventory is whatever its image holds, and today the
+    microVM backend reports an empty one for a stated reason.
+    """
+    del policy_profile_id
+    for name in ("commands", "runtimes", "packages", "formats"):
+        declared = capabilities.get(name)
+        if not isinstance(declared, list) or declared != sorted(set(declared)):
+            return False
+        if not all(isinstance(item, str) and item for item in declared):
+            return False
+    if not capabilities["commands"] or not capabilities["formats"]:
+        return False
+    return not (
+        capabilities["commands"] == ["fixture-upper"]
+        and capabilities["runtimes"] == ["fixture"]
     )
 
 

--- a/batch-runner/core/agentic_v2_runner.py
+++ b/batch-runner/core/agentic_v2_runner.py
@@ -26,7 +26,9 @@ from core.agentic_v2_provenance import (
     AgenticV2EventChain,
     canonical_sha256,
     foundation_implementation_fingerprint,
+    result_verification_standard,
     runtime_fingerprint,
+    startup_is_admissible,
     trace_pair_fingerprint,
     validate_failure_stage,
     verify_agentic_v2_failure_result,
@@ -363,6 +365,7 @@ class AgenticV2ScriptedRunner:
         cancel_requested: Optional[Callable[[], bool]] = None,
         clock: Callable[[], float] = time.monotonic,
         required_backend_type: type | None = None,
+        admitted_identity: Optional[Mapping[str, Any]] = None,
     ):
         if not callable(backend_factory):
             raise ValueError("agentic v2 backend_factory is required")
@@ -373,6 +376,7 @@ class AgenticV2ScriptedRunner:
         self.cancel_requested = cancel_requested or (lambda: False)
         self.clock = clock
         self.required_backend_type = required_backend_type
+        self.admitted_identity = _validate_admitted_identity(admitted_identity)
         self._closed = False
 
     def close(self) -> None:
@@ -464,32 +468,32 @@ class AgenticV2ScriptedRunner:
                 ))
             startup_data = startup.get("data") or {}
             identity = startup_data.get("backend_identity") or {}
-            expected_implementation_sha = foundation_implementation_fingerprint()
-            # The admitted set, written as a set of one.
+            # The one identity this run will admit.
             #
-            # There is a second backend in this repository --
+            # There are two backends in this repository: the fixture, and
             # core/agentic_v2_microvm_backend.py, which boots a real guest and
             # reports an identity derived from the image rather than from its
-            # own source text. It does not appear here, and this change does
-            # not put it here.
+            # own source text. Which one a run admits is now a value the caller
+            # supplies, not a comparison written into this file, and the
+            # default is the fixture -- so nothing changes for any caller that
+            # does not say otherwise, and no caller in this repository says
+            # otherwise today.
             #
-            # What the shape buys is that admitting it later is an edit to a
-            # named list rather than a loosened comparison, so it shows up in a
-            # diff as what it is. It is also not the only thing that would have
-            # to change: the semantic verifier in agentic_v2_provenance.py
-            # re-simulates every executed tool call against the fixture's known
-            # behaviour, and a command run in a real guest cannot be
-            # re-simulated. Admitting a second identity without answering that
-            # would produce runs this code calls verified while checking
-            # strictly less than the word implies.
-            admitted_identities = (
-                {
-                    "backend_id": FOUNDATION_BACKEND_ID,
-                    "foundation_only": True,
-                    "implementation_sha256": expected_implementation_sha,
-                },
-            )
-            if identity not in admitted_identities:
+            # Two things are checked elsewhere rather than here, and both are
+            # load-bearing. `_validate_admitted_identity` refuses a backend
+            # that has no declared result-verification standard, so admission
+            # cannot outrun the verifier. And the verifier's fixture branch
+            # still re-simulates every executed call against known fixture
+            # behaviour; a guest's results are verified under the weaker,
+            # separately named `attested-execution-v1` instead, which is what
+            # makes admitting a second identity honest rather than a quiet
+            # widening of the word "verified".
+            admitted = self.admitted_identity or {
+                "backend_id": FOUNDATION_BACKEND_ID,
+                "foundation_only": True,
+                "implementation_sha256": foundation_implementation_fingerprint(),
+            }
+            if identity != admitted:
                 lifecycle.transition(LifecycleState.FAILED)
                 return finish(_failure(
                     "compute_start_failed", lifecycle, audit_chain, public_chain,
@@ -548,6 +552,17 @@ class AgenticV2ScriptedRunner:
                     "budget_caps": deepcopy(self.budget_caps),
                 },
             }
+            # Ask now whether a record built on this would verify later. The
+            # checks above cover what the runner can compare things to; this
+            # covers what the backend's own declared standard requires of it,
+            # and asking after the event is appended is too late -- the failure
+            # envelope would carry the bad event and be unverifiable itself.
+            if not startup_is_admissible(started_payload):
+                lifecycle.transition(LifecycleState.FAILED)
+                return finish(_failure(
+                    "compute_start_failed", lifecycle, audit_chain, public_chain,
+                    stage="startup",
+                ))
             audit_chain.append(
                 "started", started_payload, state_sha256=initial_state
             )
@@ -764,6 +779,13 @@ def _failure(
         "error": public_error,
         "agentic_v2": {
             "schema_version": "2.0",
+            # Constant, and now for a stated reason rather than by inheritance
+            # from a time when there was only one backend. Every identity a run
+            # can admit must declare `foundation_only: True` -- see
+            # `_validate_admitted_identity` -- so no run that reaches this
+            # function was anything else. If that condition is ever relaxed,
+            # this literal is one of the places that has to move with it, and a
+            # test pins the pair together so the move cannot be forgotten.
             "foundation_only": True,
             "lifecycle_state": terminal_state,
             "private_audit": private_trace,
@@ -797,6 +819,51 @@ def _public_result_commitment(result: Mapping[str, Any]) -> dict:
         "state_after_sha256",
     )
     return {field: deepcopy(result.get(field)) for field in fields}
+
+
+def _validate_admitted_identity(
+    value: Optional[Mapping[str, Any]],
+) -> Optional[dict[str, Any]]:
+    """Check a caller's declaration of which backend a run may admit.
+
+    ``None`` means the foundation fixture, resolved at run time because its
+    implementation hash is a hash of files on disk. Anything else has to be a
+    complete identity, and has to clear three conditions that are each there
+    for a different reason:
+
+    * **a declared verification standard.** ``result_verification_standard``
+      raises for a backend nobody has mapped, so a run can never admit a
+      backend whose results the verifier would not know how to judge. This is
+      the reason admission lives here rather than in the caller.
+    * **foundation only.** Admitting a second backend is a change of *which*
+      substrate may run; it is not permission to leave the foundation. The
+      substrate manifests carry their own ``production_activation`` brake and
+      this does not touch it.
+    * **a real implementation hash.** An identity with a placeholder in it
+      would put a fingerprint into the run record that corresponds to nothing.
+
+    Raising here rather than failing the run is deliberate: a malformed
+    declaration is a mistake in configuration, and a configuration mistake that
+    surfaces as ``compute_start_failed`` on every task looks like an
+    infrastructure fault and would be counted as one.
+    """
+    if value is None:
+        return None
+    identity = dict(value)
+    if set(identity) != {
+        "backend_id", "foundation_only", "implementation_sha256"
+    }:
+        raise ValueError("agentic v2 admitted identity is malformed")
+    result_verification_standard(identity["backend_id"])
+    if identity["foundation_only"] is not True:
+        raise ValueError(
+            "agentic v2 admitted identity must still be foundation only"
+        )
+    if not is_sha256(identity["implementation_sha256"]):
+        raise ValueError(
+            "agentic v2 admitted identity needs an implementation hash"
+        )
+    return identity
 
 
 def _validate_budget_caps(value: Optional[Mapping[str, Any]]) -> dict[str, int]:

--- a/batch-runner/tests/test_agentic_v2_foundation.py
+++ b/batch-runner/tests/test_agentic_v2_foundation.py
@@ -23,6 +23,7 @@ import core.agentic_v2_runner as agentic_v2_runner
 from core.agentic_v2_contract import (
     EVENT_SCHEMA,
     FOUNDATION_BACKEND_ID,
+    MICROVM_BACKEND_ID,
     TOOL_CONTRACT_VERSION,
     TOOL_RESULT_SCHEMA,
     AgenticV2Lifecycle,
@@ -3642,27 +3643,270 @@ def test_an_identity_differing_only_in_foundation_only_is_refused(tmp_path):
     verify_agentic_v2_failure_result(result)
 
 
-def test_the_admitted_set_holds_exactly_one_identity_and_names_the_fixture():
-    """The seam, asserted as a set of one.
+class _ClaimsToBeTheGuest(AgenticV2FixtureBackend):
+    """The fixture with the guest's name on it, and nothing else changed.
 
-    There is a second backend in this repository -- the microVM one, which
-    boots a real guest -- and admitting it is a change somebody will want to
-    make. This asserts the shape that makes such a change legible: a named
-    tuple of complete identities, so an addition appears in a diff as a new
-    entry rather than as a comparison that quietly got weaker.
-
-    It is deliberately not a test that the microVM backend is *excluded by
-    name*. Excluding one thing by name would pass while admitting anything
-    else; requiring the set to be exactly one entry, and that entry to be the
-    foundation's, does not.
+    Two different things are being probed with this one object. Without a
+    declaration it must be refused, because the default admits the fixture and
+    only the fixture. *With* a declaration naming the guest it must still not
+    produce a verified run, because its capabilities are the fixture's: the
+    lighter standard exists for results nobody can re-simulate, and a fixture
+    relabelled into it would be getting the discount without the reason.
     """
-    source = inspect.getsource(agentic_v2_runner)
-    start = source.index("admitted_identities = (")
-    body = source[start:source.index("if identity not in admitted_identities:")]
 
-    assert body.count('"backend_id":') == 1
-    assert "FOUNDATION_BACKEND_ID" in body
-    assert "agentic-v2-microvm-v1" not in source
+    def start(self, timeout_seconds: float):
+        startup = dict(super().start(timeout_seconds))
+        data = dict(startup["data"])
+        identity = dict(data["backend_identity"])
+        identity["backend_id"] = MICROVM_BACKEND_ID
+        data["backend_identity"] = identity
+        startup["data"] = data
+        return startup
+
+
+def test_by_default_a_run_admits_the_fixture_and_only_the_fixture(tmp_path):
+    """The default did not move, which is the whole claim about this change.
+
+    Admission became a value a caller supplies. That is only safe if not
+    supplying it leaves behaviour exactly where it was, so this asserts the
+    thing a reader would want to check first: a backend calling itself the
+    guest is refused by a runner that was told nothing.
+    """
+    result = _successful_run(tmp_path, _ClaimsToBeTheGuest)
+
+    assert result["success"] is False
+    assert result["error"] == "compute_start_failed"
+    verify_agentic_v2_failure_result(result)
+
+
+def test_a_declared_identity_does_not_let_the_fixture_pass_as_a_guest(tmp_path):
+    # Admitted at the identity check -- the declaration matches exactly -- and
+    # still refused, because what it then reports about itself is the
+    # fixture's. Being admitted is not being verified.
+    declared = {
+        "backend_id": MICROVM_BACKEND_ID,
+        "foundation_only": True,
+        "implementation_sha256": foundation_implementation_fingerprint(),
+    }
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: _ClaimsToBeTheGuest(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=deepcopy(_SUCCESSFUL_CALLS),
+        profile=PROFILE,
+        admitted_identity=declared,
+    ).run("Create report", task_id="task-1")
+
+    assert result["success"] is False
+    verify_agentic_v2_failure_result(result)
+
+
+class _ShapedLikeAGuest(AgenticV2FixtureBackend):
+    """A stand-in for a backend whose capabilities come from an image.
+
+    Not a guest -- it still upper-cases a file, because booting a machine in a
+    unit test is not a thing this suite does. What it reproduces is the only
+    property the attested branch actually turns on: capabilities that are *not*
+    the fixture's, because they were read out of a substrate manifest rather
+    than derived from this repository's source. That is enough to exercise the
+    branch, and pretending it is more would be the re-simulation problem all
+    over again.
+    """
+
+    GUEST_COMMANDS = ["fixture-upper", "python3"]
+    GUEST_RUNTIMES = ["python"]
+
+    def _capabilities(self):
+        capabilities = dict(super()._capabilities())
+        capabilities["commands"] = list(self.GUEST_COMMANDS)
+        capabilities["runtimes"] = list(self.GUEST_RUNTIMES)
+        return capabilities
+
+    def start(self, timeout_seconds: float):
+        startup = dict(super().start(timeout_seconds))
+        data = dict(startup["data"])
+        identity = dict(data["backend_identity"])
+        identity["backend_id"] = MICROVM_BACKEND_ID
+        data["backend_identity"] = identity
+        data["capabilities"] = self._capabilities()
+        startup["data"] = data
+        return startup
+
+
+def _declared_guest_run(tmp_path):
+    return AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: _ShapedLikeAGuest(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=deepcopy(_SUCCESSFUL_CALLS),
+        profile=PROFILE,
+        admitted_identity={
+            "backend_id": MICROVM_BACKEND_ID,
+            "foundation_only": True,
+            "implementation_sha256": foundation_implementation_fingerprint(),
+        },
+    ).run("Create report", task_id="task-1")
+
+
+def test_a_declared_guest_identity_produces_a_run_that_verifies(tmp_path):
+    """The point of the whole change: admission that is not a hole.
+
+    A backend whose capabilities cannot be re-derived from this repository's
+    source is admitted, runs, and produces a record that passes verification --
+    under the standard its backend id maps to, which is the weaker one, which
+    is named.
+    """
+    result = _declared_guest_run(tmp_path)
+
+    assert result["success"] is True
+    verify_agentic_v2_result(result)
+    started = result["agentic_v2"]["private_audit"]["events"][0]["payload"]
+    assert started["backend_identity"]["backend_id"] == MICROVM_BACKEND_ID
+    assert agentic_v2_provenance.result_verification_standard(
+        started["backend_identity"]["backend_id"]
+    ) == agentic_v2_provenance.RESULT_STANDARD_ATTESTED_EXECUTION
+
+
+def test_the_fixture_still_gets_the_stricter_standard_in_the_same_suite(
+    tmp_path,
+):
+    # The pair that matters: two runs, two standards, neither borrowing the
+    # other's. If the branch ever collapses to one arm, one of these fails.
+    guest = _declared_guest_run(tmp_path / "guest")
+    fixture = _successful_run(tmp_path / "fixture")
+
+    verify_agentic_v2_result(guest)
+    verify_agentic_v2_result(fixture)
+    standards = {
+        agentic_v2_provenance.result_verification_standard(
+            run["agentic_v2"]["backend_identity"]["backend_id"]
+        )
+        for run in (guest, fixture)
+    }
+    assert standards == {
+        agentic_v2_provenance.RESULT_STANDARD_FIXTURE_REPLAY,
+        agentic_v2_provenance.RESULT_STANDARD_ATTESTED_EXECUTION,
+    }
+
+
+def test_a_guest_run_is_still_refused_if_it_declares_nothing_runnable(tmp_path):
+    # `attested-execution-v1` is a standard for results of executions. A
+    # backend declaring no commands has executed nothing, so the record it
+    # would produce describes something the name does not cover.
+    class _OffersNoCommands(_ShapedLikeAGuest):
+        GUEST_COMMANDS: list = []
+
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: _OffersNoCommands(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=deepcopy(_SUCCESSFUL_CALLS),
+        profile=PROFILE,
+        admitted_identity={
+            "backend_id": MICROVM_BACKEND_ID,
+            "foundation_only": True,
+            "implementation_sha256": foundation_implementation_fingerprint(),
+        },
+    ).run("Create report", task_id="task-1")
+
+    assert result["success"] is False
+    assert result["error"] == "compute_start_failed"
+    verify_agentic_v2_failure_result(result)
+
+
+def test_a_startup_no_standard_accepts_fails_cleanly_rather_than_late(tmp_path):
+    """The failure record of a bad startup must itself be verifiable.
+
+    Found by the test above it: a startup that no standard accepts used to sail
+    past the runner and be rejected only when the finished record was verified,
+    at which point the failure envelope contained the bad event and nothing
+    downstream would accept it either. The reason for the failure survived
+    nowhere. Now it is refused before the event is written.
+    """
+    refused = _successful_run(tmp_path, _ClaimsToBeTheGuest)
+
+    assert refused["error"] == "compute_start_failed"
+    verify_agentic_v2_failure_result(refused)
+    kinds = [
+        event["kind"]
+        for event in refused["agentic_v2"]["private_audit"]["events"]
+    ]
+    assert "started" not in kinds
+
+
+def test_nothing_in_this_repository_declares_a_non_default_identity():
+    """The claim that the guest is mapped but not run, made checkable.
+
+    `_RESULT_STANDARD_BY_BACKEND` now has an entry for the microVM backend, so
+    the old "there is only one backend anywhere" guard no longer says anything.
+    This is what replaces it: admission is possible, and nothing does it. The
+    day some caller does, this test is the line that has to change with it.
+    """
+    core = Path(agentic_v2_runner.__file__).resolve().parent
+    declaring = [
+        path.name
+        for path in sorted(core.glob("*.py"))
+        if "admitted_identity=" in path.read_text(encoding="utf-8")
+        and path.name != "agentic_v2_runner.py"
+    ]
+
+    assert declaring == []
+
+
+@pytest.mark.parametrize(
+    "declared, expected",
+    [
+        ({"backend_id": "agentic-v2-nothing-v1", "foundation_only": True,
+          "implementation_sha256": "a" * 64}, "declared result verification"),
+        ({"backend_id": MICROVM_BACKEND_ID, "foundation_only": False,
+          "implementation_sha256": "a" * 64}, "still be foundation only"),
+        ({"backend_id": MICROVM_BACKEND_ID, "foundation_only": True,
+          "implementation_sha256": "not-a-hash"}, "implementation hash"),
+        ({"backend_id": MICROVM_BACKEND_ID, "foundation_only": True},
+         "malformed"),
+    ],
+)
+def test_a_declaration_is_refused_at_construction_and_says_why(
+    tmp_path, declared, expected
+):
+    # Loudly, and before any task runs. A bad declaration that surfaced as a
+    # per-task compute_start_failed would be counted as an infrastructure
+    # fault in the ledger, which is exactly the wrong story.
+    with pytest.raises(ValueError, match=expected):
+        AgenticV2ScriptedRunner(
+            backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+                root=tmp_path, **kwargs
+            ),
+            scripted_calls=deepcopy(_SUCCESSFUL_CALLS),
+            profile=PROFILE,
+            admitted_identity=declared,
+        )
+
+
+def test_the_failure_envelope_and_the_admission_rule_agree(tmp_path):
+    """`_failure` writes `foundation_only: True` as a literal. This is why.
+
+    Every identity that can be admitted must declare it, so the literal is a
+    consequence rather than a guess. The two halves are asserted together so
+    that relaxing one without the other fails here instead of producing a
+    failure record that misdescribes the run it came from.
+    """
+    with pytest.raises(ValueError, match="still be foundation only"):
+        AgenticV2ScriptedRunner(
+            backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+                root=tmp_path, **kwargs
+            ),
+            scripted_calls=[],
+            profile=PROFILE,
+            admitted_identity={
+                "backend_id": FOUNDATION_BACKEND_ID,
+                "foundation_only": False,
+                "implementation_sha256": foundation_implementation_fingerprint(),
+            },
+        )
+
+    refused = _successful_run(tmp_path, _ClaimsToBeTheGuest)
+    assert refused["agentic_v2"]["foundation_only"] is True
 
 
 # ── the second verification standard ──────────────────────────────────────
@@ -3711,7 +3955,7 @@ class TestTheStandardIsNamedAndChosenDeliberately:
         ) == agentic_v2_provenance.RESULT_STANDARD_FIXTURE_REPLAY
 
     @pytest.mark.parametrize(
-        "backend_id", ["agentic-v2-microvm-v1", "", None, 0, object()]
+        "backend_id", ["agentic-v2-nothing-v1", "", None, 0, object()]
     )
     def test_a_backend_with_no_declared_standard_raises_rather_than_defaulting(
         self, backend_id
@@ -3723,12 +3967,20 @@ class TestTheStandardIsNamedAndChosenDeliberately:
         with pytest.raises(ValueError, match="declared result verification standard"):
             agentic_v2_provenance.result_verification_standard(backend_id)
 
-    def test_exactly_one_backend_has_a_standard_today(self):
-        # The microVM backend exists in this repository and is still not here.
-        # Admitting it is an edit to this mapping, which is a line in a diff.
-        assert list(agentic_v2_provenance._RESULT_STANDARD_BY_BACKEND) == [
-            FOUNDATION_BACKEND_ID
-        ]
+    def test_the_two_backends_have_the_two_different_standards(self):
+        # The microVM backend is mapped here, which is what makes it
+        # admissible at all. Mapping is not running: nothing declares it as the
+        # identity to admit, and the manifests still disable activation. What
+        # this pins is that the mapping stayed a mapping of exactly the two
+        # backends that exist, each to the standard its results can support.
+        assert agentic_v2_provenance._RESULT_STANDARD_BY_BACKEND == {
+            FOUNDATION_BACKEND_ID: (
+                agentic_v2_provenance.RESULT_STANDARD_FIXTURE_REPLAY
+            ),
+            MICROVM_BACKEND_ID: (
+                agentic_v2_provenance.RESULT_STANDARD_ATTESTED_EXECUTION
+            ),
+        }
 
     def test_the_run_can_say_which_standard_verified_it(self):
         # The point of naming them. "Verified" is a different claim for a

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
@@ -2153,6 +2153,133 @@ microVM backend needs, and the stage E ledger and retry wiring, need no host and
 no access change, so they are where the work continues while this sits with
 whoever owns the subscription.
 
+##### The second standard, written: what "verified" means when nothing can be re-simulated
+
+That is where the work went. `core/agentic_v2_provenance.py` now names two
+standards instead of assuming one:
+
+| standard | for |
+|---|---|
+| `fixture-replay-v1` | the foundation fixture, every result of which can be produced again from a known simulation and compared in full |
+| `attested-execution-v1` | a backend whose output nothing in this process can predict |
+
+**Naming it is the change; the contents follow from the name.** A run that says
+*verified* is making a claim, and the claim is not the same for a fixture as for
+a guest. Three parts of a real result cannot be predicted by anything in the
+verifying process — the bytes a command actually wrote, the time it actually
+took, and the state of a filesystem that is not a dictionary in memory — so
+re-simulation there is not expensive, it is undefined. Letting both kinds of run
+say the same word would let the weaker claim be read as the stronger one, and
+nothing in the record would show which had been made.
+
+`RESULT_STANDARD_COVERAGE` writes out both halves in the record's own words. The
+attested standard **checks eight things**: the envelope's shape and its declared
+schema version, `request_sha256` recomputed from the committed request,
+`result_sha256` recomputed over the envelope's own fields, the result data
+against the tool contract's schema, `output_bytes` against the encoded length of
+the data reported, the state chain either side of the call, the tool-call budget
+counted the same way for every backend, and the 64 KiB result ceiling together
+with the error it must produce. It **declines three**: whether the data is what
+the command *should* have produced, which no party to this process knows;
+`wall_ms` against any particular value, because a real command takes real time;
+and the state digest against a re-simulation, because the state is a real
+filesystem rather than a ledger in memory. The fixture standard's
+`does_not_check` is empty, and that emptiness is a fact about it rather than a
+section nobody filled in.
+
+The three declines are the useful half. "Verified" with nothing after it reads
+as the strongest thing the word can mean; this standard is genuinely weaker, and
+a reader who cannot see *where* it is weaker will assume it is not.
+
+**The standard is chosen by backend id with no default.**
+`result_verification_standard()` raises for a backend nobody has mapped rather
+than falling through to the looser of the two. A new backend quietly receiving
+the weakest available verification is the failure this whole arrangement exists
+to prevent, and a `ValueError` at startup is a much better outcome than a run
+record that overclaims.
+
+##### D4 — the guest identity becomes admissible, and nothing admits it
+
+With the standard written, the remaining barrier turned out not to be about
+results at all. It is at startup. `_valid_started_payload` did not merely check
+that a startup event was well formed: it reconstructed the fixture's **entire**
+payload — `commands == ["fixture-upper"]`, `runtimes == ["fixture"]`, the fixed
+package records, the fixed browser digest — and required equality. A real guest
+reports its own capabilities out of its substrate manifest, so its startup could
+never have matched, whatever standard its results were later judged under.
+
+**What changed, exactly.** Four things, each smaller than it sounds:
+
+- `MICROVM_BACKEND_ID` moved into `core/agentic_v2_contract.py` beside the
+  foundation's, and the backend module re-exports it. Two files spelling the
+  same identity is one file spelling it differently later, and the difference
+  would surface as a run silently refused at startup rather than as anything a
+  reader could name.
+- `_RESULT_STANDARD_BY_BACKEND` gained its second entry. That table is what
+  makes the guest admissible at all, because admission refuses any backend it
+  cannot look up in it.
+- `_valid_started_payload` split in three: a backend-agnostic structural chain
+  both standards share, then the fixture's exact-equality block **unchanged**,
+  then a shape-only check for the attested standard. What the attested branch
+  adds beyond shape is one rule — a payload whose commands are exactly
+  `["fixture-upper"]` and whose runtimes are exactly `["fixture"]` is refused —
+  so a guest identity cannot be worn by the fixture.
+- the runner's hard-coded admitted set became `admitted_identity`, a constructor
+  argument that defaults to the fixture.
+
+**`foundation_only` was not relaxed, and did not need to be.** The microVM
+backend reads that flag from its substrate manifest, and under the manifests in
+this repository it reports `True`. So both standards still require it, and this
+change is about *which* backend may start, never about how far one may go.
+`production_activation: "disabled"` is untouched and stays an independent brake.
+The same reading turned `_failure()`'s hard-coded `"foundation_only": True` from
+accidentally correct into correct on purpose, and a test now pins the two
+together.
+
+**A declaration is refused where it is made, not where it runs.**
+`_validate_admitted_identity` raises at construction for an identity that is
+malformed, that is not foundation-only, or whose implementation hash is not a
+hash. The alternative — failing the run — would surface a configuration mistake
+as `compute_start_failed` on every task, which reads as an infrastructure fault
+and, by the disposition map below, would be counted as one.
+
+**And it found an ordering fault that predates it.** A startup no standard
+accepts used to be caught only at final verification, by which point the failure
+envelope being written *contained* the bad started event and could not be
+verified either. A run that failed cleanly, for a nameable reason, produced a
+record nothing downstream would accept — and the reason was lost.
+`startup_is_admissible()` asks the same question before the event is appended,
+so the run stops with an ordinary `compute_start_failed` that verifies like any
+other failure. Its test asserts the chain contains no `started` event at all.
+
+**What is still shut.** Nothing in this repository declares a non-default
+identity, and a test globs `core/*.py` to establish that rather than asserting
+it. `production_activation` is `"disabled"`. `exec_run` on a real guest reaches
+nothing through the product path, and the two guards in `step2_run_inference.py`
+and `core/executor.py` are where they were. What changed is that admitting a
+guest is now an argument someone passes — which a diff shows as an addition —
+instead of a comparison someone loosens, which a diff shows as the deletion of a
+line that used to say the fixture's name.
+
+**Checked.** 264 tests across the foundation, microVM and contract modules;
+2,851 passed and 4 skipped across the wider agentic subset. Nine new tests.
+`mypy` on the four changed modules reports 29 errors against a 34-error baseline
+taken from `origin/main` in a throwaway worktree — five fewer, none introduced.
+
+The evidence that the fixture path is untouched is the *absence* of behavioural
+failures. Three tests failed on the first run and all three asserted the old
+one-backend world: that the admitted set had exactly one member, that exactly
+one backend had a standard, and that the microVM id appeared nowhere in the
+runner's source. They were rewritten to assert the new invariants, which are
+still narrow. No test was relaxed to pass.
+
+And the attested branch is exercised rather than merely present: the guest
+double declares `commands == ["fixture-upper", "python3"]`, which the fixture
+branch rejects outright, and its run verifies — so the attested branch is the
+one that ran. That is a proof by consequence rather than by mutation, which is
+deliberate: rewriting the source in place would have corrupted the suite running
+beside it.
+
 ### Stage E — not yet run
 
 Before any of it is written, what the repository already has. Two searches this
@@ -2197,6 +2324,40 @@ status, not the hardware, so a job that measured `/dev/kvm` on a runner would
 answer a true but different question — and presenting that measurement as
 reopening the route would be the same overclaim as reading a self-computed
 digest as a supplier signature.
+
+#### The cost and blame wiring, built. Nothing has run through it.
+
+`core/agentic_v2_cost_binding.py` is the V2 caller `core/cost_receipts.py` did
+not have. It is a separate module on purpose: the ledger is shared with other
+work, and binding a backend to it should not mean editing it.
+
+**All 27 error types are mapped onto 8 dispositions, and two of the eight are
+neither the model's fault nor the environment's.** Ten are `semantic` — the
+model did something the contract refuses — five are `infrastructure`, one is
+internal recovery, and four are terminal. The two that matter are the ones an
+easier map would not have:
+
+- **`runner_defect`, seven error types.** They can only be produced by this code
+  misbehaving. Filing them under infrastructure would inflate the one retry
+  count the 220-task run exists to measure, and would make the sandbox look
+  unreliable on occasions when it was fine.
+- **`ambiguous_not_attributable`, one.** `task_wall_time_exhausted` cannot be
+  attributed from the error alone: a model looping and a host crawling produce
+  the same symbol. It is recorded as undecidable rather than assigned to
+  whichever side is convenient.
+
+The map is total in both directions and the check is at import — a contract
+error nobody classified, or a classification invented for an error that does not
+exist, stops the build rather than defaulting to somebody's fault.
+
+**The guest's own time is recorded unpriced rather than free.**
+`RUNTIME_KIND_MICROVM_GUEST` is not in the price table, so its seconds go into
+the ledger with no amount and a `runtime_cost_unpriced` reason, which holds the
+task's receipt at `partial`. That is the same rule the host windows above
+follow, for the same reason: a bill this repository cannot read must not be
+allowed to look like zero.
+
+Built and tested. Nothing has run through it, because nothing has run.
 
 ### Stage F — pre-registered on 2026-09-11, not yet run
 


### PR DESCRIPTION
## What this is

The second half of the V2 startup gate, written as a change that can be
reviewed rather than as a flag that got flipped.

#517 answered the **result** half: a microVM result is judged by
`attested-execution-v1` — eight checks, three named declines — rather than by
the re-simulation a real command makes undefined. The **startup** half was
still shut, and for a reason unrelated to results: `_valid_started_payload`
reconstructed the fixture's entire startup payload (`commands ==
["fixture-upper"]`, `runtimes == ["fixture"]`, fixed package records, fixed
browser digest) and required equality. A real guest reports its own
capabilities out of its substrate manifest, so it could never have started,
whatever standard its results were later judged under.

## The change

| | |
|---|---|
| `agentic_v2_contract.py` | `MICROVM_BACKEND_ID` moves here beside the foundation's; the backend module re-exports it |
| `agentic_v2_provenance.py` | `_RESULT_STANDARD_BY_BACKEND` gains its second entry; `_valid_started_payload` splits in three; new `startup_is_admissible()` |
| `agentic_v2_runner.py` | the hard-coded admitted set becomes `admitted_identity`, a constructor argument defaulting to the fixture, validated at construction |
| `agentic_v2_microvm_backend.py` | `BACKEND_ID` becomes a re-export; the stale docstring paragraph rewritten |

The split keeps the fixture's exact-equality block **byte-for-byte unchanged**
and adds a shape-only branch for the attested standard, whose single extra rule
refuses a payload wearing the fixture's capabilities — a guest identity cannot
be worn by the fixture.

## What stayed shut

- **`foundation_only` was not relaxed.** The microVM backend reads it from its
  substrate manifest and reports `True` there, so both standards still require
  it. This change is about *which* backend may start, never about how far one
  may go.
- **`production_activation: "disabled"`** is untouched and remains an
  independent brake.
- **Nothing declares a non-default identity.**
  `test_nothing_in_this_repository_declares_a_non_default_identity` globs
  `core/*.py` to establish that rather than asserting it.
- The two guards in `step2_run_inference.py` and `core/executor.py` are where
  they were. `exec_run` on a real guest reaches nothing through the product
  path.

Admitting a guest is now an argument someone passes — an addition in a diff —
instead of a comparison someone loosens, which would be the deletion of a line
that used to say the fixture's name.

## An ordering fault fixed on the way

A startup that no standard accepted was caught only at final verification, by
which point the failure envelope being written *contained* the bad started
event and could not be verified either: a run that failed cleanly for a
nameable reason produced a record nothing downstream would accept, and the
reason was lost. `startup_is_admissible()` asks the same question before the
event is appended, so the run stops with an ordinary `compute_start_failed`
that verifies like any other failure. Its test asserts the chain holds no
`started` event at all.

`_validate_admitted_identity` raises at construction rather than failing the
run for the same class of reason: a configuration mistake surfacing as
`compute_start_failed` on every task reads as an infrastructure fault, and by
`agentic_v2_cost_binding.ERROR_DISPOSITION` it would be counted as one.

## Checked

- **2,851 passed / 4 skipped** across `-k "agentic or envelope or substrate or
  exec_boot or microvm or provenance or contract"`; 264 across the foundation,
  microVM and contract modules.
- **9 new tests.** Three old ones were rewritten because they asserted the
  one-backend world (the admitted set has one member; exactly one backend has a
  standard; the microVM id appears nowhere in the runner's source). No test was
  relaxed to pass, and no *behavioural* test failed — which is the evidence the
  fixture path is untouched.
- The attested branch is exercised rather than merely present: the guest double
  declares `commands == ["fixture-upper", "python3"]`, which the fixture branch
  rejects outright, and its run verifies. Proof by consequence rather than by
  mutation — rewriting the source in place would have corrupted the suite
  running beside it.
- `mypy` on the four changed modules: **29 errors against a 34-error baseline**
  taken from `origin/main` in a throwaway worktree. Five fewer, none introduced.

## Also in here

`tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md` records three
things the code had outrun: the second verification standard and what its three
declines mean, this change, and the cost/blame wiring from #517 that stage E
still described as unbuilt.