### PR TITLE
feat(agentic): give a V2 run a resume, a collector and a report row

### DIFF
--- a/batch-runner/core/agentic_v2_deliverable_collection.py
+++ b/batch-runner/core/agentic_v2_deliverable_collection.py
@@ -1,0 +1,337 @@
+"""Getting the guest's files onto the host, or not pretending they are there.
+
+``finalize`` ends a V2 task by naming the files the model considers its answer.
+By the time the run record exists those bytes are already in memory and already
+checked against the digests the guest declared — that is
+``verify_agentic_v2_terminal_result`` in :mod:`core.agentic_v2_provenance`, and
+it is not repeated here. What has never existed is the other half: putting them
+on the host, in the layout the submission pipeline reads, in a way that cannot
+leave a half-written answer behind.
+
+**Why a half-written collection is the failure worth designing against.** A task
+with five deliverables that writes three and then meets a full disk leaves a
+directory that looks exactly like a finished task with three deliverables.
+Nothing downstream can tell the difference: ``fill_parquet`` reads the paths,
+``step5_validate`` checks they exist, and the submission goes out short. So the
+files are written into a staging directory named after the attempt, every one is
+read back and re-hashed, and only then is the directory moved into place. An
+interrupted collection leaves a ``.collecting-…`` directory that is obviously
+not a result.
+
+**Why the bytes are hashed again after they are written.** They were hashed
+coming out of the guest. Hashing them again after the write is asking a
+different question: not *did the guest produce this*, but *is this what is on the
+host's disk now*. A short write, a filesystem that silently truncates, and a
+disk that filled between two files all produce a file that exists and is wrong.
+One extra pass over at most 64 MiB is the only way to know, and the cost of not
+knowing is a corrupt deliverable submitted under a clean name.
+
+**Why the model's directory structure is kept.** ``finalize`` takes workspace-
+relative paths, and the contract already guarantees they are unique within one
+call. Flattening them to basenames would turn ``analysis/summary.xlsx`` and
+``raw/summary.xlsx`` into one file, and the loss would look like a model that
+produced fewer deliverables than it did. The structure is carried across
+unchanged, under ``deliverable_files/<task_id>/``.
+
+**Why an existing directory is refused rather than replaced.** A second
+collection for a task that already has one means either a retry after an
+abandoned attempt or a bug, and those want opposite handling. Refusing makes the
+caller say which: :func:`discard_previous_collection` exists so that overwriting
+a previous attempt's answer is always a line somebody wrote on purpose.
+
+Nothing here runs a model, boots a guest, or decides whether a task succeeded.
+It is handed a verified result and it either puts it on disk completely or
+leaves nothing behind.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping, Sequence
+
+from core.agentic_v2_contract import canonical_relative_path
+
+
+DELIVERABLE_ROOT = "deliverable_files"
+"""The directory name the submission parquet's paths are relative to.
+
+Fixed by ``fill_parquet`` and the dataset layout, not by this module.
+"""
+
+MOST_BYTES_IN_ONE_COLLECTION = 64 * 1024 * 1024
+"""The ceiling this enforces for itself.
+
+The backend enforces the same figure when it reads the files out of the
+workspace. Checking it again here is not redundancy for its own sake: this is
+the module that writes to the host's disk, and a writer that trusts a limit
+applied somewhere else has no limit at all if that somewhere else changes.
+"""
+
+STAGING_PREFIX = ".collecting-"
+"""What an interrupted collection leaves behind, so it cannot be mistaken.
+
+A directory under this name is not a result and no reader treats it as one.
+"""
+
+
+class CollectionRefused(RuntimeError):
+    """The deliverables were not collected, and nothing was left on disk."""
+
+
+@dataclass(frozen=True)
+class CollectedDeliverable:
+    """One file, where the model put it and where it now is."""
+
+    #: Repo-relative, in the form the submission parquet stores.
+    submission_path: str
+    #: What ``finalize`` called it, inside the guest's workspace.
+    workspace_path: str
+    sha256: str
+    size: int
+
+
+@dataclass(frozen=True)
+class Collection:
+    """Everything one task's ``finalize`` produced, now on the host."""
+
+    task_id: str
+    directory: Path
+    deliverables: tuple[CollectedDeliverable, ...]
+
+    def submission_paths(self) -> list[str]:
+        """The value the pipeline's ``deliverable_files`` field takes."""
+        return [item.submission_path for item in self.deliverables]
+
+    def journal_entries(self) -> list[dict[str, Any]]:
+        """The shape :meth:`core.agentic_v2_task_journal.TaskJournal.close_task`
+        records — a path with the digest and size that were verified for it."""
+        return [
+            {
+                "path": item.submission_path,
+                "sha256": item.sha256,
+                "size": item.size,
+            }
+            for item in self.deliverables
+        ]
+
+    def total_bytes(self) -> int:
+        return sum(item.size for item in self.deliverables)
+
+
+def _task_directory_name(task_id: str) -> str:
+    """The task's own directory under ``deliverable_files``.
+
+    Validated as a single path component rather than trusted: a task id with a
+    slash in it would otherwise write one level up, and task ids come from a
+    dataset this repository does not own.
+    """
+    name = str(task_id)
+    if not name or name in {".", ".."} or "/" in name or "\\" in name:
+        raise CollectionRefused(
+            f"task id {task_id!r} is not usable as a directory name"
+        )
+    if any(ord(character) < 32 or 127 <= ord(character) <= 159 for character in name):
+        raise CollectionRefused(f"task id {task_id!r} holds a control character")
+    return name
+
+
+def _files_from(result: Mapping[str, Any]) -> Sequence[Mapping[str, Any]]:
+    if not isinstance(result, Mapping):
+        raise CollectionRefused("a result to collect from must be a mapping")
+    if result.get("success") is not True:
+        raise CollectionRefused(
+            "only a successful run has deliverables to collect; a failed one is "
+            "recorded by its error, not by an empty directory"
+        )
+    files = result.get("files")
+    if not isinstance(files, Sequence) or isinstance(files, (str, bytes)):
+        raise CollectionRefused("a result's files must be a list")
+    if not files:
+        raise CollectionRefused(
+            "a successful run with no files did not finalize anything, and an "
+            "empty collection would be indistinguishable from a lost one"
+        )
+    return files
+
+
+def _write_one(
+    *,
+    staging: Path,
+    relative: str,
+    content: bytes,
+) -> None:
+    """Write one file under the staging directory, refusing a link or a repeat."""
+    target = staging / PurePosixPath(relative)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+    try:
+        descriptor = os.open(str(target), flags, 0o644)
+    except FileExistsError:
+        raise CollectionRefused(
+            f"two deliverables both want {relative!r}; one would silently "
+            "replace the other"
+        ) from None
+    except OSError as error:
+        raise CollectionRefused(f"could not write {relative!r}: {error}") from None
+    try:
+        written = 0
+        while written < len(content):
+            written += os.write(descriptor, content[written:])
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _verify_on_disk(staging: Path, relative: str, expected: str, size: int) -> None:
+    """Read back what was just written and insist it is the same file."""
+    target = staging / PurePosixPath(relative)
+    digest = hashlib.sha256()
+    seen = 0
+    with open(target, "rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            seen += len(chunk)
+            digest.update(chunk)
+    if seen != size or digest.hexdigest() != expected:
+        raise CollectionRefused(
+            f"{relative!r} is not on disk as it came out of the guest "
+            f"({seen} bytes, {digest.hexdigest()[:12]}…, expected {size} bytes, "
+            f"{expected[:12]}…)"
+        )
+
+
+def collect_deliverables(
+    result: Mapping[str, Any],
+    *,
+    task_id: str,
+    into: str | Path,
+    attempt_name: str,
+) -> Collection:
+    """Put one task's deliverables on the host, completely or not at all.
+
+    ``attempt_name`` names the staging directory and must be unique per
+    attempt; :func:`core.agentic_v2_task_journal.workspace_name_for` produces
+    exactly such a name, which is why the two are meant to be used together. A
+    reused name would let a second attempt write into the first one's staging
+    directory and inherit its files.
+    """
+    files = _files_from(result)
+    root = Path(into) / DELIVERABLE_ROOT
+    directory = root / _task_directory_name(task_id)
+    if directory.exists():
+        raise CollectionRefused(
+            f"{directory} already holds a collection for this task; clear it "
+            "with discard_previous_collection if replacing it is intended"
+        )
+    if not attempt_name or "/" in attempt_name or attempt_name.startswith("."):
+        raise CollectionRefused(f"attempt name {attempt_name!r} is not usable")
+
+    staging = root / f"{STAGING_PREFIX}{attempt_name}"
+    if staging.exists():
+        shutil.rmtree(staging)
+    staging.mkdir(parents=True)
+
+    collected: list[CollectedDeliverable] = []
+    total = 0
+    try:
+        for entry in files:
+            if not isinstance(entry, Mapping):
+                raise CollectionRefused("a file entry must be a mapping")
+            content = entry.get("content")
+            if not isinstance(content, bytes):
+                raise CollectionRefused(
+                    "a deliverable's content must be bytes; text would have "
+                    "been decoded somewhere and a spreadsheet does not survive "
+                    "that"
+                )
+            try:
+                relative = canonical_relative_path(entry.get("filename"))
+            except ValueError as error:
+                raise CollectionRefused(
+                    f"deliverable path {entry.get('filename')!r} is not a "
+                    f"canonical relative path: {error}"
+                ) from None
+            if relative == ".":
+                raise CollectionRefused("a deliverable cannot be the directory")
+            total += len(content)
+            if total > MOST_BYTES_IN_ONE_COLLECTION:
+                raise CollectionRefused(
+                    f"this task's deliverables exceed "
+                    f"{MOST_BYTES_IN_ONE_COLLECTION} bytes"
+                )
+            digest = hashlib.sha256(content).hexdigest()
+            _write_one(staging=staging, relative=relative, content=content)
+            _verify_on_disk(staging, relative, digest, len(content))
+            collected.append(
+                CollectedDeliverable(
+                    submission_path=(
+                        f"{DELIVERABLE_ROOT}/{_task_directory_name(task_id)}/"
+                        f"{relative}"
+                    ),
+                    workspace_path=relative,
+                    sha256=digest,
+                    size=len(content),
+                )
+            )
+
+        directory.parent.mkdir(parents=True, exist_ok=True)
+        os.replace(staging, directory)
+    except BaseException:
+        # Including KeyboardInterrupt: a staging directory left where a result
+        # belongs is exactly the confusion this module exists to prevent.
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+    _fsync_directory(directory.parent)
+    return Collection(
+        task_id=str(task_id),
+        directory=directory,
+        deliverables=tuple(collected),
+    )
+
+
+def _fsync_directory(where: Path) -> None:
+    descriptor = os.open(str(where), os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def discard_previous_collection(into: str | Path, task_id: str) -> bool:
+    """Remove a task's collected deliverables, deliberately.
+
+    Returns whether there was anything to remove. Separate from
+    :func:`collect_deliverables` so that throwing away a previous attempt's
+    answer is never something that happens as a side effect of retrying.
+    """
+    directory = Path(into) / DELIVERABLE_ROOT / _task_directory_name(task_id)
+    if not directory.exists():
+        return False
+    if not directory.is_dir():
+        raise CollectionRefused(f"{directory} is not a directory")
+    shutil.rmtree(directory)
+    return True
+
+
+def abandoned_collections(into: str | Path) -> list[Path]:
+    """Staging directories left by collections that were interrupted.
+
+    Worth reporting rather than cleaning silently: each one is a task that
+    spent money and produced files that never reached the submission, and that
+    is a line in the run's account of itself.
+    """
+    root = Path(into) / DELIVERABLE_ROOT
+    if not root.is_dir():
+        return []
+    return sorted(
+        child
+        for child in root.iterdir()
+        if child.is_dir() and child.name.startswith(STAGING_PREFIX)
+    )

--- a/batch-runner/core/agentic_v2_run_report.py
+++ b/batch-runner/core/agentic_v2_run_report.py
@@ -1,0 +1,299 @@
+"""Turning what a V2 task actually did into the row the report already reads.
+
+Step 6 renders whatever step 3 wrote. It reads a per-task row with a ``status``,
+a deliverable count, a cost receipt and an ``observability.agentic_metrics``
+block, and it has read that shape since the V1 agentic runner. A V2 run that
+produced results and no row would be a run whose report says nothing happened.
+
+So this is the adapter, and it exists as its own module for the same reason
+:mod:`core.agentic_v2_cost_binding` does: the report is shared with other work
+and binding a backend to it should not mean editing it.
+
+Three things it refuses to smooth over.
+
+**A cost nobody priced is not ``$0``.** The report's ``conservative_cost_usd``
+is summed as a plain float, so writing a zero there for an unpriced run would
+put a wrong number in a headline. The receipt is where the truth lives —
+``problem_solving_cost`` carries ``partial`` or ``unavailable`` with its reasons
+— so ``conservative_cost_usd`` is written only when the receipt is
+:data:`~core.cost_receipts.STATUS_COMPLETE` and is otherwise absent. An absent
+key contributes nothing and claims nothing; a zero claims something false.
+
+**The report's per-tool breakdown is V1's and will read zero for V2.** Its tool
+names are ``inspect_workspace``, ``run_python`` and the rest. V2's are
+``exec_run``, ``environment_resolve`` and the rest, and the two sets do not
+overlap at all — :data:`TOOL_NAMES_THE_REPORT_KNOWS` is checked against the
+contract's at import, so this cannot quietly become half-true. The honest
+handling is to write the V2 counts under their own names, where a reader can
+find them, and to state here that the report's ``tool_calls_by_name`` will show
+zeros until the report itself learns V2's vocabulary. That is a change to a
+shared file and it is not made from here.
+
+**An attempt that vanished is part of the task's story.** The journal knows a
+task was opened and never closed; nothing in the report's vocabulary does. The
+count is carried through so that a task which cost money twice and succeeded
+once is not reported as a task that cost money once.
+
+Nothing here runs a model, prices a call, or decides whether a task succeeded.
+It is handed facts that were established elsewhere and arranges them.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from core.agentic_v2_contract import TOOL_NAMES
+from core.agentic_v2_cost_binding import describe_run_outcome
+from core.agentic_v2_task_journal import (
+    DECISION_SKIP_FINISHED,
+    TaskStanding,
+)
+from core.cost_receipts import (
+    STATUS_COMPLETE,
+    STATUS_NOT_RUN,
+    STATUS_PARTIAL,
+    STATUS_UNAVAILABLE,
+)
+
+
+AGENTIC_V2_METRICS_SCHEMA_VERSION = "agentic-v2-report-row-v1"
+
+STATUS_SUCCESS = "success"
+STATUS_ERROR = "error"
+
+#: The tool names ``step6_report._compute_agentic_metrics`` buckets calls under.
+#:
+#: Copied here so the mismatch with V2 can be asserted rather than described.
+#: If the report ever learns V2's vocabulary this constant stops matching it and
+#: the test that guards it fails, which is the point.
+TOOL_NAMES_THE_REPORT_KNOWS = (
+    "inspect_workspace",
+    "inspect_environment",
+    "run_python",
+    "run_ffmpeg",
+    "inspect_artifacts",
+    "finalize",
+)
+
+#: What V2 calls its tools, in the order the contract lists them.
+TOOL_NAMES_V2_USES = TOOL_NAMES
+
+#: The one name both vocabularies share.
+#:
+#: ``finalize`` means the same thing in both, so its count *will* appear in the
+#: report's existing breakdown. Every other V2 tool will not, and a reader who
+#: sees a lone non-zero ``finalize`` beside five zeros would reasonably conclude
+#: the model used one tool. Naming the overlap is what makes that conclusion
+#: checkable instead of surprising.
+SHARED_TOOL_NAMES = tuple(
+    name for name in TOOL_NAMES_V2_USES if name in TOOL_NAMES_THE_REPORT_KNOWS
+)
+
+if set(SHARED_TOOL_NAMES) != {"finalize"}:  # pragma: no cover - import guard
+    raise RuntimeError(
+        "the report's tool vocabulary and V2's now overlap differently than "
+        f"recorded: {sorted(SHARED_TOOL_NAMES)}"
+    )
+
+
+class ReportRowRefused(RuntimeError):
+    """The row was not built, because building it would have stated something
+    that is not known."""
+
+
+def _tool_counts(calls: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts = {name: 0 for name in TOOL_NAMES_V2_USES}
+    for call in calls:
+        name = call.get("tool_name") if isinstance(call, Mapping) else None
+        if name not in counts:
+            raise ReportRowRefused(
+                f"a recorded call names a tool the contract does not have: "
+                f"{name!r}"
+            )
+        counts[name] += 1
+    return counts
+
+
+def _receipt_status(receipt: Mapping[str, Any] | None) -> str:
+    if receipt is None:
+        return STATUS_NOT_RUN
+    status = receipt.get("status")
+    if status not in (
+        STATUS_COMPLETE,
+        STATUS_PARTIAL,
+        STATUS_UNAVAILABLE,
+        STATUS_NOT_RUN,
+    ):
+        raise ReportRowRefused(f"{status!r} is not a receipt status")
+    return str(status)
+
+
+def build_agentic_v2_metrics(
+    run_record: Mapping[str, Any],
+    *,
+    standing: TaskStanding,
+    tool_calls: Sequence[Mapping[str, Any]] = (),
+    model_api_calls: int = 0,
+    input_tokens: int | None = None,
+    output_tokens: int | None = None,
+    task_wall_time_ms: float | None = None,
+    receipt: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """The ``observability.agentic_metrics`` block for one V2 task.
+
+    ``task_wall_time_ms`` is what makes the report count this task as measured
+    at all, so a run that did not time itself is refused rather than reported
+    as a task nobody ran.
+    """
+    if task_wall_time_ms is None:
+        raise ReportRowRefused(
+            "a task with no measured wall time is invisible to the report's "
+            "agentic metrics; record the time or do not claim the task ran"
+        )
+    outcome = describe_run_outcome(run_record)
+    counts = _tool_counts(tool_calls)
+    status = _receipt_status(receipt)
+    cost_is_known = status == STATUS_COMPLETE and standing.cost_is_fully_accounted
+
+    metrics: dict[str, Any] = {
+        "schema_version": AGENTIC_V2_METRICS_SCHEMA_VERSION,
+        "task_wall_time_ms": float(task_wall_time_ms),
+        "model_api_calls": int(model_api_calls),
+        "tool_calls": sum(counts.values()),
+        "tool_errors": 0 if outcome["succeeded"] else 1,
+        "tool_calls_by_name": counts,
+        "terminal_error_category": outcome["error_type"] or "",
+        "usage_complete": cost_is_known,
+        # V2's own fields. The report does not read these yet; they are here so
+        # that when it does, nothing has to be reconstructed from a log.
+        "agentic_v2_disposition": outcome["disposition"],
+        "agentic_v2_attributable_to": outcome["attributable_to"],
+        "agentic_v2_attempts": standing.attempts,
+        "agentic_v2_abandoned_attempts": standing.abandoned_attempts,
+        "agentic_v2_cost_receipt_status": status,
+    }
+    if input_tokens is not None:
+        metrics["input_tokens"] = int(input_tokens)
+    if output_tokens is not None:
+        metrics["output_tokens"] = int(output_tokens)
+    if cost_is_known:
+        # ``estimated_cost_usd`` rather than ``known_cost_usd``: the receipt
+        # documents the first as the only field that claims to be a total, and
+        # it is ``None`` on anything but a complete receipt, so reading it makes
+        # the gate above belt-and-braces instead of the sole guard.
+        amount = receipt.get("estimated_cost_usd") if receipt else None
+        if isinstance(amount, (int, float)) and not isinstance(amount, bool):
+            metrics["conservative_cost_usd"] = float(amount)
+    # No else. A run whose cost is not fully known writes no amount at all,
+    # because the report sums this field as a plain float and a zero there
+    # would be read as "this task was free".
+    return metrics
+
+
+def build_result_row(
+    run_record: Mapping[str, Any],
+    *,
+    task_id: str,
+    standing: TaskStanding,
+    sector: str = "",
+    occupation: str = "",
+    instruction: str = "",
+    deliverable_files: Sequence[str] = (),
+    latency_ms: float | None = None,
+    metrics: Mapping[str, Any],
+    receipt: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """One V2 task as the row step 3 writes and step 6 renders.
+
+    The deliverable paths are the ones
+    :meth:`core.agentic_v2_deliverable_collection.Collection.submission_paths`
+    returned — that is, paths that were written and read back — rather than the
+    ones the model named. A row whose file list came from the model's own
+    ``finalize`` would claim files that a failed collection never put on disk.
+    """
+    outcome = describe_run_outcome(run_record)
+    files = list(deliverable_files)
+    if outcome["succeeded"] and not files:
+        raise ReportRowRefused(
+            f"task {task_id!r} succeeded with no collected deliverables; a "
+            "successful row with an empty file list reads as a model that "
+            "produced nothing"
+        )
+    if not outcome["succeeded"] and files:
+        raise ReportRowRefused(
+            f"task {task_id!r} failed and yet carries {len(files)} deliverable "
+            "paths; a failed task's partial files are not its answer"
+        )
+
+    row: dict[str, Any] = {
+        "task_id": str(task_id),
+        "sector": str(sector),
+        "occupation": str(occupation),
+        "status": STATUS_SUCCESS if outcome["succeeded"] else STATUS_ERROR,
+        "retried": standing.attempts > 1,
+        "instruction": str(instruction),
+        "deliverable_text": str(run_record.get("deliverable_text") or ""),
+        "deliverable_files": files,
+        "deliverable_files_count": len(files),
+        "latency_ms": latency_ms,
+        "observability": {"agentic_metrics": dict(metrics)},
+    }
+    if not outcome["succeeded"]:
+        row["error"] = outcome["error_type"]
+    if receipt is not None:
+        # Absent stays absent: a task with no receipt gains no key, so the
+        # dashboard can tell "not recorded" from "recorded as nothing".
+        row["problem_solving_cost"] = dict(receipt)
+    return row
+
+
+def summarise_v2_run(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    manifest_size: int,
+    receipt_ceiling: str,
+) -> dict[str, Any]:
+    """What the whole run did, with its three milestones kept apart.
+
+    Environment readiness, execution and grading are separate claims and the
+    summary says so in separate fields. A run that executed 220 tasks and graded
+    none must not be readable as a run that graded 220, so ``graded`` is
+    ``None`` with a stated reason rather than ``0`` — zero graded and grading
+    not attempted look identical as a number and are not the same fact.
+    """
+    dispositions: dict[str, int] = {}
+    abandoned = 0
+    succeeded = 0
+    for row in rows:
+        metrics = (row.get("observability") or {}).get("agentic_metrics") or {}
+        disposition = metrics.get("agentic_v2_disposition")
+        if disposition:
+            dispositions[disposition] = dispositions.get(disposition, 0) + 1
+        abandoned += int(metrics.get("agentic_v2_abandoned_attempts") or 0)
+        if row.get("status") == STATUS_SUCCESS:
+            succeeded += 1
+
+    return {
+        "schema_version": AGENTIC_V2_METRICS_SCHEMA_VERSION,
+        "manifest_size": int(manifest_size),
+        "rows_written": len(rows),
+        "executed": len(rows),
+        "succeeded": succeeded,
+        "failed": len(rows) - succeeded,
+        "not_reached": max(0, int(manifest_size) - len(rows)),
+        "abandoned_attempts": abandoned,
+        "dispositions": dict(sorted(dispositions.items())),
+        "receipt_ceiling": str(receipt_ceiling),
+        "cost_is_fully_accounted": receipt_ceiling == STATUS_COMPLETE,
+        "graded": None,
+        "graded_reason": "grading is a separate run and has not been made",
+    }
+
+
+def finished_tasks(standings: Sequence[TaskStanding]) -> tuple[str, ...]:
+    """The task ids the journal considers done, in manifest order."""
+    return tuple(
+        standing.task_id
+        for standing in standings
+        if standing.decision == DECISION_SKIP_FINISHED
+    )

--- a/batch-runner/core/agentic_v2_task_journal.py
+++ b/batch-runner/core/agentic_v2_task_journal.py
@@ -1,0 +1,795 @@
+"""What a 220-task run has already done, written down before it becomes true.
+
+A run over 220 tasks takes hours, and hours is long enough that it will be
+interrupted — a runner restarted, a host reclaimed, a wall clock reached. So it
+has to be resumable, and the resume has to answer one question per task: *was
+this finished, and if not, what has already been spent on it?*
+
+**Why the obvious journal is wrong.** The obvious journal writes one record per
+task when the task ends. If the process dies during task 137 there is no record
+for 137, so a resume re-runs it — which is right about the work and wrong about
+the money. The first attempt's model calls were made and charged, and they are
+now invisible to the run's own accounting. Over a few interruptions the run
+under-reports its own cost, which is the precise failure the rule *a missing
+cost is partial, never zero* exists to stop. A journal that only records
+endings cannot distinguish a task that never started from one that started,
+cost money, and vanished.
+
+So there are **two records per attempt**, and the first is written *before* the
+work:
+
+``opened``
+    Flushed to disk before the first model call. It names the task, the attempt
+    number, the workspace that attempt owns, and the stage the spend will be
+    booked under. Its only purpose is to exist when the process dies.
+
+``closed``
+    Written once the outcome is known. It names the disposition, the
+    deliverables that were carried out, and whether the cost was settled.
+
+An ``opened`` with no ``closed`` is the signature of an interruption, and it is
+the only thing in this repository that can tell one apart from a task that was
+never reached.
+
+**What resume is allowed to conclude.** Four states, and the decision is total
+over them:
+
+===========================  ==========================================
+state                        decision
+===========================  ==========================================
+no record                    run it, as attempt 1
+opened + closed(finished)    skip it — it is done
+opened + closed(failed)      run it again if the disposition is
+                             retryable, otherwise skip it as a settled
+                             failure
+opened, no closed            run it again — **and carry the abandoned
+                             attempt forward**, so the task's receipt can
+                             never afterwards claim to be complete
+===========================  ==========================================
+
+**Where attempt numbers come from.** Nowhere, until now.
+:func:`core.cost_receipts.make_call_id` derives a call's ledger name partly from
+``attempt_index``, which is what keeps a retry's rows from colliding with the
+rows of the attempt it is replacing. Nothing owned that number. This journal
+does: it hands one out only after the intent to spend is on disk, so a crashed
+attempt's number is never reissued and its ledger rows keep their own names
+rather than being overwritten by the attempt that followed.
+
+**Per-task isolation, as a refusal rather than a convention.** Each attempt is
+given its own workspace name and the journal refuses to hand the same one out
+twice. Two tasks sharing a directory would cross-contaminate deliverables in a
+way that reads, afterwards, as a model that produced someone else's file. A
+resumed attempt gets a *new* directory rather than the dead one's, because a
+half-written workspace left by a killed process boots into a guest and produces
+work that looks like the model's and is not.
+
+**Refusing to resume into a different run.** The header record holds the run id
+and a digest of the fixed task manifest. Appending to a journal whose header
+disagrees is refused. Resuming a 220-task run against a different task list
+would silently change what "finished" means, and the change would surface as a
+coverage figure nobody could reproduce.
+
+**Surviving the kill it exists for.** Records are appended as one line each and
+``fsync``-ed, and the containing directory is ``fsync``-ed when the file is
+first created, so the file itself survives too. A *last* line that is torn —
+the process died mid-write — is dropped, because a journal that refuses to load
+after a crash is a journal that does not work at the one moment it is for. A
+torn line anywhere *earlier* is refused: that is not an interruption, it is
+corruption, and continuing past it would silently drop attempts.
+
+Dropping the torn tail is safe in one direction and only because of the
+ordering. An ``opened`` record is flushed *before* :meth:`TaskJournal.open_task`
+returns, so a torn ``opened`` means the caller never got its attempt number and
+never made a call — there is no spend to lose. A torn ``closed`` leaves an
+attempt looking abandoned, which over-states what was lost rather than
+under-stating it. Both errors fall on the side that cannot make a receipt claim
+more than it should.
+
+This module writes no ledger rows, contacts no provider, boots nothing and
+opens nothing. It records and it refuses.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+from core.agentic_v2_cost_binding import (
+    RETRYABLE_DISPOSITIONS,
+    disposition_for_error,
+)
+from core.agentic_v2_provenance import canonical_sha256
+from core.cost_receipts import STAGE_GENERATION, STATUS_COMPLETE, STATUS_PARTIAL
+
+
+JOURNAL_SCHEMA_VERSION = "agentic-v2-task-journal-v1"
+"""Written into the header and checked on load.
+
+A journal read by code that expects different fields is worse than an
+unreadable one, because it produces a resume plan rather than an error.
+"""
+
+RECORD_HEADER = "header"
+RECORD_OPENED = "opened"
+RECORD_CLOSED = "closed"
+
+RECORD_KINDS = (RECORD_HEADER, RECORD_OPENED, RECORD_CLOSED)
+
+OUTCOME_FINISHED = "finished"
+"""The task produced its deliverables and they were carried out of the guest."""
+
+OUTCOME_FAILED = "failed"
+"""The attempt ended with one of the contract's error types."""
+
+OUTCOMES = (OUTCOME_FINISHED, OUTCOME_FAILED)
+
+DECISION_RUN = "run_it"
+DECISION_SKIP_FINISHED = "skip_it_finished"
+DECISION_SKIP_SETTLED_FAILURE = "skip_it_settled_failure"
+
+DECISIONS = (DECISION_RUN, DECISION_SKIP_FINISHED, DECISION_SKIP_SETTLED_FAILURE)
+
+#: How many attempts one task may be given before the run stops trying.
+#:
+#: Present so that a task failing for a reason that *looks* retryable and is
+#: not — a semantic failure the model reproduces every time — cannot spend the
+#: run's whole budget by itself. The ceiling is low on purpose: the point of a
+#: retry here is to survive an interruption, not to sample the model until it
+#: succeeds.
+MOST_ATTEMPTS_PER_TASK = 3
+
+#: How much of a task id survives into a workspace directory name.
+#:
+#: Truncation alone would let two long ids collide, so the full id's digest is
+#: appended; see :func:`workspace_name_for`.
+MOST_CHARACTERS_FROM_A_TASK_ID = 48
+
+
+class JournalRefused(RuntimeError):
+    """The journal will not do what was asked, and nothing was written."""
+
+
+class JournalCorrupt(JournalRefused):
+    """The file on disk is not a journal this can safely continue from."""
+
+
+# ---------------------------------------------------------------------------
+# What is on disk
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class OpenedAttempt:
+    """An intent to spend, recorded before anything was spent."""
+
+    task_id: str
+    attempt_index: int
+    workspace_name: str
+    stage: str
+    opened_at: float
+
+
+@dataclass(frozen=True)
+class ClosedAttempt:
+    """How one attempt ended, once that was known."""
+
+    task_id: str
+    attempt_index: int
+    outcome: str
+    error_type: str | None
+    disposition: str | None
+    deliverables: tuple[Mapping[str, Any], ...]
+    cost_settled: bool
+    closed_at: float
+
+
+@dataclass(frozen=True)
+class TaskStanding:
+    """Everything the journal knows about one task, resolved.
+
+    ``abandoned_attempts`` is the count of attempts that were opened and never
+    closed. It is the number that stops a receipt claiming to be complete.
+    """
+
+    task_id: str
+    attempts: int
+    abandoned_attempts: int
+    last_closed: ClosedAttempt | None
+    decision: str
+    reason: str
+
+    @property
+    def cost_is_fully_accounted(self) -> bool:
+        """Whether every attempt on this task reached a settled cost.
+
+        False whenever an attempt was abandoned, and false when the attempt
+        that closed said its cost had not been settled. Either way the spend
+        exists and this run cannot name it.
+        """
+        if self.abandoned_attempts:
+            return False
+        if self.last_closed is None:
+            return True
+        return self.last_closed.cost_settled
+
+
+@dataclass
+class JournalState:
+    """A journal read back off disk."""
+
+    run_id: str
+    manifest_sha256: str
+    schema_version: str
+    opened: list[OpenedAttempt] = field(default_factory=list)
+    closed: list[ClosedAttempt] = field(default_factory=list)
+    #: True when the final line was a partial write and was dropped.
+    dropped_torn_tail: bool = False
+
+    def attempts_for(self, task_id: str) -> list[OpenedAttempt]:
+        return [record for record in self.opened if record.task_id == task_id]
+
+    def closes_for(self, task_id: str) -> list[ClosedAttempt]:
+        return [record for record in self.closed if record.task_id == task_id]
+
+    def workspace_names(self) -> set[str]:
+        return {record.workspace_name for record in self.opened}
+
+
+@dataclass(frozen=True)
+class ResumePlan:
+    """What a resumed run should do with each task in the manifest."""
+
+    run_id: str
+    standings: tuple[TaskStanding, ...]
+
+    def to_run(self) -> tuple[str, ...]:
+        return tuple(
+            standing.task_id
+            for standing in self.standings
+            if standing.decision == DECISION_RUN
+        )
+
+    def receipt_ceiling(self) -> str:
+        """The best status this run's receipt may claim, given what was lost.
+
+        A ceiling, never a verdict: the journal can lower what a receipt is
+        allowed to say and can never raise it. Anything abandoned puts the run
+        at :data:`core.cost_receipts.STATUS_PARTIAL` permanently, because the
+        spend happened and no row names it.
+        """
+        if all(standing.cost_is_fully_accounted for standing in self.standings):
+            return STATUS_COMPLETE
+        return STATUS_PARTIAL
+
+    def unaccounted_tasks(self) -> tuple[str, ...]:
+        return tuple(
+            standing.task_id
+            for standing in self.standings
+            if not standing.cost_is_fully_accounted
+        )
+
+
+# ---------------------------------------------------------------------------
+# Names
+# ---------------------------------------------------------------------------
+
+
+def manifest_digest(task_ids: Sequence[str]) -> str:
+    """A digest of the fixed task list, order included.
+
+    Order is part of it because a run that executes the same 220 tasks in a
+    different order is a different run for every purpose that matters here:
+    which tasks a wall clock cut off, and which were reached at all.
+    """
+    ids = [str(value) for value in task_ids]
+    if not ids:
+        raise JournalRefused("a task manifest with no tasks in it is not a manifest")
+    if len(set(ids)) != len(ids):
+        raise JournalRefused("a task manifest may not name the same task twice")
+    return canonical_sha256(ids)
+
+
+def workspace_name_for(task_id: str, attempt_index: int) -> str:
+    """A directory name for one attempt that no other attempt will be given.
+
+    The task id is cleaned to what a filesystem and a jailer will both accept
+    and truncated; the truncation is made safe by appending eight hex
+    characters of the full id, so two long ids sharing a prefix do not share a
+    workspace.
+    """
+    if not isinstance(attempt_index, int) or isinstance(attempt_index, bool):
+        raise JournalRefused(f"attempt index {attempt_index!r} is not a number")
+    if attempt_index < 1:
+        raise JournalRefused("attempt numbering starts at 1")
+    raw = str(task_id)
+    if not raw:
+        raise JournalRefused("a task with no id cannot be given a workspace")
+    cleaned = "".join(
+        character if (character.isalnum() or character in "-_") else "-"
+        for character in raw
+    )
+    stem = cleaned.strip("-")[:MOST_CHARACTERS_FROM_A_TASK_ID] or "task"
+    if not stem[0].isalnum():
+        stem = f"t{stem}"
+    tail = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:8]
+    return f"{stem}-{tail}-a{attempt_index:02d}"
+
+
+# ---------------------------------------------------------------------------
+# Reading
+# ---------------------------------------------------------------------------
+
+
+def _line_records(path: Path) -> tuple[list[Mapping[str, Any]], bool]:
+    """Every complete record in the file, and whether a torn tail was dropped.
+
+    Records are written ASCII-only, so a write cut in half cannot leave an
+    undecodable byte sequence behind — the damage is always a short line, which
+    is a thing this can see.
+    """
+    text = path.read_text(encoding="utf-8")
+    if not text:
+        raise JournalCorrupt(f"journal {path} is empty and has no header")
+    lines = text.split("\n")
+    dropped = False
+    if lines and lines[-1] == "":
+        lines.pop()
+    else:
+        # No trailing newline: the last write did not finish.
+        dropped = True
+        lines.pop()
+    records: list[Mapping[str, Any]] = []
+    for number, line in enumerate(lines, start=1):
+        try:
+            value = json.loads(line)
+        except ValueError as error:
+            raise JournalCorrupt(
+                f"journal {path} line {number} is not a record, and it is not "
+                f"the last line, so this is corruption rather than an "
+                f"interruption: {error}"
+            ) from None
+        if not isinstance(value, Mapping):
+            raise JournalCorrupt(f"journal {path} line {number} is not an object")
+        records.append(value)
+    return records, dropped
+
+
+def _read_opened(value: Mapping[str, Any]) -> OpenedAttempt:
+    return OpenedAttempt(
+        task_id=str(value["task_id"]),
+        attempt_index=int(value["attempt_index"]),
+        workspace_name=str(value["workspace_name"]),
+        stage=str(value["stage"]),
+        opened_at=float(value["at"]),
+    )
+
+
+def _read_closed(value: Mapping[str, Any]) -> ClosedAttempt:
+    deliverables = value.get("deliverables") or ()
+    if not isinstance(deliverables, Sequence) or isinstance(deliverables, (str, bytes)):
+        raise JournalCorrupt("a closed record's deliverables must be a list")
+    outcome = str(value["outcome"])
+    if outcome not in OUTCOMES:
+        raise JournalCorrupt(f"a closed record names an unknown outcome {outcome!r}")
+    error_type = value.get("error_type")
+    return ClosedAttempt(
+        task_id=str(value["task_id"]),
+        attempt_index=int(value["attempt_index"]),
+        outcome=outcome,
+        error_type=None if error_type is None else str(error_type),
+        disposition=(
+            None if value.get("disposition") is None else str(value["disposition"])
+        ),
+        deliverables=tuple(dict(entry) for entry in deliverables),
+        cost_settled=bool(value["cost_settled"]),
+        closed_at=float(value["at"]),
+    )
+
+
+def read_journal(path: str | Path) -> JournalState:
+    """Load a journal, dropping a torn final line and refusing an earlier one."""
+    where = Path(path)
+    try:
+        records, dropped = _line_records(where)
+    except FileNotFoundError:
+        raise JournalRefused(f"there is no journal at {where}") from None
+    if not records:
+        raise JournalCorrupt(f"journal {where} holds no complete record")
+
+    head = records[0]
+    if head.get("kind") != RECORD_HEADER:
+        raise JournalCorrupt(f"journal {where} does not begin with a header")
+    try:
+        state = JournalState(
+            run_id=str(head["run_id"]),
+            manifest_sha256=str(head["manifest_sha256"]),
+            schema_version=str(head["schema_version"]),
+            dropped_torn_tail=dropped,
+        )
+    except KeyError as error:
+        raise JournalCorrupt(f"journal {where} header is missing {error}") from None
+    if state.schema_version != JOURNAL_SCHEMA_VERSION:
+        raise JournalCorrupt(
+            f"journal {where} was written under {state.schema_version!r} and this "
+            f"is {JOURNAL_SCHEMA_VERSION!r}"
+        )
+
+    for number, value in enumerate(records[1:], start=2):
+        kind = value.get("kind")
+        try:
+            if kind == RECORD_OPENED:
+                state.opened.append(_read_opened(value))
+            elif kind == RECORD_CLOSED:
+                state.closed.append(_read_closed(value))
+            elif kind == RECORD_HEADER:
+                raise JournalCorrupt(
+                    f"journal {where} has a second header at line {number}"
+                )
+            else:
+                raise JournalCorrupt(
+                    f"journal {where} line {number} is of unknown kind {kind!r}"
+                )
+        except (KeyError, TypeError, ValueError) as error:
+            if isinstance(error, JournalCorrupt):
+                raise
+            raise JournalCorrupt(
+                f"journal {where} line {number} is malformed: {error}"
+            ) from None
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Deciding
+# ---------------------------------------------------------------------------
+
+
+def _standing_for(state: JournalState, task_id: str) -> TaskStanding:
+    opens = state.attempts_for(task_id)
+    closes = state.closes_for(task_id)
+    closed_indices = {record.attempt_index for record in closes}
+    abandoned = sum(
+        1 for record in opens if record.attempt_index not in closed_indices
+    )
+    last_closed = closes[-1] if closes else None
+
+    if not opens:
+        return TaskStanding(
+            task_id=task_id,
+            attempts=0,
+            abandoned_attempts=0,
+            last_closed=None,
+            decision=DECISION_RUN,
+            reason="never attempted",
+        )
+
+    if last_closed is not None and last_closed.outcome == OUTCOME_FINISHED:
+        return TaskStanding(
+            task_id=task_id,
+            attempts=len(opens),
+            abandoned_attempts=abandoned,
+            last_closed=last_closed,
+            decision=DECISION_SKIP_FINISHED,
+            reason="finished, with deliverables carried out",
+        )
+
+    if len(opens) >= MOST_ATTEMPTS_PER_TASK:
+        return TaskStanding(
+            task_id=task_id,
+            attempts=len(opens),
+            abandoned_attempts=abandoned,
+            last_closed=last_closed,
+            decision=DECISION_SKIP_SETTLED_FAILURE,
+            reason=(
+                f"{len(opens)} attempts is the ceiling; a further one would "
+                "spend without evidence that it would end differently"
+            ),
+        )
+
+    if abandoned and (last_closed is None or last_closed.attempt_index < max(
+        record.attempt_index for record in opens
+    )):
+        return TaskStanding(
+            task_id=task_id,
+            attempts=len(opens),
+            abandoned_attempts=abandoned,
+            last_closed=last_closed,
+            decision=DECISION_RUN,
+            reason=(
+                "the last attempt was interrupted before it could say how it "
+                "ended; its spend is real and is carried forward"
+            ),
+        )
+
+    if last_closed is None:  # pragma: no cover - unreachable by construction
+        # Every open attempt is either closed or abandoned, and the abandoned
+        # case returned above. Raising rather than asserting because `assert`
+        # is removed under -O, and a silent fall-through here would decide a
+        # task's fate from nothing.
+        raise JournalCorrupt(
+            f"task {task_id!r} has open attempts, none abandoned, and no close"
+        )
+    if last_closed.disposition in RETRYABLE_DISPOSITIONS:
+        return TaskStanding(
+            task_id=task_id,
+            attempts=len(opens),
+            abandoned_attempts=abandoned,
+            last_closed=last_closed,
+            decision=DECISION_RUN,
+            reason=f"failed with a retryable disposition: {last_closed.disposition}",
+        )
+    return TaskStanding(
+        task_id=task_id,
+        attempts=len(opens),
+        abandoned_attempts=abandoned,
+        last_closed=last_closed,
+        decision=DECISION_SKIP_SETTLED_FAILURE,
+        reason=(
+            f"failed with {last_closed.disposition!r}, which a further attempt "
+            "would not change"
+        ),
+    )
+
+
+def plan_resume(state: JournalState, task_ids: Sequence[str]) -> ResumePlan:
+    """Decide, for every task in the fixed manifest, what a resume should do.
+
+    Refuses a manifest that is not the one the journal was opened against. A
+    resume against a different task list would quietly redefine what "finished"
+    means for the run, and the redefinition would only ever surface as a
+    coverage figure that could not be reproduced.
+    """
+    digest = manifest_digest(task_ids)
+    if digest != state.manifest_sha256:
+        raise JournalRefused(
+            "this journal was opened against a different task manifest "
+            f"({state.manifest_sha256[:12]}…, and this one is {digest[:12]}…). "
+            "Resuming across manifests would change what the run covers"
+        )
+    known = set(task_ids)
+    strays = sorted({record.task_id for record in state.opened} - known)
+    if strays:
+        raise JournalRefused(
+            f"the journal holds attempts on tasks the manifest does not name: "
+            f"{strays[:5]}"
+        )
+    return ResumePlan(
+        run_id=state.run_id,
+        standings=tuple(_standing_for(state, task_id) for task_id in task_ids),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Writing
+# ---------------------------------------------------------------------------
+
+
+class TaskJournal:
+    """The append-only record a resumable run is driven from.
+
+    One instance owns one file. Opening an existing file adopts its contents
+    after checking that the run and the manifest are the same ones — so a
+    restarted process continues the journal it left rather than starting a
+    second one beside it.
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        run_id: str,
+        task_ids: Sequence[str],
+        stage: str = STAGE_GENERATION,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self.path = Path(path)
+        self.run_id = str(run_id)
+        self.task_ids = tuple(str(value) for value in task_ids)
+        self.manifest_sha256 = manifest_digest(self.task_ids)
+        self.stage = str(stage)
+        self._clock = clock
+        self._known = set(self.task_ids)
+        self._open_task: OpenedAttempt | None = None
+
+        if self.path.exists() and self.path.stat().st_size > 0:
+            state = read_journal(self.path)
+            if state.run_id != self.run_id:
+                raise JournalRefused(
+                    f"journal {self.path} belongs to run {state.run_id!r} and this "
+                    f"is {self.run_id!r}; two runs must not share a journal"
+                )
+            if state.manifest_sha256 != self.manifest_sha256:
+                raise JournalRefused(
+                    f"journal {self.path} was opened against a different task "
+                    "manifest"
+                )
+            self.state = state
+        else:
+            self.state = JournalState(
+                run_id=self.run_id,
+                manifest_sha256=self.manifest_sha256,
+                schema_version=JOURNAL_SCHEMA_VERSION,
+            )
+            # A zero-length file is a header write that did not survive. Nothing
+            # had been opened when it was made, so there is nothing to recover
+            # and starting the header again loses no attempt.
+            self._create_with_header()
+
+    # -- disk ------------------------------------------------------------
+
+    def _create_with_header(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        header = {
+            "kind": RECORD_HEADER,
+            "schema_version": JOURNAL_SCHEMA_VERSION,
+            "run_id": self.run_id,
+            "manifest_sha256": self.manifest_sha256,
+            "task_count": len(self.task_ids),
+            "stage": self.stage,
+            "at": self._clock(),
+        }
+        self._append(header)
+        # The record is durable; the directory entry pointing at the file is
+        # not, until the directory itself is flushed.
+        directory = os.open(str(self.path.parent), os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+
+    def _append(self, record: Mapping[str, Any]) -> None:
+        line = json.dumps(
+            record, sort_keys=True, separators=(",", ":"), ensure_ascii=True,
+            allow_nan=False,
+        )
+        with open(self.path, "a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+
+    # -- the two records -------------------------------------------------
+
+    def open_task(self, task_id: str) -> OpenedAttempt:
+        """Record the intent to spend on one task, and hand out its attempt.
+
+        Written and flushed before the caller makes a single model call. The
+        record's whole purpose is to exist if the process does not.
+        """
+        task_id = str(task_id)
+        if task_id not in self._known:
+            raise JournalRefused(
+                f"task {task_id!r} is not in this run's fixed manifest"
+            )
+        if self._open_task is not None:
+            raise JournalRefused(
+                f"task {self._open_task.task_id!r} is still open; one task at a "
+                "time is what keeps two tasks out of one sandbox"
+            )
+        prior = self.state.attempts_for(task_id)
+        if any(
+            record.outcome == OUTCOME_FINISHED
+            for record in self.state.closes_for(task_id)
+        ):
+            raise JournalRefused(f"task {task_id!r} has already finished")
+        if len(prior) >= MOST_ATTEMPTS_PER_TASK:
+            raise JournalRefused(
+                f"task {task_id!r} has had {len(prior)} attempts, which is the "
+                f"ceiling of {MOST_ATTEMPTS_PER_TASK}"
+            )
+        attempt_index = len(prior) + 1
+        workspace = workspace_name_for(task_id, attempt_index)
+        if workspace in self.state.workspace_names():
+            raise JournalRefused(
+                f"workspace {workspace!r} has been used before; a reused "
+                "workspace is how one task's files end up in another's result"
+            )
+        opened = OpenedAttempt(
+            task_id=task_id,
+            attempt_index=attempt_index,
+            workspace_name=workspace,
+            stage=self.stage,
+            opened_at=self._clock(),
+        )
+        self._append({
+            "kind": RECORD_OPENED,
+            "task_id": opened.task_id,
+            "attempt_index": opened.attempt_index,
+            "workspace_name": opened.workspace_name,
+            "stage": opened.stage,
+            "at": opened.opened_at,
+        })
+        self.state.opened.append(opened)
+        self._open_task = opened
+        return opened
+
+    def close_task(
+        self,
+        *,
+        outcome: str,
+        error_type: str | None = None,
+        deliverables: Iterable[Mapping[str, Any]] = (),
+        cost_settled: bool,
+    ) -> ClosedAttempt:
+        """Record how the open attempt ended, once its cost has been settled.
+
+        ``cost_settled`` is not a courtesy flag. A caller that settled nothing
+        and says it did turns an unpriced attempt into one the receipt will
+        count as complete, and the loss is unrecoverable afterwards because the
+        guest and its workspace are gone.
+        """
+        opened = self._open_task
+        if opened is None:
+            raise JournalRefused("no task is open, so there is nothing to close")
+        if outcome not in OUTCOMES:
+            raise JournalRefused(
+                f"{outcome!r} is not an outcome; it is one of {OUTCOMES}"
+            )
+
+        if outcome == OUTCOME_FINISHED:
+            if error_type is not None:
+                raise JournalRefused(
+                    "a finished task does not also carry an error type"
+                )
+            disposition = None
+            collected = tuple(dict(entry) for entry in deliverables)
+            if not collected:
+                raise JournalRefused(
+                    "a task that finished with no deliverables carried out is "
+                    "not a task that finished; the workspace is purged at close "
+                    "and there is nothing left to collect later"
+                )
+            for entry in collected:
+                missing = {"path", "sha256", "size"} - set(entry)
+                if missing:
+                    raise JournalRefused(
+                        f"a deliverable is missing {sorted(missing)}; a path with "
+                        "no digest is a claim rather than a record"
+                    )
+        else:
+            # Raises on an error type the contract does not name, which is the
+            # point: an unrecorded failure mode must not reach the report as a
+            # blank. Re-raised as a refusal so that a caller guarding the
+            # journal with one exception type does not miss it.
+            try:
+                disposition = disposition_for_error(error_type)
+            except ValueError as error:
+                raise JournalRefused(str(error)) from None
+            collected = tuple(dict(entry) for entry in deliverables)
+
+        closed = ClosedAttempt(
+            task_id=opened.task_id,
+            attempt_index=opened.attempt_index,
+            outcome=outcome,
+            error_type=error_type,
+            disposition=disposition,
+            deliverables=collected,
+            cost_settled=bool(cost_settled),
+            closed_at=self._clock(),
+        )
+        self._append({
+            "kind": RECORD_CLOSED,
+            "task_id": closed.task_id,
+            "attempt_index": closed.attempt_index,
+            "outcome": closed.outcome,
+            "error_type": closed.error_type,
+            "disposition": closed.disposition,
+            "deliverables": [dict(entry) for entry in closed.deliverables],
+            "cost_settled": closed.cost_settled,
+            "at": closed.closed_at,
+        })
+        self.state.closed.append(closed)
+        self._open_task = None
+        return closed
+
+    # -- reading back ----------------------------------------------------
+
+    def plan(self) -> ResumePlan:
+        """What a resume of this run would do, as of what is on disk now."""
+        return plan_resume(self.state, self.task_ids)
+
+    def standing(self, task_id: str) -> TaskStanding:
+        return _standing_for(self.state, str(task_id))

--- a/batch-runner/tests/test_agentic_v2_deliverable_collection.py
+++ b/batch-runner/tests/test_agentic_v2_deliverable_collection.py
@@ -1,0 +1,347 @@
+"""Whether the guest's files reach the host whole, or leave nothing behind.
+
+The interesting tests are the ones that break a collection half way through and
+then assert on what is on disk afterwards. A collector is easy to write and easy
+to get wrong in exactly one way — leaving a directory that looks like a short
+answer — so that is what most of this file is about.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from core.agentic_v2_deliverable_collection import (
+    DELIVERABLE_ROOT,
+    MOST_BYTES_IN_ONE_COLLECTION,
+    STAGING_PREFIX,
+    CollectionRefused,
+    abandoned_collections,
+    collect_deliverables,
+    discard_previous_collection,
+)
+
+
+TASK = "task-0001"
+ATTEMPT = "task-0001-deadbeef-a01"
+
+
+def _result(*files):
+    return {
+        "success": True,
+        "text": "done",
+        "deliverable_text": "done",
+        "files": [
+            {"filename": name, "content": content} for name, content in files
+        ],
+    }
+
+
+def _sha(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+# ── the ordinary path ────────────────────────────────────────────────────
+
+
+def test_files_land_where_the_submission_expects_them(tmp_path):
+    collection = collect_deliverables(
+        _result(("report.xlsx", b"\x00\xffbytes")),
+        task_id=TASK,
+        into=tmp_path,
+        attempt_name=ATTEMPT,
+    )
+    assert collection.submission_paths() == [
+        f"{DELIVERABLE_ROOT}/{TASK}/report.xlsx"
+    ]
+    landed = tmp_path / DELIVERABLE_ROOT / TASK / "report.xlsx"
+    assert landed.read_bytes() == b"\x00\xffbytes"
+
+
+def test_binary_content_is_not_mangled(tmp_path):
+    payload = bytes(range(256)) * 8
+    collect_deliverables(
+        _result(("book.xlsx", payload)),
+        task_id=TASK,
+        into=tmp_path,
+        attempt_name=ATTEMPT,
+    )
+    landed = tmp_path / DELIVERABLE_ROOT / TASK / "book.xlsx"
+    assert landed.read_bytes() == payload
+
+
+def test_the_model_s_directory_structure_survives(tmp_path):
+    collection = collect_deliverables(
+        _result(
+            ("analysis/summary.xlsx", b"one"),
+            ("raw/summary.xlsx", b"two"),
+        ),
+        task_id=TASK,
+        into=tmp_path,
+        attempt_name=ATTEMPT,
+    )
+    assert collection.submission_paths() == [
+        f"{DELIVERABLE_ROOT}/{TASK}/analysis/summary.xlsx",
+        f"{DELIVERABLE_ROOT}/{TASK}/raw/summary.xlsx",
+    ]
+    root = tmp_path / DELIVERABLE_ROOT / TASK
+    assert (root / "analysis" / "summary.xlsx").read_bytes() == b"one"
+    assert (root / "raw" / "summary.xlsx").read_bytes() == b"two"
+
+
+def test_the_journal_entries_carry_verified_digests(tmp_path):
+    collection = collect_deliverables(
+        _result(("report.xlsx", b"payload")),
+        task_id=TASK,
+        into=tmp_path,
+        attempt_name=ATTEMPT,
+    )
+    assert collection.journal_entries() == [
+        {
+            "path": f"{DELIVERABLE_ROOT}/{TASK}/report.xlsx",
+            "sha256": _sha(b"payload"),
+            "size": len(b"payload"),
+        }
+    ]
+    assert collection.total_bytes() == len(b"payload")
+
+
+def test_nothing_is_staged_once_a_collection_succeeds(tmp_path):
+    collect_deliverables(
+        _result(("report.xlsx", b"payload")),
+        task_id=TASK,
+        into=tmp_path,
+        attempt_name=ATTEMPT,
+    )
+    assert abandoned_collections(tmp_path) == []
+
+
+# ── all or nothing ───────────────────────────────────────────────────────
+
+
+def test_a_failure_part_way_through_leaves_no_result_directory(tmp_path, monkeypatch):
+    import core.agentic_v2_deliverable_collection as module
+
+    real = module._write_one
+    calls = {"n": 0}
+
+    def fail_on_the_second(**kwargs):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise OSError(28, "No space left on device")
+        return real(**kwargs)
+
+    monkeypatch.setattr(module, "_write_one", fail_on_the_second)
+
+    with pytest.raises(OSError):
+        collect_deliverables(
+            _result(("a.txt", b"one"), ("b.txt", b"two"), ("c.txt", b"three")),
+            task_id=TASK,
+            into=tmp_path,
+            attempt_name=ATTEMPT,
+        )
+
+    assert not (tmp_path / DELIVERABLE_ROOT / TASK).exists()
+    assert abandoned_collections(tmp_path) == []
+
+
+def test_a_keyboard_interrupt_also_leaves_nothing(tmp_path, monkeypatch):
+    import core.agentic_v2_deliverable_collection as module
+
+    def interrupt(**kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(module, "_write_one", interrupt)
+
+    with pytest.raises(KeyboardInterrupt):
+        collect_deliverables(
+            _result(("a.txt", b"one")),
+            task_id=TASK,
+            into=tmp_path,
+            attempt_name=ATTEMPT,
+        )
+    assert not (tmp_path / DELIVERABLE_ROOT / TASK).exists()
+
+
+def test_bytes_that_did_not_survive_the_write_are_refused(tmp_path, monkeypatch):
+    import core.agentic_v2_deliverable_collection as module
+
+    real = module._write_one
+
+    def truncating_write(*, staging, relative, content):
+        return real(staging=staging, relative=relative, content=content[:-1])
+
+    monkeypatch.setattr(module, "_write_one", truncating_write)
+
+    with pytest.raises(CollectionRefused, match="not on disk as it came out"):
+        collect_deliverables(
+            _result(("report.xlsx", b"payload")),
+            task_id=TASK,
+            into=tmp_path,
+            attempt_name=ATTEMPT,
+        )
+    assert not (tmp_path / DELIVERABLE_ROOT / TASK).exists()
+
+
+# ── refusals ─────────────────────────────────────────────────────────────
+
+
+def test_a_failed_run_has_nothing_to_collect(tmp_path):
+    with pytest.raises(CollectionRefused, match="only a successful run"):
+        collect_deliverables(
+            {"success": False, "files": [], "error": "compute_start_failed"},
+            task_id=TASK,
+            into=tmp_path,
+            attempt_name=ATTEMPT,
+        )
+
+
+def test_a_success_with_no_files_is_refused(tmp_path):
+    with pytest.raises(CollectionRefused, match="did not finalize anything"):
+        collect_deliverables(
+            {"success": True, "files": []},
+            task_id=TASK,
+            into=tmp_path,
+            attempt_name=ATTEMPT,
+        )
+
+
+def test_text_content_is_refused(tmp_path):
+    with pytest.raises(CollectionRefused, match="must be bytes"):
+        collect_deliverables(
+            {"success": True, "files": [{"filename": "a.txt", "content": "one"}]},
+            task_id=TASK,
+            into=tmp_path,
+            attempt_name=ATTEMPT,
+        )
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/etc/passwd", "../escape.txt", "a/../../escape.txt", "a\\b.txt"],
+)
+def test_a_path_that_leaves_the_task_directory_is_refused(tmp_path, path):
+    with pytest.raises(CollectionRefused, match="canonical relative path"):
+        collect_deliverables(
+            _result((path, b"payload")),
+            task_id=TASK,
+            into=tmp_path,
+            attempt_name=ATTEMPT,
+        )
+    assert not (tmp_path / DELIVERABLE_ROOT / TASK).exists()
+
+
+def test_a_task_id_with_a_slash_is_refused(tmp_path):
+    with pytest.raises(CollectionRefused, match="not usable as a directory"):
+        collect_deliverables(
+            _result(("a.txt", b"one")),
+            task_id="../elsewhere",
+            into=tmp_path,
+            attempt_name=ATTEMPT,
+        )
+
+
+def test_two_deliverables_with_one_path_are_refused(tmp_path):
+    with pytest.raises(CollectionRefused, match="both want"):
+        collect_deliverables(
+            _result(("a.txt", b"one"), ("a.txt", b"two")),
+            task_id=TASK,
+            into=tmp_path,
+            attempt_name=ATTEMPT,
+        )
+    assert not (tmp_path / DELIVERABLE_ROOT / TASK).exists()
+
+
+def test_too_many_bytes_are_refused(tmp_path):
+    big = b"x" * (MOST_BYTES_IN_ONE_COLLECTION // 2 + 1)
+    with pytest.raises(CollectionRefused, match="exceed"):
+        collect_deliverables(
+            _result(("a.bin", big), ("b.bin", big)),
+            task_id=TASK,
+            into=tmp_path,
+            attempt_name=ATTEMPT,
+        )
+    assert not (tmp_path / DELIVERABLE_ROOT / TASK).exists()
+
+
+def test_an_existing_collection_is_refused_rather_than_replaced(tmp_path):
+    collect_deliverables(
+        _result(("report.xlsx", b"first")),
+        task_id=TASK,
+        into=tmp_path,
+        attempt_name=ATTEMPT,
+    )
+    with pytest.raises(CollectionRefused, match="already holds a collection"):
+        collect_deliverables(
+            _result(("report.xlsx", b"second")),
+            task_id=TASK,
+            into=tmp_path,
+            attempt_name="task-0001-deadbeef-a02",
+        )
+    landed = tmp_path / DELIVERABLE_ROOT / TASK / "report.xlsx"
+    assert landed.read_bytes() == b"first"
+
+
+def test_an_unusable_attempt_name_is_refused(tmp_path):
+    with pytest.raises(CollectionRefused, match="not usable"):
+        collect_deliverables(
+            _result(("a.txt", b"one")),
+            task_id=TASK,
+            into=tmp_path,
+            attempt_name="a/b",
+        )
+
+
+# ── replacing on purpose ─────────────────────────────────────────────────
+
+
+def test_discarding_then_collecting_replaces_the_answer(tmp_path):
+    collect_deliverables(
+        _result(("report.xlsx", b"first")),
+        task_id=TASK,
+        into=tmp_path,
+        attempt_name=ATTEMPT,
+    )
+    assert discard_previous_collection(tmp_path, TASK) is True
+    collect_deliverables(
+        _result(("report.xlsx", b"second")),
+        task_id=TASK,
+        into=tmp_path,
+        attempt_name="task-0001-deadbeef-a02",
+    )
+    landed = tmp_path / DELIVERABLE_ROOT / TASK / "report.xlsx"
+    assert landed.read_bytes() == b"second"
+
+
+def test_discarding_nothing_says_so(tmp_path):
+    assert discard_previous_collection(tmp_path, TASK) is False
+
+
+# ── what an interruption leaves ──────────────────────────────────────────
+
+
+def test_a_staging_directory_left_behind_is_reported(tmp_path):
+    staging = tmp_path / DELIVERABLE_ROOT / f"{STAGING_PREFIX}{ATTEMPT}"
+    staging.mkdir(parents=True)
+    (staging / "half.txt").write_bytes(b"partial")
+    assert abandoned_collections(tmp_path) == [staging]
+
+
+def test_no_deliverable_root_means_nothing_abandoned(tmp_path):
+    assert abandoned_collections(tmp_path) == []
+
+
+def test_a_stale_staging_directory_does_not_block_a_retry(tmp_path):
+    staging = tmp_path / DELIVERABLE_ROOT / f"{STAGING_PREFIX}{ATTEMPT}"
+    staging.mkdir(parents=True)
+    (staging / "half.txt").write_bytes(b"partial")
+
+    collection = collect_deliverables(
+        _result(("report.xlsx", b"whole")),
+        task_id=TASK,
+        into=tmp_path,
+        attempt_name=ATTEMPT,
+    )
+    assert not (collection.directory / "half.txt").exists()
+    assert (collection.directory / "report.xlsx").read_bytes() == b"whole"

--- a/batch-runner/tests/test_agentic_v2_run_report.py
+++ b/batch-runner/tests/test_agentic_v2_run_report.py
@@ -1,0 +1,373 @@
+"""Whether a V2 run's report says what happened, and refuses to say more.
+
+Most of these tests are about the things that would be easy to state wrongly: a
+zero where a number is unknown, a graded count where nothing was graded, a
+deliverable list that came from the model rather than from the disk. The
+mismatch between V1's tool names and V2's is asserted here rather than merely
+noted, so that fixing the report later breaks this file on purpose.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.agentic_v2_contract import TOOL_NAMES
+from core.agentic_v2_run_report import (
+    AGENTIC_V2_METRICS_SCHEMA_VERSION,
+    SHARED_TOOL_NAMES,
+    STATUS_ERROR,
+    STATUS_SUCCESS,
+    TOOL_NAMES_THE_REPORT_KNOWS,
+    ReportRowRefused,
+    build_agentic_v2_metrics,
+    build_result_row,
+    finished_tasks,
+    summarise_v2_run,
+)
+from core.agentic_v2_task_journal import (
+    DECISION_RUN,
+    DECISION_SKIP_FINISHED,
+    TaskStanding,
+)
+from core.cost_receipts import (
+    STATUS_COMPLETE,
+    STATUS_NOT_RUN,
+    STATUS_PARTIAL,
+    STATUS_UNAVAILABLE,
+)
+
+
+TASK = "task-0001"
+
+
+def _standing(
+    *,
+    attempts=1,
+    abandoned=0,
+    decision=DECISION_SKIP_FINISHED,
+    task_id=TASK,
+):
+    return TaskStanding(
+        task_id=task_id,
+        attempts=attempts,
+        abandoned_attempts=abandoned,
+        last_closed=None,
+        decision=decision,
+        reason="for the test",
+    )
+
+
+def _ok_run(**extra):
+    record = {"success": True, "deliverable_text": "the answer"}
+    record.update(extra)
+    return record
+
+
+def _failed_run(error="compute_start_failed"):
+    return {"success": False, "error": error}
+
+
+def _receipt(status=STATUS_COMPLETE, total=1.25):
+    return {
+        "status": status,
+        "estimated_cost_usd": total if status == STATUS_COMPLETE else None,
+        "known_cost_usd": total,
+        "currency": "USD",
+    }
+
+
+def _metrics(**kwargs):
+    defaults = {
+        "standing": _standing(),
+        "task_wall_time_ms": 1234.0,
+        "receipt": _receipt(),
+    }
+    defaults.update(kwargs)
+    return build_agentic_v2_metrics(_ok_run(), **defaults)
+
+
+# ── the two tool vocabularies ────────────────────────────────────────────
+
+
+def test_the_report_s_tool_names_and_v2_s_share_only_finalize():
+    """If this fails the report has changed and this module must follow it."""
+    overlap = set(TOOL_NAMES) & set(TOOL_NAMES_THE_REPORT_KNOWS)
+    assert overlap == {"finalize"}
+    assert SHARED_TOOL_NAMES == ("finalize",)
+
+
+def test_every_v2_tool_gets_a_bucket_even_when_unused():
+    metrics = _metrics()
+    assert set(metrics["tool_calls_by_name"]) == set(TOOL_NAMES)
+    assert metrics["tool_calls"] == 0
+
+
+def test_v2_calls_are_counted_under_v2_names():
+    metrics = _metrics(
+        tool_calls=[
+            {"tool_name": "exec_run"},
+            {"tool_name": "exec_run"},
+            {"tool_name": "finalize"},
+        ]
+    )
+    assert metrics["tool_calls_by_name"]["exec_run"] == 2
+    assert metrics["tool_calls_by_name"]["finalize"] == 1
+    assert metrics["tool_calls"] == 3
+
+
+def test_a_tool_the_contract_does_not_have_is_refused():
+    with pytest.raises(ReportRowRefused, match="does not have"):
+        _metrics(tool_calls=[{"tool_name": "run_python"}])
+
+
+# ── money ────────────────────────────────────────────────────────────────
+
+
+def test_a_complete_receipt_puts_its_total_in_the_headline():
+    metrics = _metrics(receipt=_receipt(total=2.5))
+    assert metrics["conservative_cost_usd"] == 2.5
+    assert metrics["usage_complete"] is True
+
+
+@pytest.mark.parametrize(
+    "status", [STATUS_PARTIAL, STATUS_UNAVAILABLE, STATUS_NOT_RUN]
+)
+def test_an_unpriced_run_writes_no_amount_at_all(status):
+    """Absent, never zero: the report sums this field as a float."""
+    metrics = _metrics(receipt=_receipt(status=status))
+    assert "conservative_cost_usd" not in metrics
+    assert metrics["usage_complete"] is False
+    assert metrics["agentic_v2_cost_receipt_status"] == status
+
+
+def test_no_receipt_at_all_is_not_run_rather_than_free():
+    metrics = _metrics(receipt=None)
+    assert metrics["agentic_v2_cost_receipt_status"] == STATUS_NOT_RUN
+    assert "conservative_cost_usd" not in metrics
+
+
+def test_an_abandoned_attempt_keeps_the_amount_out_even_on_a_complete_receipt():
+    """The retry was priced. The attempt that vanished was not."""
+    metrics = _metrics(standing=_standing(attempts=2, abandoned=1))
+    assert "conservative_cost_usd" not in metrics
+    assert metrics["usage_complete"] is False
+    assert metrics["agentic_v2_abandoned_attempts"] == 1
+
+
+def test_a_receipt_status_the_vocabulary_does_not_have_is_refused():
+    with pytest.raises(ReportRowRefused, match="not a receipt status"):
+        _metrics(receipt={"status": "probably_fine"})
+
+
+def test_a_receipt_whose_total_is_not_a_number_writes_nothing():
+    metrics = _metrics(
+        receipt={"status": STATUS_COMPLETE, "estimated_cost_usd": "1.25"}
+    )
+    assert "conservative_cost_usd" not in metrics
+
+
+# ── what the report needs to see the task at all ─────────────────────────
+
+
+def test_a_task_with_no_measured_time_is_refused():
+    with pytest.raises(ReportRowRefused, match="invisible to the report"):
+        build_agentic_v2_metrics(
+            _ok_run(), standing=_standing(), task_wall_time_ms=None
+        )
+
+
+def test_token_counts_are_written_as_ints_the_report_will_accept():
+    metrics = _metrics(input_tokens=1000, output_tokens=250)
+    assert metrics["input_tokens"] == 1000
+    assert type(metrics["input_tokens"]) is int
+    assert type(metrics["output_tokens"]) is int
+
+
+def test_absent_token_counts_stay_absent():
+    metrics = _metrics()
+    assert "input_tokens" not in metrics
+    assert "output_tokens" not in metrics
+
+
+def test_a_failure_carries_its_error_category_and_who_it_points_at():
+    metrics = build_agentic_v2_metrics(
+        _failed_run("compute_start_failed"),
+        standing=_standing(decision=DECISION_RUN),
+        task_wall_time_ms=99.0,
+        receipt=_receipt(),
+    )
+    assert metrics["terminal_error_category"] == "compute_start_failed"
+    assert metrics["agentic_v2_disposition"] == "infrastructure"
+    assert metrics["agentic_v2_attributable_to"] == "environment"
+    assert metrics["tool_errors"] == 1
+
+
+def test_a_success_names_no_error():
+    metrics = _metrics()
+    assert metrics["terminal_error_category"] == ""
+    assert metrics["agentic_v2_disposition"] is None
+    assert metrics["tool_errors"] == 0
+    assert metrics["schema_version"] == AGENTIC_V2_METRICS_SCHEMA_VERSION
+
+
+# ── the row ──────────────────────────────────────────────────────────────
+
+
+def test_a_successful_row_carries_the_collected_paths():
+    row = build_result_row(
+        _ok_run(),
+        task_id=TASK,
+        standing=_standing(),
+        sector="Finance",
+        occupation="Analyst",
+        instruction="do the thing",
+        deliverable_files=[f"deliverable_files/{TASK}/report.xlsx"],
+        latency_ms=1234.0,
+        metrics=_metrics(),
+        receipt=_receipt(),
+    )
+    assert row["status"] == STATUS_SUCCESS
+    assert row["deliverable_files_count"] == 1
+    assert row["deliverable_text"] == "the answer"
+    assert row["sector"] == "Finance"
+    assert row["retried"] is False
+    assert "error" not in row
+    assert row["problem_solving_cost"]["status"] == STATUS_COMPLETE
+
+
+def test_a_success_with_nothing_collected_is_refused():
+    with pytest.raises(ReportRowRefused, match="produced nothing"):
+        build_result_row(
+            _ok_run(),
+            task_id=TASK,
+            standing=_standing(),
+            deliverable_files=[],
+            metrics=_metrics(),
+        )
+
+
+def test_a_failure_carrying_files_is_refused():
+    """A half-collected answer is not the task's answer."""
+    with pytest.raises(ReportRowRefused, match="not its answer"):
+        build_result_row(
+            _failed_run(),
+            task_id=TASK,
+            standing=_standing(decision=DECISION_RUN),
+            deliverable_files=[f"deliverable_files/{TASK}/half.xlsx"],
+            metrics=_metrics(),
+        )
+
+
+def test_a_failed_row_records_the_error_and_no_files():
+    row = build_result_row(
+        _failed_run("finalize_not_called"),
+        task_id=TASK,
+        standing=_standing(attempts=2, decision=DECISION_RUN),
+        metrics=_metrics(),
+    )
+    assert row["status"] == STATUS_ERROR
+    assert row["error"] == "finalize_not_called"
+    assert row["deliverable_files"] == []
+    assert row["retried"] is True
+
+
+def test_a_row_without_a_receipt_gains_no_cost_key():
+    row = build_result_row(
+        _failed_run(),
+        task_id=TASK,
+        standing=_standing(decision=DECISION_RUN),
+        metrics=_metrics(),
+    )
+    assert "problem_solving_cost" not in row
+
+
+def test_the_metrics_are_copied_rather_than_shared():
+    metrics = _metrics()
+    row = build_result_row(
+        _failed_run(),
+        task_id=TASK,
+        standing=_standing(decision=DECISION_RUN),
+        metrics=metrics,
+    )
+    metrics["tool_calls"] = 999
+    assert row["observability"]["agentic_metrics"]["tool_calls"] == 0
+
+
+# ── the run ──────────────────────────────────────────────────────────────
+
+
+def _row(status=STATUS_SUCCESS, disposition=None, abandoned=0):
+    return {
+        "status": status,
+        "observability": {
+            "agentic_metrics": {
+                "agentic_v2_disposition": disposition,
+                "agentic_v2_abandoned_attempts": abandoned,
+            }
+        },
+    }
+
+
+def test_a_run_that_did_not_reach_every_task_says_so():
+    summary = summarise_v2_run(
+        [_row(), _row(STATUS_ERROR, "infrastructure")],
+        manifest_size=220,
+        receipt_ceiling=STATUS_COMPLETE,
+    )
+    assert summary["executed"] == 2
+    assert summary["succeeded"] == 1
+    assert summary["failed"] == 1
+    assert summary["not_reached"] == 218
+    assert summary["manifest_size"] == 220
+
+
+def test_grading_is_never_reported_as_zero():
+    """Nothing graded and grading not attempted are different facts."""
+    summary = summarise_v2_run([_row()], manifest_size=1, receipt_ceiling=STATUS_COMPLETE)
+    assert summary["graded"] is None
+    assert "separate run" in summary["graded_reason"]
+
+
+def test_dispositions_are_counted_across_the_run():
+    summary = summarise_v2_run(
+        [
+            _row(STATUS_ERROR, "infrastructure"),
+            _row(STATUS_ERROR, "infrastructure"),
+            _row(STATUS_ERROR, "semantic"),
+            _row(),
+        ],
+        manifest_size=4,
+        receipt_ceiling=STATUS_PARTIAL,
+    )
+    assert summary["dispositions"] == {"infrastructure": 2, "semantic": 1}
+
+
+def test_a_partial_ceiling_makes_the_run_s_cost_not_fully_accounted():
+    summary = summarise_v2_run(
+        [_row(abandoned=1)], manifest_size=1, receipt_ceiling=STATUS_PARTIAL
+    )
+    assert summary["cost_is_fully_accounted"] is False
+    assert summary["abandoned_attempts"] == 1
+
+
+def test_a_complete_ceiling_says_the_cost_is_accounted():
+    summary = summarise_v2_run(
+        [_row()], manifest_size=1, receipt_ceiling=STATUS_COMPLETE
+    )
+    assert summary["cost_is_fully_accounted"] is True
+
+
+def test_an_over_long_run_never_reports_a_negative_remainder():
+    summary = summarise_v2_run(
+        [_row(), _row()], manifest_size=1, receipt_ceiling=STATUS_COMPLETE
+    )
+    assert summary["not_reached"] == 0
+
+
+def test_finished_tasks_keeps_manifest_order():
+    standings = [
+        _standing(task_id="task-one", decision=DECISION_SKIP_FINISHED),
+        _standing(task_id="task-two", decision=DECISION_RUN),
+        _standing(task_id="task-three", decision=DECISION_SKIP_FINISHED),
+    ]
+    assert finished_tasks(standings) == ("task-one", "task-three")

--- a/batch-runner/tests/test_agentic_v2_task_journal.py
+++ b/batch-runner/tests/test_agentic_v2_task_journal.py
@@ -1,0 +1,428 @@
+"""What the task journal has to survive: a kill, a resume, and a second run.
+
+The tests that matter here are the ones that produce a *file* and then read it
+back with a different object, because an in-memory journal is not the thing
+being built. Several of them truncate the file by hand: that is the interruption
+the module exists for, and asserting on it is the only way to know the recovery
+is real rather than described.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from core.agentic_v2_task_journal import (
+    DECISION_RUN,
+    DECISION_SKIP_FINISHED,
+    DECISION_SKIP_SETTLED_FAILURE,
+    JOURNAL_SCHEMA_VERSION,
+    MOST_ATTEMPTS_PER_TASK,
+    OUTCOME_FAILED,
+    OUTCOME_FINISHED,
+    JournalCorrupt,
+    JournalRefused,
+    TaskJournal,
+    manifest_digest,
+    read_journal,
+    workspace_name_for,
+)
+from core.cost_receipts import STATUS_COMPLETE, STATUS_PARTIAL
+
+
+TASKS = ("task-one", "task-two", "task-three")
+
+A_DELIVERABLE = {
+    "path": "out/report.xlsx",
+    "sha256": "a" * 64,
+    "size": 4096,
+}
+
+
+class _Tick:
+    """A clock that moves by one and never surprises an assertion."""
+
+    def __init__(self) -> None:
+        self.now = 1_700_000_000.0
+
+    def __call__(self) -> float:
+        self.now += 1.0
+        return self.now
+
+
+def _journal(tmp_path, *, run_id="run-a", tasks=TASKS):
+    return TaskJournal(
+        tmp_path / "journal.jsonl",
+        run_id=run_id,
+        task_ids=tasks,
+        clock=_Tick(),
+    )
+
+
+# ── names ────────────────────────────────────────────────────────────────
+
+
+def test_manifest_digest_depends_on_order():
+    assert manifest_digest(["a", "b"]) != manifest_digest(["b", "a"])
+
+
+def test_manifest_digest_refuses_a_repeated_task():
+    with pytest.raises(JournalRefused, match="same task twice"):
+        manifest_digest(["a", "a"])
+
+
+def test_manifest_digest_refuses_an_empty_manifest():
+    with pytest.raises(JournalRefused, match="not a manifest"):
+        manifest_digest([])
+
+
+def test_long_task_ids_sharing_a_prefix_do_not_share_a_workspace():
+    shared = "x" * 60
+    first = workspace_name_for(shared + "-alpha", 1)
+    second = workspace_name_for(shared + "-beta", 1)
+    assert first != second
+
+
+def test_a_workspace_name_carries_its_attempt():
+    assert workspace_name_for("task-one", 2).endswith("-a02")
+
+
+def test_attempt_numbering_starts_at_one():
+    with pytest.raises(JournalRefused, match="starts at 1"):
+        workspace_name_for("task-one", 0)
+
+
+# ── the ordinary path ────────────────────────────────────────────────────
+
+
+def test_a_fresh_journal_plans_every_task_to_run(tmp_path):
+    journal = _journal(tmp_path)
+    plan = journal.plan()
+    assert plan.to_run() == TASKS
+    assert plan.receipt_ceiling() == STATUS_COMPLETE
+    assert all(standing.attempts == 0 for standing in plan.standings)
+
+
+def test_the_header_is_the_first_line_on_disk(tmp_path):
+    journal = _journal(tmp_path)
+    first = json.loads(journal.path.read_text(encoding="utf-8").splitlines()[0])
+    assert first["kind"] == "header"
+    assert first["schema_version"] == JOURNAL_SCHEMA_VERSION
+    assert first["task_count"] == len(TASKS)
+
+
+def test_a_finished_task_is_skipped_on_resume(tmp_path):
+    journal = _journal(tmp_path)
+    journal.open_task("task-one")
+    journal.close_task(
+        outcome=OUTCOME_FINISHED,
+        deliverables=[A_DELIVERABLE],
+        cost_settled=True,
+    )
+    standing = journal.standing("task-one")
+    assert standing.decision == DECISION_SKIP_FINISHED
+    assert standing.cost_is_fully_accounted
+    assert journal.plan().to_run() == ("task-two", "task-three")
+
+
+def test_the_deliverables_survive_the_round_trip(tmp_path):
+    journal = _journal(tmp_path)
+    journal.open_task("task-one")
+    journal.close_task(
+        outcome=OUTCOME_FINISHED,
+        deliverables=[A_DELIVERABLE],
+        cost_settled=True,
+    )
+    reloaded = read_journal(journal.path)
+    assert reloaded.closed[0].deliverables == (A_DELIVERABLE,)
+
+
+def test_a_retryable_failure_is_run_again(tmp_path):
+    journal = _journal(tmp_path)
+    journal.open_task("task-one")
+    journal.close_task(
+        outcome=OUTCOME_FAILED,
+        error_type="compute_start_failed",
+        cost_settled=True,
+    )
+    standing = journal.standing("task-one")
+    assert standing.decision == DECISION_RUN
+    assert standing.last_closed is not None
+    assert standing.last_closed.disposition == "infrastructure"
+
+
+def test_a_terminal_failure_is_not_run_again(tmp_path):
+    journal = _journal(tmp_path)
+    journal.open_task("task-one")
+    journal.close_task(
+        outcome=OUTCOME_FAILED,
+        error_type="runner_internal_error",
+        cost_settled=True,
+    )
+    standing = journal.standing("task-one")
+    assert standing.decision == DECISION_SKIP_SETTLED_FAILURE
+    assert standing.last_closed is not None
+    assert standing.last_closed.disposition == "runner_defect"
+
+
+def test_attempts_are_numbered_and_never_share_a_workspace(tmp_path):
+    journal = _journal(tmp_path)
+    seen = set()
+    for _ in range(MOST_ATTEMPTS_PER_TASK):
+        opened = journal.open_task("task-one")
+        assert opened.workspace_name not in seen
+        seen.add(opened.workspace_name)
+        journal.close_task(
+            outcome=OUTCOME_FAILED,
+            error_type="compute_start_failed",
+            cost_settled=True,
+        )
+    assert len(seen) == MOST_ATTEMPTS_PER_TASK
+    assert journal.standing("task-one").decision == DECISION_SKIP_SETTLED_FAILURE
+
+
+def test_a_task_may_not_exceed_the_attempt_ceiling(tmp_path):
+    journal = _journal(tmp_path)
+    for _ in range(MOST_ATTEMPTS_PER_TASK):
+        journal.open_task("task-one")
+        journal.close_task(
+            outcome=OUTCOME_FAILED,
+            error_type="compute_start_failed",
+            cost_settled=True,
+        )
+    with pytest.raises(JournalRefused, match="ceiling"):
+        journal.open_task("task-one")
+
+
+# ── the interruption ─────────────────────────────────────────────────────
+
+
+def test_an_abandoned_attempt_is_run_again_and_never_fully_accounted(tmp_path):
+    journal = _journal(tmp_path)
+    journal.open_task("task-one")  # and then the process dies
+
+    resumed = _journal(tmp_path)
+    standing = resumed.standing("task-one")
+    assert standing.decision == DECISION_RUN
+    assert standing.abandoned_attempts == 1
+    assert not standing.cost_is_fully_accounted
+    assert "interrupted" in standing.reason
+    assert resumed.plan().receipt_ceiling() == STATUS_PARTIAL
+
+
+def test_a_resumed_attempt_gets_a_new_workspace(tmp_path):
+    journal = _journal(tmp_path)
+    first = journal.open_task("task-one")
+
+    resumed = _journal(tmp_path)
+    second = resumed.open_task("task-one")
+    assert second.attempt_index == first.attempt_index + 1
+    assert second.workspace_name != first.workspace_name
+
+
+def test_a_later_success_does_not_undo_an_abandoned_attempt(tmp_path):
+    """The spend that vanished stays vanished, however well the retry goes."""
+    journal = _journal(tmp_path)
+    journal.open_task("task-one")
+
+    resumed = _journal(tmp_path)
+    resumed.open_task("task-one")
+    resumed.close_task(
+        outcome=OUTCOME_FINISHED,
+        deliverables=[A_DELIVERABLE],
+        cost_settled=True,
+    )
+    standing = resumed.standing("task-one")
+    assert standing.decision == DECISION_SKIP_FINISHED
+    assert standing.abandoned_attempts == 1
+    assert not standing.cost_is_fully_accounted
+    assert resumed.plan().receipt_ceiling() == STATUS_PARTIAL
+    assert resumed.plan().unaccounted_tasks() == ("task-one",)
+
+
+def test_an_unsettled_cost_lowers_the_ceiling_too(tmp_path):
+    journal = _journal(tmp_path)
+    journal.open_task("task-one")
+    journal.close_task(
+        outcome=OUTCOME_FINISHED,
+        deliverables=[A_DELIVERABLE],
+        cost_settled=False,
+    )
+    assert not journal.standing("task-one").cost_is_fully_accounted
+    assert journal.plan().receipt_ceiling() == STATUS_PARTIAL
+
+
+def test_a_torn_final_line_is_dropped_and_the_rest_survives(tmp_path):
+    journal = _journal(tmp_path)
+    journal.open_task("task-one")
+    journal.close_task(
+        outcome=OUTCOME_FINISHED,
+        deliverables=[A_DELIVERABLE],
+        cost_settled=True,
+    )
+    journal.open_task("task-two")
+
+    raw = journal.path.read_text(encoding="utf-8")
+    journal.path.write_text(raw[: len(raw) - 20], encoding="utf-8")
+
+    state = read_journal(journal.path)
+    assert state.dropped_torn_tail
+    assert [record.task_id for record in state.opened] == ["task-one"]
+    assert [record.task_id for record in state.closed] == ["task-one"]
+
+    resumed = _journal(tmp_path)
+    assert resumed.plan().to_run() == ("task-two", "task-three")
+
+
+def test_a_torn_line_in_the_middle_is_refused(tmp_path):
+    journal = _journal(tmp_path)
+    journal.open_task("task-one")
+    journal.close_task(
+        outcome=OUTCOME_FINISHED,
+        deliverables=[A_DELIVERABLE],
+        cost_settled=True,
+    )
+    lines = journal.path.read_text(encoding="utf-8").splitlines()
+    lines[1] = lines[1][:-9]
+    journal.path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    with pytest.raises(JournalCorrupt, match="corruption rather than"):
+        read_journal(journal.path)
+
+
+def test_a_zero_length_journal_is_started_again_rather_than_refused(tmp_path):
+    where = tmp_path / "journal.jsonl"
+    where.write_bytes(b"")
+    journal = TaskJournal(
+        where, run_id="run-a", task_ids=TASKS, clock=_Tick()
+    )
+    assert journal.plan().to_run() == TASKS
+
+
+# ── refusals ─────────────────────────────────────────────────────────────
+
+
+def test_a_second_run_may_not_share_a_journal(tmp_path):
+    _journal(tmp_path)
+    with pytest.raises(JournalRefused, match="must not share a journal"):
+        _journal(tmp_path, run_id="run-b")
+
+
+def test_a_different_manifest_is_refused(tmp_path):
+    _journal(tmp_path)
+    with pytest.raises(JournalRefused, match="different task manifest"):
+        _journal(tmp_path, tasks=("task-one", "task-two"))
+
+
+def test_a_task_outside_the_manifest_is_refused(tmp_path):
+    journal = _journal(tmp_path)
+    with pytest.raises(JournalRefused, match="fixed manifest"):
+        journal.open_task("task-nine")
+
+
+def test_two_tasks_may_not_be_open_at_once(tmp_path):
+    journal = _journal(tmp_path)
+    journal.open_task("task-one")
+    with pytest.raises(JournalRefused, match="one task at a time"):
+        journal.open_task("task-two")
+
+
+def test_a_finished_task_may_not_be_reopened(tmp_path):
+    journal = _journal(tmp_path)
+    journal.open_task("task-one")
+    journal.close_task(
+        outcome=OUTCOME_FINISHED,
+        deliverables=[A_DELIVERABLE],
+        cost_settled=True,
+    )
+    with pytest.raises(JournalRefused, match="already finished"):
+        journal.open_task("task-one")
+
+
+def test_closing_nothing_is_refused(tmp_path):
+    journal = _journal(tmp_path)
+    with pytest.raises(JournalRefused, match="nothing to close"):
+        journal.close_task(outcome=OUTCOME_FINISHED, cost_settled=True)
+
+
+def test_finishing_with_no_deliverables_is_refused(tmp_path):
+    journal = _journal(tmp_path)
+    journal.open_task("task-one")
+    with pytest.raises(JournalRefused, match="nothing left to collect"):
+        journal.close_task(
+            outcome=OUTCOME_FINISHED, deliverables=[], cost_settled=True
+        )
+
+
+def test_a_deliverable_without_a_digest_is_refused(tmp_path):
+    journal = _journal(tmp_path)
+    journal.open_task("task-one")
+    with pytest.raises(JournalRefused, match="claim rather than a record"):
+        journal.close_task(
+            outcome=OUTCOME_FINISHED,
+            deliverables=[{"path": "out/report.xlsx"}],
+            cost_settled=True,
+        )
+
+
+def test_finishing_with_an_error_type_is_refused(tmp_path):
+    journal = _journal(tmp_path)
+    journal.open_task("task-one")
+    with pytest.raises(JournalRefused, match="does not also carry an error"):
+        journal.close_task(
+            outcome=OUTCOME_FINISHED,
+            error_type="compute_start_failed",
+            deliverables=[A_DELIVERABLE],
+            cost_settled=True,
+        )
+
+
+def test_an_error_the_contract_does_not_name_is_refused(tmp_path):
+    journal = _journal(tmp_path)
+    journal.open_task("task-one")
+    with pytest.raises(JournalRefused, match="no recorded disposition"):
+        journal.close_task(
+            outcome=OUTCOME_FAILED,
+            error_type="the_vibes_were_off",
+            cost_settled=True,
+        )
+
+
+def test_an_outcome_the_journal_does_not_name_is_refused(tmp_path):
+    journal = _journal(tmp_path)
+    journal.open_task("task-one")
+    with pytest.raises(JournalRefused, match="is not an outcome"):
+        journal.close_task(outcome="sort_of_worked", cost_settled=True)
+
+
+def test_a_journal_from_another_schema_version_is_refused(tmp_path):
+    journal = _journal(tmp_path)
+    lines = journal.path.read_text(encoding="utf-8").splitlines()
+    head = json.loads(lines[0])
+    head["schema_version"] = "agentic-v2-task-journal-v0"
+    lines[0] = json.dumps(head, sort_keys=True)
+    journal.path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    with pytest.raises(JournalCorrupt, match="was written under"):
+        read_journal(journal.path)
+
+
+def test_a_file_that_does_not_start_with_a_header_is_refused(tmp_path):
+    where = tmp_path / "journal.jsonl"
+    where.write_text(json.dumps({"kind": "opened"}) + "\n", encoding="utf-8")
+    with pytest.raises(JournalCorrupt, match="does not begin with a header"):
+        read_journal(where)
+
+
+def test_a_missing_journal_is_refused_rather_than_invented(tmp_path):
+    with pytest.raises(JournalRefused, match="there is no journal"):
+        read_journal(tmp_path / "absent.jsonl")
+
+
+def test_planning_against_a_different_manifest_is_refused(tmp_path):
+    journal = _journal(tmp_path)
+    state = read_journal(journal.path)
+    from core.agentic_v2_task_journal import plan_resume
+
+    with pytest.raises(JournalRefused, match="different task manifest"):
+        plan_resume(state, ("task-one", "task-two"))

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
@@ -2438,3 +2438,74 @@ Regenerate with `python batch-runner/scripts/write_v2_preregistration.py`;
 before regenerating: this repository's own inputs moving and A's experiment
 file moving produce the same failure but mean different things, and the second
 one means someone has to decide whether the runs are still comparable at all.
+
+### Stage E — a run that can be resumed, collected and reported, 2026-09-11.
+
+Three modules, 91 tests, no model call and no Azure spend. They are the parts
+of step 4 that were still missing: per-task isolation and resume, file
+collection, and the connection to the report. The retry distinction and the
+cost ledger binding were already built and are unchanged here.
+
+**V2 had no resume at all.** Not a weak one — none. A grep across the 26 V2
+modules finds the word only in docstrings. V1 has one, but it cannot carry V2:
+`workspace/step2_inference_progress.json`, written by `step2_run_inference.py`,
+appends a result only once a task has *finished*, as `success` or `error`. A
+task that started, cost money and was killed half way through leaves no record
+in it at all, and so on resume is indistinguishable from a task that never
+began.
+
+`core/agentic_v2_task_journal.py` writes **two** records per attempt for that
+reason. An `opened` record is fsync'd *before* `open_task` returns, so a torn
+`opened` at the end of the file means the process died before any model call —
+which is the fact that makes dropping a torn tail safe rather than convenient. A
+torn line anywhere *earlier* is `JournalCorrupt` and stops the run. The journal
+also owns `attempt_index`, which nothing owned before and which `make_call_id`
+already needed: without it a retry's ledger rows collide with the dead
+attempt's, and the two attempts' spend becomes one number.
+
+**An abandoned attempt lowers the run's receipt permanently.** Once a task has
+an `opened` with no `closed`, `receipt_ceiling()` returns `partial` and keeps
+returning it however well the retry goes — `test_a_later_success_does_not_undo_an_abandoned_attempt`
+is the test that pins this. The spend that vanished stays vanished. This is the
+same rule as everywhere else in the repository: unpriced is `partial`, and it is
+not `$0`.
+
+**A half-written deliverable directory is indistinguishable from a short
+answer.** That is the failure `core/agentic_v2_deliverable_collection.py`
+exists against. Five files, three written, then a full disk, and what is left on
+disk looks exactly like a finished task with three deliverables: `fill_parquet`
+reads the paths, `step5_validate` checks they exist, and the submission goes out
+short with nothing anywhere saying so. So files are written into
+`deliverable_files/.collecting-<attempt>/`, every one is read back and
+re-hashed, and only then is the directory `os.replace`d into place. Any
+exception — including `KeyboardInterrupt` — removes the staging directory.
+
+The bytes are hashed twice on purpose. The guest's digests answer *did the guest
+produce this*; re-reading answers *is this what is on the host's disk now*, and
+a short write, a silently truncating filesystem and a disk that filled between
+two files all produce a file that exists and is wrong.
+
+**The report will show zeros for seven of V2's eight tools, and that is stated
+rather than left to be discovered.** `step6_report._compute_agentic_metrics`
+buckets tool calls under V1's names — `inspect_workspace`, `run_python` and the
+rest. V2's are `exec_run`, `environment_resolve` and the rest. The two
+vocabularies share exactly one name, `finalize`, and
+`core/agentic_v2_run_report.py` asserts that overlap at import so it cannot
+quietly become half-true. A reader who saw one non-zero `finalize` beside five
+zeros would reasonably conclude the model used one tool. The counts are
+therefore written under V2's own names as well, where they can be found.
+Teaching the report V2's vocabulary is a change to a shared file and is not made
+from here.
+
+**`conservative_cost_usd` is absent, never zero, when the cost is unknown.** The
+report sums that field as a plain float, so a zero would put a wrong number in a
+headline; an absent key contributes nothing and claims nothing. It is written
+only when the receipt is `complete` *and* the journal says every attempt was
+accounted for. `summarise_v2_run` reports `graded: None` with a stated reason
+rather than `graded: 0`, because zero graded and grading-not-attempted look
+identical as a number and are not the same fact.
+
+**What this does not mean.** No V2 task has run. Nothing here boots a guest,
+asks a model, or prices a call — all three modules are handed facts established
+elsewhere and arrange them. The blocker is still the single role assignment
+named in stage D, which remains reported and not requested.


### PR DESCRIPTION
Three modules, 91 tests. No model call, no Azure spend. These are the parts of step 4 that were still missing: per-task isolation and resume, file collection, and the connection to the report. The retry distinction and the cost-ledger binding were already built and are untouched.

## `core/agentic_v2_task_journal.py` — resume

V2 had no resume at all; a grep across the 26 V2 modules finds the word only in docstrings. V1 has one and it cannot carry V2: `workspace/step2_inference_progress.json` appends a result only once a task has *finished*, so a task that started, cost money and was killed leaves no record and on resume is indistinguishable from a task that never began.

The journal writes **two** records per attempt. An `opened` is fsync'd *before* `open_task` returns, so a torn `opened` at the end of the file means no model call was ever made — that is what makes dropping a torn tail safe rather than convenient. A torn line *earlier* is `JournalCorrupt` and stops the run.

It also owns `attempt_index`, which nothing owned before and which `make_call_id` already needed: without it a retry's ledger rows collide with the dead attempt's and two attempts' spend becomes one number.

Once a task has an `opened` with no `closed`, `receipt_ceiling()` returns `partial` and keeps returning it however well the retry goes.

## `core/agentic_v2_deliverable_collection.py` — files

Five deliverables, three written, then a full disk: what is left on disk reads downstream as a finished task with three files. `fill_parquet` reads the paths, `step5_validate` checks they exist, and the submission goes out short with nothing saying so.

Files are staged under `deliverable_files/.collecting-<attempt>/`, every one is read back and re-hashed, and only then is the directory `os.replace`d into place. Any exception — including `KeyboardInterrupt` — removes the staging directory. The double hash is deliberate: the guest's digests answer *did the guest produce this*, re-reading answers *is this what is on the host's disk now*.

## `core/agentic_v2_run_report.py` — the row

Two things stated rather than smoothed over:

- **The report's tool vocabulary is V1's.** It buckets calls under `inspect_workspace`, `run_python` and the rest; V2's tools are `exec_run`, `environment_resolve` and the rest. The two share exactly one name, `finalize`, and that overlap is asserted at import so it cannot quietly become half-true. V2's counts are written under V2's own names as well. Teaching the report V2's vocabulary is a change to a shared file and is not made here.
- **`conservative_cost_usd` is absent, never zero, when the cost is unknown.** The report sums it as a plain float, so a zero would put a wrong number in a headline. It is written only when the receipt is `complete` *and* the journal says every attempt was accounted for. `summarise_v2_run` reports `graded: None` with a stated reason rather than `graded: 0` — zero graded and grading-not-attempted look identical as a number and are not the same fact.

## Verification

- `pytest tests/test_agentic_v2_task_journal.py tests/test_agentic_v2_deliverable_collection.py tests/test_agentic_v2_run_report.py` → **91 passed**
- `mypy` on the three new modules → **0 errors** (17 reported are pre-existing, all in `agentic_v2_provenance.py`)

## What this does not mean

No V2 task has run. Nothing here boots a guest, asks a model, or prices a call — all three modules are handed facts established elsewhere and arrange them. The blocker is still the single role assignment named in stage D, which remains reported and not requested.