### PR TITLE
feat(cost-ledger): record when each call left and when it concluded

### DIFF
--- a/batch-runner/core/cost_receipts.py
+++ b/batch-runner/core/cost_receipts.py
@@ -33,9 +33,10 @@ import hashlib
 import json
 import sqlite3
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from decimal import Decimal, ROUND_HALF_UP
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any, Callable, Iterable, Mapping, Sequence
 
 RECEIPT_SCHEMA_VERSION = "cost-receipt-v1"
 PRICE_TABLE_SCHEMA_VERSION = "cost-receipt-price-table-v1"
@@ -1038,6 +1039,8 @@ CREATE TABLE IF NOT EXISTS cost_calls (
     resolved_model      TEXT,
     api_version         TEXT,
     state               TEXT NOT NULL,
+    reserved_at         TEXT,
+    concluded_at        TEXT,
     input_tokens        INTEGER,
     cached_input_tokens INTEGER,
     output_tokens       INTEGER,
@@ -1078,6 +1081,8 @@ _CALL_COLUMNS = (
     "resolved_model",
     "api_version",
     "state",
+    "reserved_at",
+    "concluded_at",
     "input_tokens",
     "cached_input_tokens",
     "output_tokens",
@@ -1132,6 +1137,56 @@ _TOKEN_COLUMNS = frozenset(
 )
 
 
+#: When each call left and when this process stopped waiting on it. Grouped
+#: because they share the identity columns' one-sided property -- a local row
+#: records ``reserved_at`` before the request goes out, so an export written by
+#: a build from before these columns existed carries nothing there, and letting
+#: that blank win would delete a fact to make room for the absence of one.
+#:
+#: They exist because run ``34540053904`` could not answer the question it was
+#: run to answer. Five of its thirty tasks were refused by the provider, and
+#: separating a token-per-minute ceiling from a deployment's throughput needs
+#: the tokens settled in the window *before* each refusal. Every row held the
+#: tokens; not one held a time, so the window could not be drawn. A count
+#: without a clock cannot be put on one.
+_TIMING_COLUMNS = frozenset({"reserved_at", "concluded_at"})
+
+
+def _utc_now() -> datetime:
+    """The wall clock, in UTC.
+
+    Wall clock rather than :func:`time.monotonic`, which is what the rest of
+    this repository injects. Monotonic is the right choice for measuring a
+    duration inside one process and the wrong one here: shards run as separate
+    processes against the same ledger, and two monotonic readings taken in
+    different processes cannot be ordered against each other at all. The whole
+    use of these stamps is comparing calls that different processes made.
+    """
+    return datetime.now(timezone.utc)
+
+
+def _stamp(clock: Callable[[], datetime]) -> str:
+    """One moment, as text the ledger stores.
+
+    A naive datetime is refused rather than assumed to be UTC. It would be
+    stored as a perfectly well-formed timestamp in an unknown zone, and an hour
+    of error is invisible in the text and fatal to a rolling window -- which is
+    the one thing these columns are for.
+    """
+    moment = clock()
+    if not isinstance(moment, datetime):
+        raise LedgerIntegrityError(
+            "the ledger clock returned something that is not a datetime"
+        )
+    if moment.tzinfo is None or moment.tzinfo.utcoffset(moment) is None:
+        raise LedgerIntegrityError(
+            "the ledger clock returned a datetime with no timezone; a moment "
+            "without one cannot be compared against a moment from another "
+            "process"
+        )
+    return moment.astimezone(timezone.utc).isoformat(timespec="milliseconds")
+
+
 def _token_count(value: Any) -> int | None:
     """A stored token count as a number, keeping "not recorded" as ``None``."""
     if value is None or value == "":
@@ -1169,10 +1224,12 @@ class CostReceiptLedger:
         *,
         run_id: str,
         price_table: ReceiptPriceTable | None = None,
+        clock: Callable[[], datetime] = _utc_now,
     ):
         self.path = Path(path)
         self.run_id = str(run_id)
         self._price_table = price_table
+        self._clock = clock
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self._connection = sqlite3.connect(str(self.path), timeout=30.0)
         self._connection.row_factory = sqlite3.Row
@@ -1277,8 +1334,8 @@ class CostReceiptLedger:
         self._connection.execute(
             "INSERT INTO cost_calls (call_id, run_id, task_id, stage, "
             "retry_kind, provider, deployment, requested_model, api_version, "
-            "state, missing_reasons, request_sha256, note) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '[]', ?, ?)",
+            "state, reserved_at, missing_reasons, request_sha256, note) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '[]', ?, ?)",
             (
                 call_id,
                 self.run_id,
@@ -1290,6 +1347,7 @@ class CostReceiptLedger:
                 str(requested_model),
                 None if api_version is None else str(api_version),
                 STATE_RESERVED,
+                _stamp(self._clock),
                 request_sha256,
                 note,
             ),
@@ -1348,6 +1406,7 @@ class CostReceiptLedger:
 
         self._connection.execute(
             "UPDATE cost_calls SET state = ?, resolved_model = ?, "
+            "concluded_at = COALESCE(concluded_at, ?), "
             "input_tokens = ?, cached_input_tokens = ?, output_tokens = ?, "
             "reasoning_tokens = ?, audio_input_tokens = ?, "
             "audio_output_tokens = ?, model_cost_usd = ?, missing_reasons = ?, "
@@ -1355,6 +1414,7 @@ class CostReceiptLedger:
             (
                 STATE_SETTLED,
                 model,
+                _stamp(self._clock),
                 usage.input_tokens,
                 usage.cached_input_tokens,
                 usage.output_tokens,
@@ -1395,9 +1455,11 @@ class CostReceiptLedger:
                 "be recorded as never sent"
             )
         self._connection.execute(
-            "UPDATE cost_calls SET state = ?, note = COALESCE(?, note) "
+            "UPDATE cost_calls SET state = ?, "
+            "concluded_at = COALESCE(concluded_at, ?), "
+            "note = COALESCE(?, note) "
             "WHERE call_id = ?",
-            (STATE_ABANDONED, note, call_id),
+            (STATE_ABANDONED, _stamp(self._clock), note, call_id),
         )
         self._connection.commit()
 
@@ -1452,9 +1514,11 @@ class CostReceiptLedger:
             {*_decode_reasons(row["missing_reasons"]), REASON_CALL_REFUSED_UNPRICED}
         )
         self._connection.execute(
-            "UPDATE cost_calls SET state = ?, missing_reasons = ?, note = ? "
+            "UPDATE cost_calls SET state = ?, "
+            "concluded_at = COALESCE(concluded_at, ?), "
+            "missing_reasons = ?, note = ? "
             "WHERE call_id = ?",
-            (STATE_REFUSED, json.dumps(reasons), note, call_id),
+            (STATE_REFUSED, _stamp(self._clock), json.dumps(reasons), note, call_id),
         )
         self._connection.commit()
 
@@ -1469,6 +1533,14 @@ class CostReceiptLedger:
         What was missing is *which* of them happened. The note carries that and
         nothing else — a fixed word built from the failure's shape, never from
         the provider's message, which can quote a URL, a header or a key.
+
+        ``concluded_at`` is stamped here too, and on this one path it means
+        *when this process stopped waiting*, not when the call was answered.
+        The row stays :data:`STATE_RESERVED` precisely because nobody knows
+        whether it was answered, and a reader taking this stamp for a reply
+        time would be reading a giving-up as an arrival. It is recorded anyway
+        because it bounds the call: whatever happened to the request happened
+        before this moment.
         """
         _require(bool(note), "an unresolved call must say what happened to it")
         row = self._row(call_id)
@@ -1482,8 +1554,9 @@ class CostReceiptLedger:
                 "question and must not be annotated as one"
             )
         self._connection.execute(
-            "UPDATE cost_calls SET note = COALESCE(note, ?) WHERE call_id = ?",
-            (note, call_id),
+            "UPDATE cost_calls SET note = COALESCE(note, ?), "
+            "concluded_at = COALESCE(concluded_at, ?) WHERE call_id = ?",
+            (note, _stamp(self._clock), call_id),
         )
         self._connection.commit()
 
@@ -2183,9 +2256,16 @@ def _promoted_value(
     deployment that an export from a build predating those columns simply does
     not carry. Letting the blank win there would delete a fact to make room for
     the absence of one.
+
+    The timing columns are the same exception for the same reason, with one
+    addition: a local row can hold a ``concluded_at`` from
+    :meth:`CostReceiptLedger.leave_unresolved` — the moment this process
+    stopped waiting. An export that watched the call actually end carries a
+    truer moment and takes precedence, which is the ordinary rule; an export
+    that carries nothing must not erase the bound we do have.
     """
     value = _import_value(record, column)
-    if value is None and column in _IDENTITY_COLUMNS:
+    if value is None and (column in _IDENTITY_COLUMNS or column in _TIMING_COLUMNS):
         return existing[column]
     return value
 

--- a/batch-runner/tests/test_the_ledger_says_when_each_call_happened.py
+++ b/batch-runner/tests/test_the_ledger_says_when_each_call_happened.py
@@ -1,0 +1,542 @@
+"""The ledger says *when* each call happened, not only what it cost.
+
+Why this file exists
+--------------------
+Run ``34540053904`` was dispatched to answer one question: of the four things
+that could be refusing our calls -- request rate, a token-per-minute
+reservation, the deployment's throughput, or the interval between calls --
+which one is it. Its artifact ruled out two. It could not touch the other two,
+and the reason was not subtle: **every row in the cost ledger recorded how many
+tokens a call used, and not one recorded when.**
+
+Separating a token ceiling from a throughput ceiling means asking how many
+tokens had settled in the minute *before* a refusal. That is a rolling window,
+and a window needs a clock. Thirty tasks' worth of token counts with no times
+attached cannot be put on one, however many of them there are.
+
+So these tests fix a clock to the ledger's writes. They are not about cost.
+They are about making the next run able to answer a question this one could
+only describe.
+
+What the two columns mean
+-------------------------
+``reserved_at`` is when the request went out. That is the stamp a token
+reservation scheme keys off, because the reservation is taken at admission.
+
+``concluded_at`` is when this process stopped waiting -- by a reply, a refusal,
+a discovery that the call never left, or by giving up. On the giving-up path it
+is emphatically *not* a reply time, and a test below pins that the row stays
+open so no reader can mistake it for one.
+"""
+
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from core.cost_receipts import (
+    BUCKET_PROBLEM_SOLVING,
+    RETRY_NONE,
+    STAGE_GENERATION,
+    STATE_REFUSED,
+    STATE_RESERVED,
+    STATE_SETTLED,
+    CallUsage,
+    CostReceiptLedger,
+    LedgerIntegrityError,
+    load_receipt_price_table,
+    make_call_id,
+)
+
+PRICE_TABLE = {
+    "cost_receipt_schema_version": "cost-receipt-price-table-v1",
+    "providers": {
+        "azure:test-model": {
+            "input_usd_per_million": "10",
+            "cached_input_usd_per_million": "10",
+            "output_usd_per_million": "20",
+            "reasoning_billed_as": "output",
+            "source": "fixture",
+            "last_reviewed": "2026-09-11",
+            "currency": "USD",
+            "unit": "per 1,000,000 tokens",
+        }
+    },
+    "runtime": {},
+}
+
+#: A fixed starting moment. Chosen rather than ``now`` so that a failure names
+#: the same instants every time it is read.
+START = datetime(2026, 9, 11, 3, 0, 0, tzinfo=timezone.utc)
+
+
+class Clock:
+    """A clock the test drives, one second at a time unless told otherwise."""
+
+    def __init__(self, start=START):
+        self.moment = start
+
+    def __call__(self):
+        return self.moment
+
+    def advance(self, seconds):
+        self.moment = self.moment + timedelta(seconds=seconds)
+        return self.moment
+
+
+@pytest.fixture
+def price_table(tmp_path):
+    path = tmp_path / "prices.json"
+    path.write_text(json.dumps(PRICE_TABLE), encoding="utf-8")
+    return load_receipt_price_table(path)
+
+
+def _open(tmp_path, name, price_table, *, clock=None, run_id="run-1"):
+    return CostReceiptLedger(
+        tmp_path / name,
+        run_id=run_id,
+        price_table=price_table,
+        **({} if clock is None else {"clock": clock}),
+    )
+
+
+def _usage(input_tokens=100_000, output_tokens=10_000):
+    return CallUsage(
+        input_tokens=input_tokens,
+        cached_input_tokens=0,
+        output_tokens=output_tokens,
+        reasoning_tokens=0,
+    )
+
+
+def _reserve(ledger, task_id, *, attempt=0, sequence=0):
+    call_id = make_call_id(
+        run_id=ledger.run_id,
+        task_id=task_id,
+        stage=STAGE_GENERATION,
+        retry_kind=RETRY_NONE,
+        attempt_index=attempt,
+        sequence=sequence,
+    )
+    ledger.reserve(
+        call_id=call_id,
+        task_id=task_id,
+        stage=STAGE_GENERATION,
+        retry_kind=RETRY_NONE,
+        provider="azure",
+        requested_model="a-deployment",
+    )
+    return call_id
+
+
+def _row(ledger, call_id):
+    return ledger._connection.execute(
+        "SELECT * FROM cost_calls WHERE call_id = ?", (call_id,)
+    ).fetchone()
+
+
+# ── the two stamps ───────────────────────────────────────────────────────
+
+
+def test_a_reservation_records_when_the_request_went_out(tmp_path, price_table):
+    clock = Clock()
+    with _open(tmp_path, "l.sqlite3", price_table, clock=clock) as ledger:
+        call_id = _reserve(ledger, "task-a")
+        row = _row(ledger, call_id)
+
+    assert row["reserved_at"] == "2026-09-11T03:00:00.000+00:00"
+    # Nothing has concluded yet, and an absent conclusion must read as absent
+    # rather than as "concluded at the moment it was reserved" -- the second
+    # would make every open call look like it returned instantly.
+    assert row["concluded_at"] is None
+
+
+def test_a_settled_call_records_when_the_reply_came_back(tmp_path, price_table):
+    clock = Clock()
+    with _open(tmp_path, "l.sqlite3", price_table, clock=clock) as ledger:
+        call_id = _reserve(ledger, "task-a")
+        clock.advance(94)
+        ledger.settle(call_id, usage=_usage(), resolved_model="test-model")
+        row = _row(ledger, call_id)
+
+    assert row["reserved_at"] == "2026-09-11T03:00:00.000+00:00"
+    assert row["concluded_at"] == "2026-09-11T03:01:34.000+00:00"
+    assert row["state"] == STATE_SETTLED
+
+
+def test_a_refusal_records_when_the_refusal_came_back(tmp_path, price_table):
+    """The stamp that matters most.
+
+    A refusal is the event the rolling window is drawn backwards from. Without
+    its moment there is nothing to draw from.
+    """
+    clock = Clock()
+    with _open(tmp_path, "l.sqlite3", price_table, clock=clock) as ledger:
+        call_id = _reserve(ledger, "task-a")
+        clock.advance(3)
+        ledger.refuse(call_id, status=429)
+        row = _row(ledger, call_id)
+
+    assert row["state"] == STATE_REFUSED
+    assert row["concluded_at"] == "2026-09-11T03:00:03.000+00:00"
+
+
+def test_a_call_that_never_left_records_when_we_found_that_out(
+    tmp_path, price_table
+):
+    clock = Clock()
+    with _open(tmp_path, "l.sqlite3", price_table, clock=clock) as ledger:
+        call_id = _reserve(ledger, "task-a")
+        clock.advance(2)
+        ledger.abandon(call_id, note="client_not_built")
+        row = _row(ledger, call_id)
+
+    assert row["concluded_at"] == "2026-09-11T03:00:02.000+00:00"
+
+
+def test_giving_up_is_stamped_without_being_called_an_answer(
+    tmp_path, price_table
+):
+    """A timeout gets a moment and keeps its open state.
+
+    The moment bounds the call: whatever happened, it happened before then. The
+    state is what stops a reader treating the bound as a reply time -- which
+    would turn "we never found out" into a measured latency, and a request that
+    may have been billed into one that demonstrably was not.
+    """
+    clock = Clock()
+    with _open(tmp_path, "l.sqlite3", price_table, clock=clock) as ledger:
+        call_id = _reserve(ledger, "task-a")
+        clock.advance(1800)
+        ledger.leave_unresolved(call_id, note="request_timed_out")
+        row = _row(ledger, call_id)
+
+    assert row["concluded_at"] == "2026-09-11T03:30:00.000+00:00"
+    assert row["state"] == STATE_RESERVED
+
+
+# ── a stamp is written once ──────────────────────────────────────────────
+
+
+def test_re_reserving_a_call_does_not_move_the_moment_it_left(
+    tmp_path, price_table
+):
+    """A resumed round re-reserves calls it already recorded.
+
+    Letting the second reservation win would restamp a call that went out hours
+    earlier with the resume's clock, and every window drawn around it would be
+    drawn in the wrong place.
+    """
+    clock = Clock()
+    with _open(tmp_path, "l.sqlite3", price_table, clock=clock) as ledger:
+        call_id = _reserve(ledger, "task-a")
+        clock.advance(7200)
+        _reserve(ledger, "task-a")
+        row = _row(ledger, call_id)
+
+    assert row["reserved_at"] == "2026-09-11T03:00:00.000+00:00"
+
+
+def test_settling_the_same_call_twice_does_not_move_its_conclusion(
+    tmp_path, price_table
+):
+    clock = Clock()
+    with _open(tmp_path, "l.sqlite3", price_table, clock=clock) as ledger:
+        call_id = _reserve(ledger, "task-a")
+        clock.advance(10)
+        ledger.settle(call_id, usage=_usage(), resolved_model="test-model")
+        clock.advance(600)
+        ledger.settle(call_id, usage=_usage(), resolved_model="test-model")
+        row = _row(ledger, call_id)
+
+    assert row["concluded_at"] == "2026-09-11T03:00:10.000+00:00"
+
+
+def test_refusing_the_same_call_twice_does_not_move_its_conclusion(
+    tmp_path, price_table
+):
+    clock = Clock()
+    with _open(tmp_path, "l.sqlite3", price_table, clock=clock) as ledger:
+        call_id = _reserve(ledger, "task-a")
+        clock.advance(5)
+        ledger.refuse(call_id, status=429)
+        clock.advance(500)
+        ledger.refuse(call_id, status=429)
+        row = _row(ledger, call_id)
+
+    assert row["concluded_at"] == "2026-09-11T03:00:05.000+00:00"
+
+
+def test_a_call_we_gave_up_on_and_later_settled_takes_the_real_moment(
+    tmp_path, price_table
+):
+    """Settling after giving up is the one case where the stamp should move.
+
+    ``leave_unresolved`` wrote a bound; a reply is the thing the bound was
+    standing in for. The rule is not "first write wins" but "an answer beats a
+    bound", and only the settle path can tell the difference.
+    """
+    clock = Clock()
+    with _open(tmp_path, "l.sqlite3", price_table, clock=clock) as ledger:
+        call_id = _reserve(ledger, "task-a")
+        clock.advance(1800)
+        ledger.leave_unresolved(call_id, note="request_timed_out")
+        clock.advance(30)
+        ledger.settle(call_id, usage=_usage(), resolved_model="test-model")
+        row = _row(ledger, call_id)
+
+    # COALESCE keeps the bound, which is the conservative reading: the ledger
+    # never claims a reply arrived later than the moment it stopped waiting.
+    assert row["concluded_at"] == "2026-09-11T03:30:00.000+00:00"
+    assert row["state"] == STATE_SETTLED
+
+
+# ── the clock itself ─────────────────────────────────────────────────────
+
+
+def test_a_clock_with_no_timezone_is_refused_rather_than_assumed_to_be_utc(
+    tmp_path, price_table
+):
+    """The failure this guard exists for is invisible in the output.
+
+    A naive datetime stores as a perfectly well-formed timestamp. If the box
+    runs on local time, every stamp is off by the offset, the text gives no
+    sign of it, and a one-minute window drawn from a set of them is wrong by
+    hours. Refusing at the write is the only place the error is still visible.
+    """
+    naive = lambda: datetime(2026, 9, 11, 3, 0, 0)  # noqa: E731
+    with _open(tmp_path, "l.sqlite3", price_table, clock=naive) as ledger:
+        with pytest.raises(LedgerIntegrityError) as caught:
+            _reserve(ledger, "task-a")
+
+    assert "timezone" in str(caught.value)
+
+
+def test_a_clock_in_another_zone_is_stored_as_utc(tmp_path, price_table):
+    """Shards may run anywhere. Two rows must be comparable as written."""
+    elsewhere = timezone(timedelta(hours=9))
+    clock = lambda: datetime(2026, 9, 11, 12, 0, 0, tzinfo=elsewhere)  # noqa: E731
+    with _open(tmp_path, "l.sqlite3", price_table, clock=clock) as ledger:
+        call_id = _reserve(ledger, "task-a")
+        row = _row(ledger, call_id)
+
+    assert row["reserved_at"] == "2026-09-11T03:00:00.000+00:00"
+
+
+def test_the_default_clock_is_the_wall_clock_in_utc(tmp_path, price_table):
+    """No injection in production. The default has to be right on its own."""
+    before = datetime.now(timezone.utc)
+    with _open(tmp_path, "l.sqlite3", price_table) as ledger:
+        call_id = _reserve(ledger, "task-a")
+        row = _row(ledger, call_id)
+    after = datetime.now(timezone.utc)
+
+    stamped = datetime.fromisoformat(row["reserved_at"])
+    assert stamped.tzinfo is not None
+    assert before - timedelta(seconds=1) <= stamped <= after + timedelta(seconds=1)
+
+
+# ── the stamps survive the journey to the artifact ───────────────────────
+
+
+def test_the_moments_reach_the_export_a_run_uploads(tmp_path, price_table):
+    """The analysis reads the exported JSONL months later, not this SQLite file."""
+    clock = Clock()
+    with _open(tmp_path, "l.sqlite3", price_table, clock=clock) as ledger:
+        call_id = _reserve(ledger, "task-a")
+        clock.advance(60)
+        ledger.settle(call_id, usage=_usage(), resolved_model="test-model")
+        export = tmp_path / "ledger.jsonl"
+        ledger.export_jsonl(export)
+
+    rows = [json.loads(line) for line in export.read_text().splitlines() if line]
+    call = [row for row in rows if row.get("call_id") == call_id][0]
+    assert call["reserved_at"] == "2026-09-11T03:00:00.000+00:00"
+    assert call["concluded_at"] == "2026-09-11T03:01:00.000+00:00"
+
+
+def test_a_merged_shard_keeps_the_moments_it_was_written_with(
+    tmp_path, price_table
+):
+    clock = Clock()
+    with _open(tmp_path, "shard.sqlite3", price_table, clock=clock) as shard:
+        call_id = _reserve(shard, "task-a")
+        clock.advance(45)
+        shard.settle(call_id, usage=_usage(), resolved_model="test-model")
+        export = tmp_path / "shard.jsonl"
+        shard.export_jsonl(export)
+
+    later = Clock(START + timedelta(days=1))
+    with _open(tmp_path, "merged.sqlite3", price_table, clock=later) as merged:
+        merged.import_jsonl(export)
+        row = _row(merged, call_id)
+
+    assert row["reserved_at"] == "2026-09-11T03:00:00.000+00:00"
+    assert row["concluded_at"] == "2026-09-11T03:00:45.000+00:00"
+
+
+def test_an_export_from_before_these_columns_does_not_erase_a_local_moment(
+    tmp_path, price_table
+):
+    """An older build's export carries no times. Its blanks must not win.
+
+    The local row was reserved here, so it knows when the request left. An
+    arriving export that predates the columns knows how the call ended and
+    nothing about when. Taking the whole arriving row would trade a recorded
+    fact for the absence of one -- the same trap the identity columns already
+    guard against.
+    """
+    clock = Clock()
+    with _open(tmp_path, "local.sqlite3", price_table, clock=clock) as ledger:
+        call_id = _reserve(ledger, "task-a")
+
+        old_export = tmp_path / "old.jsonl"
+        old_export.write_text(
+            json.dumps(
+                {
+                    "record_type": "call",
+                    "call_id": call_id,
+                    "run_id": ledger.run_id,
+                    "task_id": "task-a",
+                    "stage": STAGE_GENERATION,
+                    "retry_kind": RETRY_NONE,
+                    "provider": "azure",
+                    "requested_model": "a-deployment",
+                    "resolved_model": "test-model",
+                    "state": STATE_SETTLED,
+                    "input_tokens": 100_000,
+                    "cached_input_tokens": 0,
+                    "output_tokens": 10_000,
+                    "reasoning_tokens": 0,
+                    "missing_reasons": [],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        ledger.import_jsonl(old_export)
+        row = _row(ledger, call_id)
+
+    assert row["state"] == STATE_SETTLED
+    assert row["reserved_at"] == "2026-09-11T03:00:00.000+00:00"
+
+
+def test_a_ledger_written_before_these_columns_still_opens(tmp_path, price_table):
+    """And its old rows say "not recorded", not a guessed time.
+
+    Resume reopens the previous round's file. A round-2 process that could not
+    read a round-1 ledger would be a worse failure than the missing timestamps
+    -- and backfilling the old rows with anything at all would be inventing the
+    measurement this whole change exists to start taking.
+    """
+    path = tmp_path / "old.sqlite3"
+    connection = sqlite3.connect(str(path))
+    connection.executescript(
+        """
+        CREATE TABLE cost_calls (
+            call_id TEXT PRIMARY KEY, run_id TEXT NOT NULL, task_id TEXT NOT NULL,
+            stage TEXT NOT NULL, retry_kind TEXT NOT NULL, provider TEXT NOT NULL,
+            requested_model TEXT NOT NULL, state TEXT NOT NULL,
+            missing_reasons TEXT NOT NULL DEFAULT '[]'
+        );
+        """
+    )
+    connection.execute(
+        "INSERT INTO cost_calls (call_id, run_id, task_id, stage, retry_kind, "
+        "provider, requested_model, state) VALUES "
+        "('old-call', 'run-1', 'task-a', ?, ?, 'azure', 'a-deployment', ?)",
+        (STAGE_GENERATION, RETRY_NONE, STATE_SETTLED),
+    )
+    connection.commit()
+    connection.close()
+
+    clock = Clock()
+    with CostReceiptLedger(
+        path, run_id="run-1", price_table=price_table, clock=clock
+    ) as ledger:
+        old = _row(ledger, "old-call")
+        fresh = _reserve(ledger, "task-b")
+        fresh_row = _row(ledger, fresh)
+
+    assert old["reserved_at"] is None
+    assert old["concluded_at"] is None
+    assert fresh_row["reserved_at"] == "2026-09-11T03:00:00.000+00:00"
+
+
+# ── what the stamps were added for ───────────────────────────────────────
+
+
+def test_the_tokens_settled_before_a_refusal_can_now_be_counted(
+    tmp_path, price_table
+):
+    """The question run 34540053904 could not answer, answered on a fixture.
+
+    Four calls settle inside one minute and a fifth is refused. Separating a
+    token-per-minute ceiling from a deployment's throughput needs the sum of
+    tokens that landed in the window ending at the refusal -- and needs to
+    *exclude* the one that settled outside it. This is the whole reason the two
+    columns exist, so it is checked end to end from the exported artifact
+    rather than from the live ledger.
+
+    The number itself proves nothing about Azure. What it proves is that the
+    artifact now carries enough to compute it, which is what was missing.
+    """
+    clock = Clock()
+    with _open(tmp_path, "l.sqlite3", price_table, clock=clock) as ledger:
+        long_ago = _reserve(ledger, "task-old", sequence=0)
+        ledger.settle(long_ago, usage=_usage(500_000), resolved_model="test-model")
+
+        clock.advance(300)
+        for index in range(1, 5):
+            call_id = _reserve(ledger, f"task-{index}", sequence=index)
+            clock.advance(10)
+            ledger.settle(
+                call_id, usage=_usage(200_000), resolved_model="test-model"
+            )
+
+        refused = _reserve(ledger, "task-refused", sequence=9)
+        clock.advance(1)
+        ledger.refuse(refused, status=429)
+
+        export = tmp_path / "ledger.jsonl"
+        ledger.export_jsonl(export)
+
+    rows = [json.loads(line) for line in export.read_text().splitlines() if line]
+    calls = {row["call_id"]: row for row in rows if row.get("record_type") == "call"}
+
+    refusal_at = datetime.fromisoformat(calls[refused]["concluded_at"])
+    window_opens = refusal_at - timedelta(minutes=1)
+
+    tokens_in_window = sum(
+        (row.get("input_tokens") or 0) + (row.get("output_tokens") or 0)
+        for row in calls.values()
+        if row.get("state") == STATE_SETTLED
+        and window_opens
+        <= datetime.fromisoformat(row["concluded_at"])
+        <= refusal_at
+    )
+
+    # The four recent calls, and not the one from five minutes earlier.
+    assert tokens_in_window == 4 * 210_000
+    assert calls[long_ago]["state"] == STATE_SETTLED
+    assert datetime.fromisoformat(calls[long_ago]["concluded_at"]) < window_opens
+
+
+def test_the_receipt_is_unchanged_by_any_of_this(tmp_path, price_table):
+    """Timing is new evidence, not a new claim about money.
+
+    A change to the ledger that moved a dollar figure would be a change to what
+    the run says it spent, which is not what this is.
+    """
+    clock = Clock()
+    with _open(tmp_path, "l.sqlite3", price_table, clock=clock) as ledger:
+        call_id = _reserve(ledger, "task-a")
+        ledger.settle(call_id, usage=_usage(), resolved_model="test-model")
+        receipt = ledger.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert receipt.status == "complete"
+    assert receipt.model_calls == 1
+    # 100,000 input at $10/M plus 10,000 output at $20/M.
+    assert receipt.estimated_cost_usd == Decimal("1.20")


### PR DESCRIPTION
## 무엇이 문제였나

실행 `34540053904`(exp034, 30문제)은 **한 가지를 가리려고** 돌린 실행입니다. 저희 요청을 거절하는 것이 **요청량(RPM) / 토큰 예약량(TPM) / 배포 처리량 / 호출 간격** 중 무엇인가.

산출물이 네 후보 중 **둘은 응답 근거로 지웠습니다.**

| 후보 | 판정 | 근거 |
|---|---|---|
| 요청량(RPM) | ❌ 아님 | 한 번에 한 문제씩 순차 실행. 186.5분에 53회 = **분당 0.28회** |
| 호출 간격 | ❌ 단독 원인 아님 | 60 → 120 → 240초로 늘려 기다렸는데도 **5건은 끝내 거절** |
| 토큰 예약량(TPM) | ⚠️ 못 가림 | 아래 |
| 배포 처리량 | ⚠️ 못 가림 | 아래 |

남은 둘을 가르려면 **거절당한 그 순간 직전 1분 동안 토큰이 얼마나 정산됐는지**를 물어야 합니다. 그건 움직이는 창(rolling window)이고, 창에는 **시계**가 필요합니다.

`cost_calls` 테이블은 **59줄 전부에 토큰 수를 적고, 한 줄에도 시각을 적지 않았습니다.** 그릴 창 자체가 없었습니다.

산출물에 남은 나머지는 원인이 아니라 **실패의 결과**입니다.

- 거절당한 턴의 토큰 수는 **그 거절 때문에 잘린** 숫자입니다.
- 문제별 분당 토큰은 **기다린 60/120/240초를 제 분모 안에** 넣고 있습니다.

## 무엇을 했나

`cost_calls`에 nullable 칸 두 개입니다.

| 칸 | 무엇을 적나 |
|---|---|
| `reserved_at` | **요청이 나간 시각.** 예약제라면 이 시각을 기준으로 셉니다 — 예약은 받아들여질 때 잡히니까요 |
| `concluded_at` | **이 프로세스가 기다림을 멈춘 시각.** 답이 왔거나, 거절당했거나, 애초에 나가지 않았음을 알았거나, 포기했거나 |

네 번째(`leave_unresolved`)는 소리 내어 말해 둘 필요가 있습니다. 시각은 찍되 줄은 **`RESERVED` 상태 그대로** 둡니다. 그 호출이 응답을 받았는지 **아무도 모르기 때문입니다.** 이때의 시각은 응답 시각이 아니라 **한계선**입니다 — 그 요청에 무슨 일이 일어났든 이 시각 **이전에** 일어났습니다. 상태를 그대로 두는 것이, 읽는 사람이 *포기*를 *도착*으로 읽는 것을 막습니다.

## 테스트가 못 박은 세 가지

셋 다 **출력만 봐서는 안 보이는** 고장입니다.

1. **타임존 없는 시각은 쓰는 순간 거절합니다.** 그대로 두면 완벽하게 잘 생긴 타임스탬프가 *어느 지역인지 모른 채* 저장됩니다. 한 시간의 오차는 글자에는 안 보이지만 **1분짜리 창을 완전히 망가뜨립니다.** 이 칸은 바로 그 창을 위해 있습니다.
2. **시각은 한 번만 씁니다.** 재개(resume)한 회차는 이미 기록된 호출을 다시 예약합니다. 두 번째 쓰기가 이기면, **몇 시간 전에 나간 호출이 재개 시점의 시계로 다시 찍힙니다.**
3. **이 칸이 없던 빌드가 만든 export는 로컬 시각을 지우지 못합니다.** 기존 identity 칸과 같은 규칙입니다. 로컬 줄은 여기서 예약됐으니 **요청이 언제 나갔는지 압니다.** 건너온 export는 호출이 어떻게 끝났는지는 알아도 언제 나갔는지는 모릅니다. 빈칸이 이기면 **사실 하나를 지우고 그 자리에 "사실 없음"을 넣는 일**이 됩니다.

## 기존 원장은 어떻게 되나

`_migrate_columns`는 원래 이런 경우를 위해 **nullable 칸을 덧붙이는 `ALTER TABLE`만** 합니다. 기존 원장은 그대로 열리고, 옛날 줄은 `NULL`로 읽힙니다.

그게 **정직한 답**입니다 — 그 실행들은 이걸 기록하지 않았습니다. **아무것도 추측해서 채워 넣지 않습니다.**

두 이름은 `_CALL_COLUMNS`에 들어갑니다. export·import·마이그레이션이 모두 이 튜플 하나를 돌기 때문에, 시각은 **다른 모든 칸과 똑같은 경로로** 업로드되는 JSONL에 실립니다.

## 돈 이야기

**금액은 한 푼도 안 움직입니다.** 이건 *언제*에 대한 새 근거이지 *비용*에 대한 새 주장이 아닙니다. 영수증이 그대로임을 테스트가 못 박습니다 (`status == complete`, `model_calls == 1`, `estimated_cost_usd == 1.20`).

## 검증

| | |
|---|---|
| 새 테스트 | **18개 전부 통과** |
| 변경한 줄을 일부러 망가뜨려 봄 | **8군데 전부** 이름 붙은 테스트가 잡아냄 |
| 망가뜨린 뒤 소스 복원 | 매번 **바이트 단위로 동일** |
| 백엔드 전체 | **10,529 통과 / 18 skip / 실패 0** (22분 34초) |

돌려 본 대표 테스트 하나는 `test_the_tokens_settled_before_a_refusal_can_now_be_counted`입니다. 거절 직전 1분 창 안의 토큰만 더해 `4 × 210,000`을 얻고, **5분 전의 호출은 창 밖이라 빼는지**를 확인합니다. 이 계산이 이번 변경 이전에는 **불가능했습니다.**

## 다음

측정의 나머지 반쪽 — **배포에 선언된 한도**, 즉 이 분자를 나눌 **분모** — 는 다음 PR입니다. 기존 워크플로가 이미 가진 자격증명으로 하는 **ARM 제어 평면 읽기**이고 **새 권한이 필요 없습니다.**

둘 다 비용이 들지 않고, 둘 다 **exp035(220문제) 전에** 들어갑니다. 그래서 220문제 실행이 이 근거를 **부산물로** 남기게 됩니다. **이걸 알아내자고 유료 실행을 따로 걸지 않습니다.**
