### PR TITLE
feat(agentic): let a model drive a V2 run, and bind a cohort to it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,6 +256,12 @@ tasks/0822_saturday/*
 # against -- so a cohort quietly edited after seeing a score fails here rather
 # than passing unnoticed.
 !tasks/0822_saturday/v2_run_preregistration.json
+# The four probes that overturned the recorded block. A correction is worth less
+# than the thing it was corrected by: the prose says a gpt-5.4 deployment
+# answers in this box's own tenant, and this is the endpoint-by-endpoint record
+# that says so, including the token counts the 0.0018 USD is derived from and
+# the four things it deliberately does not prove.
+!tasks/0822_saturday/model_reachability_survey.json
 !tasks/0828_friday/
 tasks/0828_friday/*
 !tasks/0828_friday/TASK_PER_TASK_COST_RECEIPTS.md

--- a/batch-runner/core/agentic_v2_conversation.py
+++ b/batch-runner/core/agentic_v2_conversation.py
@@ -284,9 +284,26 @@ class DispatcherToolDesk:
     against the published contract, counts the call against its own ceiling,
     and refuses ``exec_run`` exactly as it does today. This adapter only
     reshapes what comes back into the form the loop reads.
+
+    ``dispatch`` exists because a dispatcher inside a live run is not reached
+    directly. :class:`core.agentic_v2_runner.AgenticV2ScriptedRunner` owes every
+    tool call a cancel check, a deadline check, a state commitment and two
+    chain appends, and a desk that called ``dispatcher.dispatch`` itself would
+    skip all four and produce a run record that looks like the others and is
+    not. So the runner hands in its own bookkeeping wrapper and this adapter
+    calls that instead. It takes the same keyword arguments and returns the
+    same dispatch, so nothing about the reshaping below changes.
     """
 
-    dispatcher: AgenticV2ToolDispatcher
+    dispatcher: Optional[AgenticV2ToolDispatcher] = None
+    dispatch: Optional[Callable[..., Any]] = None
+
+    def __post_init__(self) -> None:
+        if self.dispatch is None and self.dispatcher is None:
+            raise ValueError(
+                "a tool desk needs somewhere to send calls: pass a dispatcher, "
+                "or the dispatch function of a run that is already open"
+            )
 
     def run_one(
         self,
@@ -295,9 +312,12 @@ class DispatcherToolDesk:
         tool_name: str,
         arguments: Mapping[str, Any],
     ) -> ToolOutcome:
-        dispatch = self.dispatcher.dispatch(
-            call_id=call_id, name=tool_name, arguments=arguments
-        )
+        send = self.dispatch
+        if send is None:
+            # __post_init__ has already established that one of the two is
+            # present, so this is the dispatcher and not None.
+            send = self.dispatcher.dispatch  # type: ignore[union-attr]
+        dispatch = send(call_id=call_id, name=tool_name, arguments=arguments)
         result = dispatch.result
         usage = result.get("usage_delta") or {}
         return ToolOutcome(

--- a/batch-runner/core/agentic_v2_conversation_runner.py
+++ b/batch-runner/core/agentic_v2_conversation_runner.py
@@ -1,0 +1,398 @@
+"""The join: a model conversation, a V2 run place, and a 220-task driver.
+
+Three things existed and did not meet.
+:func:`core.agentic_v2_conversation.run_model_conversation` asks a model and
+runs what it asks for. :class:`core.agentic_v2_runner.AgenticV2ScriptedRunner`
+admits a backend, enforces the tool contract and produces a verified record.
+:func:`core.agentic_v2_run_driver.run_manifest` walks a fixed manifest, resumes,
+collects files and stops when it should. This module is the wiring between them,
+and it is the last structural piece of "model call → tool choice → isolated
+``exec_run`` → result files → next model call" that was missing.
+
+**Where the conversation's record goes, and why not in the result.**
+:func:`core.agentic_v2_provenance.verify_agentic_v2_result` compares the
+envelope's key set for exact equality, so an extra field would make every
+successful run unverifiable. That is a good rule and this module does not bend
+it: the conversation outcome is kept by :class:`TaskConversations`, beside the
+run rather than inside it. A caller that wants the stop reason, the turns, or
+the token counts asks that.
+
+**Why a fresh budget per task and not one for the run.** A single
+:class:`~core.agentic_v2_stage_one_budget.StageOneBudget` shared across 220
+tasks would let the first tasks spend what the last ones needed, and the run
+would report 180 honest results and 40 refusals that say nothing about the
+model. So each task gets its own ceiling. The run-wide total is not thereby
+abandoned — :attr:`TaskConversations.spent` sums what every task actually used,
+and :meth:`TaskConversations.run_wide_refusal` is asked before each task, so an
+overall cap still stops the run. Two different limits, both enforced, neither
+pretending to be the other.
+
+**On token counts.** Every :class:`~core.agentic_v2_conversation.TurnRecord`
+that exists carries counts the provider really reported: the loop stops with
+``model_reply_unusable`` rather than recording a reply whose usage it could not
+read. So :func:`model_turns_of` may build :class:`~core.cost_receipts.CallUsage`
+from them directly without a zero ever standing in for an unknown.
+
+**Why this file is not in the foundation fingerprint.**
+:data:`~core.agentic_v2_provenance._FOUNDATION_MODULES` covers the five files
+that define and enforce the tool contract and write the record.
+:mod:`core.agentic_v2_conversation` is already outside it and this file is too,
+on the same reasoning: deciding *which* calls to make is not the same as
+enforcing what a call may do, and every call this module causes still passes
+through the fingerprinted ``dispatch_one``. Listing it here would make a change
+to the wiring invalidate the attestation of runs that never used it.
+
+**What this does not do.** It does not build a model client, name a deployment,
+open :data:`exec_run`, change ``foundation_only`` or ``production_activation``,
+or decide that something is affordable. The voice is a parameter. Passing a real
+one is a separate, reviewable change, and the deployment it would reach is still
+behind a role assignment nobody in this repository may grant.
+
+It also does not pass an ``admitted_identity`` through to the runner, although
+the runner accepts one. ``AgenticV2ScriptedRunner`` is the only file in ``core``
+allowed to mention that argument, and
+``test_nothing_in_this_repository_declares_a_non_default_identity`` enforces it
+by reading every other module's source. That test is the standing evidence for
+the claim that the guest is mapped and not run, and a wiring module that
+forwarded the argument would retire the claim in exchange for a parameter no
+caller uses today. When a run is admitted for real, adding it back is part of
+that change, and that test is the line that changes with it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping, Optional, Sequence
+
+from core.agentic_v2_conversation import (
+    DispatcherToolDesk,
+    LoopLimits,
+    run_model_conversation,
+)
+from core.agentic_v2_contract import TOOL_NAMES
+from core.agentic_v2_cost_binding import ModelTurn, retry_kind_for_error
+from core.agentic_v2_runner import AgenticV2ScriptedRunner
+from core.agentic_v2_stage_one_budget import StageOneBudget
+from core.cost_receipts import CallUsage, RETRY_NONE
+
+
+class ConversationRunnerRefused(RuntimeError):
+    """The run was not wired up, because wiring it that way would be unsound."""
+
+
+@dataclass(frozen=True)
+class PerTaskCeilings:
+    """What one task may spend before it is stopped.
+
+    Every field is required. :class:`~core.agentic_v2_conversation.LoopLimits`
+    already refuses a run with a ceiling nobody set, and this type exists so
+    that the refusal happens once when the run is configured rather than 220
+    times when it is too late to fix.
+    """
+
+    max_model_turns: int
+    max_written_tokens_per_turn: int
+    max_seconds: float
+    max_model_calls: int
+    max_input_tokens: int
+    max_output_tokens: int
+    max_repeats_of_one_request: int
+
+    def fresh_limits(self) -> LoopLimits:
+        """A new set of ceilings, with a budget that has spent nothing."""
+        return LoopLimits(
+            max_model_turns=self.max_model_turns,
+            max_written_tokens_per_turn=self.max_written_tokens_per_turn,
+            max_seconds=self.max_seconds,
+            budget=StageOneBudget(
+                max_model_calls=self.max_model_calls,
+                max_input_tokens=self.max_input_tokens,
+                max_output_tokens=self.max_output_tokens,
+            ),
+            max_repeats_of_one_request=self.max_repeats_of_one_request,
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "max_model_turns": self.max_model_turns,
+            "max_written_tokens_per_turn": self.max_written_tokens_per_turn,
+            "max_seconds": self.max_seconds,
+            "max_model_calls": self.max_model_calls,
+            "max_input_tokens": self.max_input_tokens,
+            "max_output_tokens": self.max_output_tokens,
+            "max_repeats_of_one_request": self.max_repeats_of_one_request,
+        }
+
+
+@dataclass(frozen=True)
+class RunWideCeilings:
+    """What a whole run may spend, across every task and every attempt.
+
+    Separate from :class:`PerTaskCeilings` because the two answer different
+    questions. A per-task ceiling stops one task from running away; this stops
+    the run. ``None`` on a field means nobody set that one, and — unlike the
+    per-task case — that is allowed here, because a run may legitimately be
+    bounded by turns and not by tokens.
+    """
+
+    max_model_calls: Optional[int] = None
+    max_input_tokens: Optional[int] = None
+    max_output_tokens: Optional[int] = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "max_model_calls": self.max_model_calls,
+            "max_input_tokens": self.max_input_tokens,
+            "max_output_tokens": self.max_output_tokens,
+        }
+
+
+@dataclass
+class TaskConversations:
+    """Every task's conversation, kept beside the runs rather than inside them.
+
+    Keyed by ``(task_id, attempt)``, because a retried task holds two
+    conversations and averaging them or keeping only the last would lose the
+    first attempt's spend — which was charged for regardless of how the task
+    ended.
+    """
+
+    per_task: PerTaskCeilings
+    run_wide: RunWideCeilings = field(default_factory=RunWideCeilings)
+    outcomes: dict[tuple[str, int], Any] = field(default_factory=dict)
+    budgets: dict[tuple[str, int], StageOneBudget] = field(default_factory=dict)
+
+    # -- what has been spent ------------------------------------------------
+
+    @property
+    def spent(self) -> dict[str, int]:
+        """The run's totals, summed over every attempt of every task."""
+        return {
+            "model_calls": sum(b.model_calls_made for b in self.budgets.values()),
+            "input_tokens": sum(b.input_tokens_used for b in self.budgets.values()),
+            "output_tokens": sum(b.output_tokens_used for b in self.budgets.values()),
+        }
+
+    def run_wide_refusal(self) -> str | None:
+        """Why the next task may not start, or ``None`` if it may.
+
+        Asked before a task rather than after it, for the same reason
+        :meth:`~core.agentic_v2_stage_one_budget.StageOneBudget.refusal_before_next_call`
+        is: a ceiling checked afterwards is a report, not a limit.
+        """
+        spent = self.spent
+        for name, used in (
+            ("max_model_calls", spent["model_calls"]),
+            ("max_input_tokens", spent["input_tokens"]),
+            ("max_output_tokens", spent["output_tokens"]),
+        ):
+            cap = getattr(self.run_wide, name)
+            if cap is not None and used >= cap:
+                return (
+                    f"this run has used {used} against a run-wide {name} of "
+                    f"{cap}, so the next task was not started"
+                )
+        return None
+
+    # -- recording ----------------------------------------------------------
+
+    def limits_for(self, task_id: str, attempt: int) -> LoopLimits:
+        limits = self.per_task.fresh_limits()
+        assert limits.budget is not None  # fresh_limits always builds one
+        self.budgets[(task_id, attempt)] = limits.budget
+        return limits
+
+    def record(self, task_id: str, attempt: int, outcome: Any) -> None:
+        self.outcomes[(task_id, attempt)] = outcome
+
+    def attempts_of(self, task_id: str) -> tuple[int, ...]:
+        return tuple(
+            sorted(attempt for (tid, attempt) in self.outcomes if tid == task_id)
+        )
+
+    def outcome_of(self, task_id: str, attempt: int) -> Any:
+        return self.outcomes.get((task_id, attempt))
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "per_task_ceilings": self.per_task.as_dict(),
+            "run_wide_ceilings": self.run_wide.as_dict(),
+            "spent": self.spent,
+            "conversations": {
+                f"{task_id}#{attempt}": outcome.as_dict()
+                for (task_id, attempt), outcome in sorted(self.outcomes.items())
+            },
+        }
+
+
+def conversation_seam(
+    *,
+    voice: Any,
+    limits: LoopLimits,
+    tools_available: Sequence[str] = TOOL_NAMES,
+    cancel_requested: Optional[Callable[[], bool]] = None,
+    on_outcome: Optional[Callable[[Any], None]] = None,
+) -> Callable[[str, Callable[..., Any]], Any]:
+    """A callable the runner can hand its dispatch function to.
+
+    The desk is built around ``dispatch`` — the runner's own bookkeeping
+    wrapper — and not around the dispatcher, so every call the model makes gets
+    the cancel check, the deadline, the state commitment and the two chain
+    appends that a scripted call gets. A desk that reached past it would produce
+    a record that looks the same and proves less.
+    """
+
+    def converse(task_prompt: str, dispatch: Callable[..., Any]) -> Any:
+        outcome = run_model_conversation(
+            task_prompt=task_prompt,
+            voice=voice,
+            desk=DispatcherToolDesk(dispatch=dispatch),
+            limits=limits,
+            tools_available=tools_available,
+            cancel_requested=cancel_requested,
+        )
+        if on_outcome is not None:
+            on_outcome(outcome)
+        return outcome
+
+    return converse
+
+
+def build_runner_factory(
+    *,
+    backend_factory: Callable[..., Any],
+    profile: Mapping[str, Any],
+    voice: Any,
+    conversations: TaskConversations,
+    attempt_of: Callable[[str], int],
+    budget_caps: Optional[Mapping[str, Any]] = None,
+    required_backend_type: type | None = None,
+    cancel_requested: Optional[Callable[[], bool]] = None,
+    tools_available: Sequence[str] = TOOL_NAMES,
+) -> Callable[[Any], AgenticV2ScriptedRunner]:
+    """A ``runner_factory`` for :func:`core.agentic_v2_run_driver.run_manifest`.
+
+    ``attempt_of`` is asked which attempt this is for a task, because the driver
+    builds a runner before it knows how the attempt will end and the ledger
+    needs the two kept apart. A caller with a journal in hand can answer from
+    it; a caller without one can count.
+
+    The run-wide ceiling is checked here rather than inside the runner. Refusing
+    at the factory means the task is never started and no guest is booted for a
+    run that has already spent what it had.
+    """
+    if voice is None:
+        raise ConversationRunnerRefused(
+            "a conversation needs a voice; there is no default model and "
+            "choosing one here would be this module deciding what a run costs"
+        )
+
+    def build(task: Any) -> AgenticV2ScriptedRunner:
+        refusal = conversations.run_wide_refusal()
+        if refusal is not None:
+            raise ConversationRunnerRefused(refusal)
+        task_id = str(getattr(task, "task_id", "unknown-task"))
+        attempt = int(attempt_of(task_id))
+        limits = conversations.limits_for(task_id, attempt)
+        return AgenticV2ScriptedRunner(
+            backend_factory=backend_factory,
+            conversation=conversation_seam(
+                voice=voice,
+                limits=limits,
+                tools_available=tools_available,
+                cancel_requested=cancel_requested,
+                on_outcome=lambda outcome: conversations.record(
+                    task_id, attempt, outcome
+                ),
+            ),
+            profile=profile,
+            budget_caps=budget_caps,
+            cancel_requested=cancel_requested,
+            required_backend_type=required_backend_type,
+        )
+
+    return build
+
+
+def model_turns_of(
+    outcome: Any,
+    *,
+    run_id: str,
+    task_id: str,
+    attempt: int,
+    provider: str,
+    requested_model: str,
+    deployment: str | None = None,
+    api_version: str | None = None,
+    resolved_model: str | None = None,
+    preceding_error: str | None = None,
+) -> tuple[ModelTurn, ...]:
+    """One task's conversation, as ledger entries.
+
+    ``call_id`` is namespaced by run, task and attempt. The ids inside a
+    conversation are the model's own and are only unique within it; writing them
+    into a shared ledger unqualified would have task 200's third call settle
+    against task 3's, and the corruption would show up as a total that is wrong
+    by an unknowable amount months later.
+
+    ``preceding_error`` is the error that caused this attempt to be made, or
+    ``None`` for a first attempt. It decides the retry kind, via the same
+    :func:`~core.agentic_v2_cost_binding.retry_kind_for_error` the rest of the
+    accounting uses, so a retried call is not silently billed as a first one.
+
+    That function returns ``None`` for an error after which there should be no
+    next attempt, and its docstring forbids callers from putting a kind of their
+    own choosing in that gap. So an attempt made after such an error is refused
+    here rather than labelled ``retry_none`` — which would file a retry that
+    should not exist as a first attempt and make the ledger's own retry counts
+    the wrong shape. The attempt has already happened by the time this is
+    called, so the refusal is loud on purpose: the caller's retry rule is wrong
+    and the spend is real.
+
+    ``resolved_model`` is what the provider said answered, which is not always
+    what was asked for. Left ``None`` when the caller does not know — a receipt
+    with no resolved model is incomplete, and incomplete is the honest state.
+    """
+    retry_kind = RETRY_NONE
+    if preceding_error is not None:
+        decided = retry_kind_for_error(preceding_error)
+        if decided is None:
+            raise ConversationRunnerRefused(
+                f"this attempt followed {preceding_error!r}, after which there "
+                "should have been no next attempt, so there is no honest retry "
+                "kind to file it under; the retry rule that produced it is "
+                "wrong and the calls it made were still charged for"
+            )
+        retry_kind = decided
+
+    turns = getattr(outcome, "turns", ()) or ()
+    entries: list[ModelTurn] = []
+    for record in turns:
+        entries.append(
+            ModelTurn(
+                call_id=f"{run_id}:{task_id}:{attempt}:{record.call_id}",
+                usage=CallUsage(
+                    input_tokens=record.input_tokens,
+                    output_tokens=record.output_tokens,
+                ),
+                provider=provider,
+                requested_model=requested_model,
+                deployment=deployment,
+                api_version=api_version,
+                resolved_model=resolved_model,
+                request_sha256=record.request_sha256,
+                retry_kind=retry_kind,
+            )
+        )
+    return tuple(entries)
+
+
+__all__ = [
+    "ConversationRunnerRefused",
+    "PerTaskCeilings",
+    "RunWideCeilings",
+    "TaskConversations",
+    "build_runner_factory",
+    "conversation_seam",
+    "model_turns_of",
+]

--- a/batch-runner/core/agentic_v2_manifest_binding.py
+++ b/batch-runner/core/agentic_v2_manifest_binding.py
@@ -1,0 +1,391 @@
+"""Turning a sealed cohort into tasks the driver can run — or refusing to.
+
+:mod:`core.agentic_v2_preregistration` fixes *which* tasks a stage runs: a list
+of task ids, pinned to a catalogue digest and a dataset revision, sealed before
+anything starts. :mod:`core.agentic_v2_run_driver` runs
+:class:`~core.agentic_v2_run_driver.TaskToRun` objects, which carry prompts.
+Nothing joined the two, and the join is not a lookup — it is the point at which
+"the manifest was fixed in advance" stops being a claim and becomes something a
+reader can check.
+
+**What is actually verified.** The committed catalogue records
+``prompt_sha256`` for every task, built as ``sha256(str(row["prompt"]).encode(
+"utf-8"))``. The dataset loader builds its prompt the same way, from the same
+column. So the two hashes are comparable exactly, and a prompt that differs by
+one character from the one the seal was computed over stops the run. This is a
+real check and not a length comparison; ``prompt_character_count`` is also
+pinned but is not what is compared, because two different prompts of the same
+length are easy and two different prompts with the same digest are not.
+
+Sector, occupation and the sorted reference-file paths are checked the same way.
+A cohort whose size no longer matches :data:`STAGE_SIZES` is refused before any
+of that, because a five-task stage that binds four tasks is not a smaller stage
+five, it is a different experiment.
+
+**What is deliberately not carried.** Every dataset row holds
+``deliverable_text`` and ``deliverable_files`` — the expert's own answer, which
+is what the run is scored against. A task handed to a model with its answer
+attached would score well and mean nothing. Those fields are never read here,
+and :data:`ANSWER_FIELDS_THAT_MUST_NOT_TRAVEL` is checked against
+``TaskToRun``'s own fields at import, so a later widening of that dataclass to
+carry an answer fails on import rather than in a result.
+
+**What is still missing, stated plainly.** ``TaskToRun.reference_files`` carries
+the *names* the dataset lists, because that is what the dataset gives and what
+:meth:`core.agentic_v2_runner.AgenticV2ScriptedRunner.run` accepts — it takes
+the list and passes it into the worker unchanged. Nothing yet copies those files
+into the guest's workspace as bytes. A bound task is therefore a task whose
+reference files are *named* and not *present*, and a task needing one of them to
+be opened will fail on its merits. That is a gap in the environment, not in this
+module, and :func:`unmet_needs` reports it per task so a stage-five result can
+be read knowing which tasks were asked to work without their inputs.
+
+Nothing here calls a model, opens a guest, or spends anything.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, fields
+from typing import Any, Iterable, Mapping, Sequence
+
+from core.agentic_v2_preregistration import (
+    ESCALATION,
+    STAGE_FIVE,
+    STAGE_SIZES,
+    STAGE_THIRTY,
+    STAGE_TWO_TWENTY,
+    manifest,
+    seal,
+)
+from core.agentic_v2_run_driver import TaskToRun
+from core.execution_envelope_tasks import (
+    CatalogTask,
+    TaskCatalog,
+    catalog_sha256,
+    full_run_tasks,
+    load_task_catalog,
+    select_advance_check_tasks,
+    select_trial_run_tasks,
+)
+
+
+BINDING_SCHEMA_VERSION = "agentic-v2-manifest-binding-v1"
+
+#: Dataset columns holding the expert's own answer.
+#:
+#: Named so that "the model was not shown the answer" is a checked property of
+#: this module rather than a habit of whoever wrote the loop.
+ANSWER_FIELDS_THAT_MUST_NOT_TRAVEL = (
+    "deliverable_text",
+    "deliverable_files",
+    "rubric_pretty",
+    "rubric_json",
+)
+
+_CARRIED = frozenset(field.name for field in fields(TaskToRun))
+
+_LEAKED = _CARRIED & set(ANSWER_FIELDS_THAT_MUST_NOT_TRAVEL)
+if _LEAKED:  # pragma: no cover - import guard
+    raise RuntimeError(
+        "TaskToRun now carries a field that holds the expert's own answer: "
+        f"{sorted(_LEAKED)}. A task handed to a model with its answer attached "
+        "scores well and means nothing."
+    )
+
+
+class ManifestRefused(RuntimeError):
+    """The cohort was not bound, because running it would not be the run that
+    was registered."""
+
+
+@dataclass(frozen=True)
+class BoundManifest:
+    """A stage's tasks, and the evidence that they are the registered ones."""
+
+    stage: str
+    tasks: tuple[TaskToRun, ...]
+    catalog_sha256: str
+    dataset_repo_id: str
+    dataset_revision: str
+    dataset_file_sha256: str
+    prompt_digests: tuple[tuple[str, str], ...]
+    preregistration_seal: str | None
+
+    @property
+    def task_ids(self) -> tuple[str, ...]:
+        return tuple(task.task_id for task in self.tasks)
+
+    def binding_seal(self) -> str:
+        """A digest over what was bound, for the run record to carry.
+
+        Distinct from :attr:`preregistration_seal`, which covers the plan. This
+        one covers the plan *and* the prompts that were found on disk for it, so
+        two runs of the same stage that read different data are distinguishable
+        even though their plans are identical.
+        """
+        return hashlib.sha256(
+            json.dumps(
+                self.as_dict(), sort_keys=True, ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": BINDING_SCHEMA_VERSION,
+            "stage": self.stage,
+            "task_ids": list(self.task_ids),
+            "catalog_sha256": self.catalog_sha256,
+            "dataset_repo_id": self.dataset_repo_id,
+            "dataset_revision": self.dataset_revision,
+            "dataset_file_sha256": self.dataset_file_sha256,
+            "prompt_digests": {
+                task_id: digest for task_id, digest in self.prompt_digests
+            },
+            "preregistration_seal": self.preregistration_seal,
+        }
+
+
+def _prompt_digest(prompt: str) -> str:
+    """Hashed the way the committed catalogue hashed it, or the check is void."""
+    return hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+
+
+def _drift(pinned: CatalogTask, row: Any) -> list[str]:
+    """Every way this dataset row is not the task the seal was computed over."""
+    problems: list[str] = []
+
+    digest = _prompt_digest(str(getattr(row, "prompt", "")))
+    if digest != pinned.prompt_sha256:
+        problems.append(
+            f"the prompt hashes to {digest} and the catalogue pinned "
+            f"{pinned.prompt_sha256}; this is a different prompt, so a run of "
+            "it is not the run that was registered"
+        )
+    for name in ("sector", "occupation"):
+        found = str(getattr(row, name, ""))
+        expected = getattr(pinned, name)
+        if found != expected:
+            problems.append(f"{name} is {found!r} and the catalogue pinned {expected!r}")
+
+    found_files = tuple(sorted(str(name) for name in getattr(row, "reference_files", ())))
+    if found_files != tuple(pinned.reference_file_paths):
+        problems.append(
+            f"the reference files are {list(found_files)} and the catalogue "
+            f"pinned {list(pinned.reference_file_paths)}"
+        )
+    return problems
+
+
+def _cohort_for(stage: str, catalog: TaskCatalog) -> tuple[str, ...]:
+    """Just this stage's task ids.
+
+    :func:`~core.agentic_v2_preregistration.cohorts` derives all three at once,
+    which means binding stage five would fail on a catalogue too small for the
+    thirty-task rule. The stages are run one at a time and a binding should
+    depend only on the one being bound.
+    """
+    if stage == STAGE_FIVE:
+        return select_advance_check_tasks(catalog).task_ids
+    if stage == STAGE_THIRTY:
+        return select_trial_run_tasks(catalog)
+    return full_run_tasks(catalog)
+
+
+def bind_stage(
+    stage: str,
+    *,
+    dataset_tasks: Iterable[Any],
+    catalog: TaskCatalog | None = None,
+    catalog_digest: str | None = None,
+    expected_seal: str | None = None,
+) -> BoundManifest:
+    """The tasks of one stage, checked against what was sealed before the run.
+
+    ``dataset_tasks`` is any iterable of rows carrying ``task_id``, ``prompt``,
+    ``sector``, ``occupation`` and ``reference_files`` —
+    :class:`prepare_dataset.GDPValTask` is one. It is a parameter rather than a
+    load so that this module holds no opinion about where the data came from and
+    a test needs no parquet.
+
+    ``catalog_digest`` is required whenever ``catalog`` is supplied.
+    :func:`~core.execution_envelope_tasks.catalog_sha256` hashes the *committed*
+    catalogue file regardless of what object is in hand, so recording its return
+    value beside a caller-supplied catalogue would label one catalogue with
+    another's fingerprint. Demanding the digest is how the binding avoids
+    claiming a provenance it cannot compute.
+
+    ``expected_seal``, when given, is compared against the pre-registration's
+    own seal. Passing it is how a run says *this* plan and not merely *a* plan.
+    """
+    if stage not in STAGE_SIZES:
+        raise ManifestRefused(
+            f"{stage!r} is not a registered stage; the escalation is "
+            f"{list(ESCALATION)}"
+        )
+    if catalog is None:
+        if catalog_digest is not None:
+            raise ManifestRefused(
+                "a catalogue digest was given without a catalogue; the "
+                "committed catalogue fingerprints itself"
+            )
+        catalog = load_task_catalog()
+        catalog_digest = catalog_sha256()
+    elif catalog_digest is None:
+        raise ManifestRefused(
+            "a catalogue was supplied without its digest, and the digest of a "
+            "supplied catalogue cannot be computed from the committed file; "
+            "pass catalog_digest or pass neither"
+        )
+    wanted = _cohort_for(stage, catalog)
+    expected_size = STAGE_SIZES[stage]
+    if len(wanted) != expected_size:
+        raise ManifestRefused(
+            f"stage {stage!r} selected {len(wanted)} tasks and the registration "
+            f"fixes {expected_size}; a stage of a different size is a different "
+            "experiment, not a smaller one"
+        )
+
+    # The seal covers the whole escalation, so computing it needs a catalogue
+    # every stage's rule can run against. A catalogue that cannot produce one
+    # has no plan seal, and that is recorded as ``None`` rather than invented —
+    # unless the caller named a seal to check, in which case being unable to
+    # compute one is the failure.
+    plan_seal: str | None = None
+    try:
+        plan_seal = seal(manifest(catalog))
+    except ValueError as error:
+        if expected_seal is not None:
+            raise ManifestRefused(
+                f"a seal was given to check against, and this catalogue cannot "
+                f"produce the escalation the seal covers: {error}"
+            ) from error
+    if expected_seal is not None and plan_seal != expected_seal:
+        raise ManifestRefused(
+            f"the manifest now seals to {plan_seal} and the run was registered "
+            f"against {expected_seal}; something that was fixed has moved"
+        )
+
+    rows: dict[str, Any] = {}
+    for row in dataset_tasks:
+        task_id = str(getattr(row, "task_id", ""))
+        if task_id in rows:
+            raise ManifestRefused(
+                f"the dataset carries {task_id!r} twice, so there is no single "
+                "prompt to bind"
+            )
+        rows[task_id] = row
+
+    missing = [task_id for task_id in wanted if task_id not in rows]
+    if missing:
+        raise ManifestRefused(
+            f"{len(missing)} registered task(s) are not in the dataset: "
+            f"{missing[:5]}"
+        )
+
+    pinned_by_id = catalog.by_task_id()
+    problems: list[str] = []
+    tasks: list[TaskToRun] = []
+    digests: list[tuple[str, str]] = []
+    for task_id in wanted:
+        row = rows[task_id]
+        pinned = pinned_by_id.get(task_id)
+        if pinned is None:
+            problems.append(f"{task_id}: chosen for the run but not in the catalogue")
+            continue
+        drifted = _drift(pinned, row)
+        if drifted:
+            problems.extend(f"{task_id}: {reason}" for reason in drifted)
+            continue
+        prompt = str(row.prompt)
+        digests.append((task_id, _prompt_digest(prompt)))
+        tasks.append(
+            TaskToRun(
+                task_id=task_id,
+                prompt=prompt,
+                occupation=pinned.occupation,
+                sector=pinned.sector,
+                # Names, not bytes. See the module docstring: nothing copies
+                # these into the guest yet, and ``unmet_needs`` says which tasks
+                # that costs.
+                reference_files=tuple(pinned.reference_file_paths),
+            )
+        )
+
+    if problems:
+        raise ManifestRefused(
+            "the dataset on disk is not the one the manifest was sealed "
+            "against:\n  " + "\n  ".join(problems[:10])
+        )
+
+    return BoundManifest(
+        stage=stage,
+        tasks=tuple(tasks),
+        catalog_sha256=str(catalog_digest),
+        dataset_repo_id=catalog.dataset_repo_id,
+        dataset_revision=catalog.dataset_revision,
+        dataset_file_sha256=catalog.dataset_file_sha256,
+        prompt_digests=tuple(digests),
+        preregistration_seal=plan_seal,
+    )
+
+
+def unmet_needs(bound: BoundManifest) -> dict[str, Any]:
+    """Which bound tasks are being asked to work without their inputs.
+
+    A task with reference files whose bytes are not in the guest can still be
+    attempted, and may still fail on its merits — but a reader comparing stages
+    needs to know which failures had that handicap. Reporting it is not the same
+    as fixing it, and this does not fix it.
+    """
+    needing = [task.task_id for task in bound.tasks if task.reference_files]
+    return {
+        "stage": bound.stage,
+        "tasks_needing_reference_files": needing,
+        "tasks_needing_reference_files_count": len(needing),
+        "reference_file_bytes_are_in_the_guest": False,
+        "what_that_means": (
+            f"{len(needing)} of {len(bound.tasks)} bound tasks name reference "
+            "files that nothing copies into the workspace, so those tasks run "
+            "with the file names in their prompt and not the files. A failure "
+            "on one of them is not evidence about the model."
+        ),
+    }
+
+
+def dataset_tasks_from_snapshot(local_path: str | None = None) -> Sequence[Any]:
+    """The dataset rows, loaded the way the rest of the pipeline loads them.
+
+    Imported inside the function because :mod:`prepare_dataset` puts the
+    repository root on ``sys.path`` at import and pulls in pandas; a module that
+    only needs to *check* a manifest should not pay for that.
+    """
+    from core.data_loader import GDPValDataset  # noqa: PLC0415
+
+    dataset = GDPValDataset(local_path=local_path, auto_download=False)
+    return dataset.load()
+
+
+def binding_record(bound: BoundManifest) -> dict[str, Any]:
+    """What the run record should carry about which tasks it ran."""
+    record: dict[str, Any] = dict(bound.as_dict())
+    record["binding_seal"] = bound.binding_seal()
+    record["unmet_needs"] = unmet_needs(bound)
+    return record
+
+
+__all__ = [
+    "ANSWER_FIELDS_THAT_MUST_NOT_TRAVEL",
+    "BINDING_SCHEMA_VERSION",
+    "BoundManifest",
+    "ManifestRefused",
+    "STAGE_FIVE",
+    "STAGE_THIRTY",
+    "STAGE_TWO_TWENTY",
+    "bind_stage",
+    "binding_record",
+    "dataset_tasks_from_snapshot",
+    "unmet_needs",
+]

--- a/batch-runner/core/agentic_v2_run_driver.py
+++ b/batch-runner/core/agentic_v2_run_driver.py
@@ -1,0 +1,416 @@
+"""Walking a fixed manifest through the parts, and stopping when it should.
+
+Every piece a 220-task run needs now exists and nothing drives them. The runner
+does one task. The journal knows what to resume. The collector puts files on
+disk. The report adapter makes a row. This is the loop that connects them, and
+it is the last piece of step 4 that is not a single-task concern.
+
+**Why the runner is rebuilt for every task rather than reused.** A backend's
+``close()`` purges its workspace, and the runner closes the backend in a
+``finally`` at the end of every ``run()`` — so the workspace is already gone by
+the time the driver sees a result. What a reused *runner* would carry across
+tasks is not files but settings and accumulated state, and the whole claim being
+tested is that one task cannot reach the next. A factory called per task makes
+that structural instead of a promise. It also costs nothing: the expensive part
+is the guest, and the guest was always per-task.
+
+**Why deliverables come out of the result rather than off the disk.** For the
+same reason. By the time ``run()`` returns, the workspace is purged; the bytes
+survive only in the result envelope, already checked against the digests the
+guest declared. Anything not collected from there is unrecoverable.
+
+**Why a collection failure is a runner defect and not a model failure.** The
+contract already validates every deliverable path at ``finalize``. A path that
+passes that and then fails the collector means the two disagree, which is this
+code's problem and not the work under test's. Recording it as
+``invalid_backend_result`` puts it in the ``runner_defect`` disposition, which
+is what the stop rule below counts — so a systematic disagreement halts the run
+instead of quietly failing 220 tasks in the same way.
+
+**Which stop rules this can actually see.** The pre-registration writes eight,
+in prose, and it would be easy to claim all eight by naming them. Four of them
+are about the run's own record — the seal, a pinned deployment, a gate, an
+approved amount — and are checked before anything starts, by code that is not
+this. :data:`RULES_THIS_DRIVER_WATCHES` names by index the ones a loop can
+observe while it runs, and :data:`RULES_THIS_DRIVER_CANNOT_SEE` names the rest.
+Both are derived from :data:`~core.agentic_v2_preregistration.STOP_RULES` rather
+than retyped, so a rule added there without a decision here fails a test.
+
+Nothing here asks a model. The model is behind ``runner_factory``, which is the
+seam the caller supplies and the one thing still blocked.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+from core.agentic_v2_cost_binding import (
+    DISPOSITION_RUNNER_DEFECT,
+    describe_run_outcome,
+)
+from core.agentic_v2_deliverable_collection import (
+    Collection,
+    CollectionRefused,
+    collect_deliverables,
+)
+from core.agentic_v2_preregistration import STOP_RULES
+from core.agentic_v2_run_report import (
+    build_agentic_v2_metrics,
+    build_result_row,
+    summarise_v2_run,
+)
+from core.agentic_v2_task_journal import (
+    DECISION_RUN,
+    MOST_ATTEMPTS_PER_TASK,
+    OUTCOME_FAILED,
+    OUTCOME_FINISHED,
+    TaskJournal,
+)
+from core.cost_receipts import STATUS_COMPLETE
+
+
+#: How many consecutive runner-defect tasks end the run.
+#:
+#: The figure is the pre-registration's, not a new one.
+CONSECUTIVE_RUNNER_DEFECTS_THAT_STOP_A_RUN = 3
+
+#: Indices into :data:`~core.agentic_v2_preregistration.STOP_RULES` that this
+#: loop enforces itself, with what it watches for.
+RULES_THIS_DRIVER_WATCHES: dict[int, str] = {
+    6: "counts consecutive runner_defect dispositions and stops at three",
+    7: "stops on compute_cleanup_failed, because the next task would inherit "
+    "a guest that was not cleaned",
+}
+
+#: The rest, and who checks them.
+#:
+#: Written down because a driver that silently enforced two of eight would read
+#: as a driver that enforced eight.
+RULES_THIS_DRIVER_CANNOT_SEE: dict[int, str] = {
+    0: "the deployment is pinned and compared where the model client is built",
+    1: "a model or deployment switch is visible to the voice, not to this loop",
+    2: "the seal is verified before a run starts",
+    3: "gate state is checked by the gate's own free check",
+    4: "budget and approved amount are enforced by the voice before a call",
+    5: "the ledger's writability is the ledger's own refusal",
+}
+
+if set(RULES_THIS_DRIVER_WATCHES) | set(RULES_THIS_DRIVER_CANNOT_SEE) != set(
+    range(len(STOP_RULES))
+):  # pragma: no cover - import guard
+    raise RuntimeError(
+        "a stop rule was added or removed without deciding whether this driver "
+        "can see it"
+    )
+
+
+class DriverRefused(RuntimeError):
+    """The run was not started, because starting it would have been unsound."""
+
+
+@dataclass(frozen=True)
+class TaskToRun:
+    """One task of the fixed manifest, as the driver needs it."""
+
+    task_id: str
+    prompt: str
+    occupation: str = "professional"
+    sector: str = ""
+    reference_files: tuple[Any, ...] = ()
+
+
+@dataclass(frozen=True)
+class StoppedEarly:
+    """Why the loop ended before the manifest did."""
+
+    rule_index: int
+    rule: str
+    detail: str
+    after_task: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "rule_index": self.rule_index,
+            "rule": self.rule,
+            "detail": self.detail,
+            "after_task": self.after_task,
+        }
+
+
+@dataclass
+class RunOutcome:
+    """What the run did, and what is left of the manifest."""
+
+    run_id: str
+    rows: list[dict[str, Any]] = field(default_factory=list)
+    summary: dict[str, Any] = field(default_factory=dict)
+    stopped: StoppedEarly | None = None
+    skipped_on_resume: tuple[str, ...] = ()
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "results": list(self.rows),
+            "summary": dict(self.summary),
+            "stopped_early": None if self.stopped is None else self.stopped.as_dict(),
+            "skipped_on_resume": list(self.skipped_on_resume),
+        }
+
+
+def _attempt_once(
+    task: TaskToRun,
+    *,
+    runner_factory: Callable[[TaskToRun], Any],
+    run_id: str,
+    condition_name: str,
+) -> dict[str, Any]:
+    """One task, one fresh runner, closed whatever happens."""
+    runner = runner_factory(task)
+    try:
+        result = runner.run(
+            task.prompt,
+            list(task.reference_files),
+            task.occupation,
+            run_id=run_id,
+            condition_name=condition_name,
+            task_id=task.task_id,
+        )
+    finally:
+        close = getattr(runner, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                # A runner that cannot close has already returned its result;
+                # losing it here would turn a recorded task into no task at all.
+                pass
+    if not isinstance(result, Mapping):
+        raise DriverRefused(
+            f"the runner returned {type(result).__name__} for {task.task_id!r}, "
+            "which is not a result envelope"
+        )
+    return dict(result)
+
+
+def _collect_or_fail(
+    result: Mapping[str, Any],
+    *,
+    task: TaskToRun,
+    into: Path,
+    attempt_name: str,
+) -> tuple[Collection | None, dict[str, Any]]:
+    """Put a successful task's files on disk, or turn the task into a failure."""
+    try:
+        return collect_deliverables(
+            result, task_id=task.task_id, into=into, attempt_name=attempt_name
+        ), dict(result)
+    except (CollectionRefused, OSError) as error:
+        spoiled = dict(result)
+        spoiled["success"] = False
+        spoiled["error"] = "invalid_backend_result"
+        spoiled["collection_error"] = str(error)
+        spoiled["files"] = []
+        return None, spoiled
+
+
+def run_manifest(
+    tasks: Iterable[TaskToRun],
+    *,
+    run_id: str,
+    runner_factory: Callable[[TaskToRun], Any],
+    journal_path: str | Path,
+    collect_into: str | Path,
+    receipt_for: Callable[[TaskToRun, int], Mapping[str, Any] | None] | None = None,
+    condition_name: str = "condition_a",
+    clock: Callable[[], float] = time.monotonic,
+    on_task: Callable[[str, Mapping[str, Any]], None] | None = None,
+) -> RunOutcome:
+    """Run a fixed manifest, resuming what a previous run left.
+
+    ``receipt_for`` is handed the task and the attempt count and returns that
+    task's cost receipt, or ``None`` when this run kept no ledger. ``None`` is
+    not free — it becomes a ``not_run`` receipt status and keeps the run's
+    ceiling below ``complete``.
+    """
+    manifest = list(tasks)
+    if not manifest:
+        raise DriverRefused("a run needs a manifest; an empty one is not one")
+    seen: set[str] = set()
+    for task in manifest:
+        if task.task_id in seen:
+            raise DriverRefused(f"{task.task_id!r} appears twice in the manifest")
+        seen.add(task.task_id)
+
+    by_id = {task.task_id: task for task in manifest}
+    into = Path(collect_into)
+    journal = TaskJournal(
+        journal_path, run_id=run_id, task_ids=[t.task_id for t in manifest]
+    )
+    opening_plan = journal.plan()
+    to_run = opening_plan.to_run()
+    skipped = tuple(
+        task.task_id for task in manifest if task.task_id not in set(to_run)
+    )
+
+    outcome = RunOutcome(run_id=run_id, skipped_on_resume=skipped)
+    consecutive_defects = 0
+
+    for task_id in to_run:
+        task = by_id[task_id]
+        row: dict[str, Any] | None = None
+
+        while (
+            journal.standing(task_id).decision == DECISION_RUN
+            and journal.standing(task_id).attempts < MOST_ATTEMPTS_PER_TASK
+        ):
+            opened = journal.open_task(task_id)
+            began = clock()
+            result = _attempt_once(
+                task,
+                runner_factory=runner_factory,
+                run_id=run_id,
+                condition_name=condition_name,
+            )
+            collection: Collection | None = None
+            if result.get("success") is True:
+                collection, result = _collect_or_fail(
+                    result,
+                    task=task,
+                    into=into,
+                    attempt_name=opened.workspace_name,
+                )
+            elapsed_ms = (clock() - began) * 1000.0
+
+            receipt = (
+                receipt_for(task, opened.attempt_index)
+                if receipt_for is not None
+                else None
+            )
+            outcome_now = describe_run_outcome(result)
+            settled = (
+                receipt is not None and receipt.get("status") == STATUS_COMPLETE
+            )
+            journal.close_task(
+                outcome=(
+                    OUTCOME_FINISHED if outcome_now["succeeded"] else OUTCOME_FAILED
+                ),
+                error_type=outcome_now["error_type"],
+                deliverables=(
+                    collection.journal_entries() if collection is not None else ()
+                ),
+                cost_settled=settled,
+            )
+
+            standing = journal.standing(task_id)
+            metrics = build_agentic_v2_metrics(
+                result,
+                standing=standing,
+                tool_calls=_tool_calls_of(result),
+                model_api_calls=_model_calls_of(result),
+                task_wall_time_ms=elapsed_ms,
+                receipt=receipt,
+            )
+            row = build_result_row(
+                result,
+                task_id=task_id,
+                standing=standing,
+                sector=task.sector,
+                occupation=task.occupation,
+                instruction=task.prompt,
+                deliverable_files=(
+                    collection.submission_paths() if collection is not None else ()
+                ),
+                latency_ms=elapsed_ms,
+                metrics=metrics,
+                receipt=receipt,
+            )
+
+            if outcome_now["disposition"] == DISPOSITION_RUNNER_DEFECT:
+                consecutive_defects += 1
+            else:
+                # Any other ending breaks the run of defects, including a
+                # failure. The rule is about this code producing the record
+                # three times over, not about three bad tasks.
+                consecutive_defects = 0
+
+            if outcome_now["error_type"] == "compute_cleanup_failed":
+                outcome.rows.append(row)
+                if on_task is not None:
+                    on_task(task_id, row)
+                outcome.stopped = StoppedEarly(
+                    rule_index=7,
+                    rule=STOP_RULES[7],
+                    detail=(
+                        "the guest was not cleaned after this task, so the next "
+                        "task could inherit its state"
+                    ),
+                    after_task=task_id,
+                )
+                break
+
+        if outcome.stopped is not None:
+            break
+        if row is not None:
+            outcome.rows.append(row)
+            if on_task is not None:
+                on_task(task_id, row)
+
+        if consecutive_defects >= CONSECUTIVE_RUNNER_DEFECTS_THAT_STOP_A_RUN:
+            outcome.stopped = StoppedEarly(
+                rule_index=6,
+                rule=STOP_RULES[6],
+                detail=(
+                    f"{consecutive_defects} tasks running returned the "
+                    "runner_defect disposition, so this code and not the work "
+                    "under test is producing the record"
+                ),
+                after_task=task_id,
+            )
+            break
+
+    outcome.summary = summarise_v2_run(
+        outcome.rows,
+        manifest_size=len(manifest),
+        receipt_ceiling=journal.plan().receipt_ceiling(),
+    )
+    outcome.summary["skipped_on_resume"] = len(skipped)
+    outcome.summary["stopped_early"] = (
+        None if outcome.stopped is None else outcome.stopped.as_dict()
+    )
+    outcome.summary["unaccounted_tasks"] = list(journal.plan().unaccounted_tasks())
+    return outcome
+
+
+def _tool_calls_of(result: Mapping[str, Any]) -> Sequence[Mapping[str, Any]]:
+    """The public trace's calls, which are the ones a report may name.
+
+    The private audit is not read here on purpose: a report is a public
+    artefact and should be built from the trace that was redacted for one.
+    """
+    block = result.get("agentic_v2")
+    if not isinstance(block, Mapping):
+        return ()
+    trace = block.get("public_trace")
+    if not isinstance(trace, Mapping):
+        return ()
+    events = trace.get("events")
+    if not isinstance(events, Sequence):
+        return ()
+    return [
+        event
+        for event in events
+        if isinstance(event, Mapping) and event.get("tool_name")
+    ]
+
+
+def _model_calls_of(result: Mapping[str, Any]) -> int:
+    block = result.get("agentic_v2")
+    if not isinstance(block, Mapping):
+        return 0
+    count = block.get("model_api_calls")
+    if type(count) is int and count >= 0:
+        return count
+    return 0

--- a/batch-runner/core/agentic_v2_runner.py
+++ b/batch-runner/core/agentic_v2_runner.py
@@ -1,4 +1,16 @@
-"""Model-free scripted runner for the Agentic Sandbox V2 foundation."""
+"""The Agentic Sandbox V2 run place, and the two things that can drive it.
+
+A run here is a backend that is admitted, a dispatcher that enforces the tool
+contract, a pair of hash chains that record what happened, and a verifier that
+refuses a record which does not add up. None of that depends on *who* chooses
+the next tool, and this module now takes that choice as a parameter: a list
+written in advance, or a model being asked.
+
+Supplying a model is the caller's job and no caller in this repository does it
+yet, because the deployment it would reach is behind a role assignment nobody
+here may grant. Nothing in this file opens that, changes ``foundation_only`` or
+``production_activation``, or loosens the ``exec_run`` refusal.
+"""
 
 from __future__ import annotations
 
@@ -35,6 +47,50 @@ from core.agentic_v2_provenance import (
     verify_agentic_v2_result,
 )
 from core.agentic_v2_tools import AgenticV2Backend, AgenticV2ToolDispatcher
+
+
+class _EndTheRun(Exception):
+    """The run must stop now, and this is the envelope it stops with.
+
+    Raised only from the per-call bookkeeping, which is shared by every call
+    source. Returning from there is not possible and returning a sentinel would
+    make every caller responsible for noticing it, so the one ending nobody may
+    continue past is the one that cannot be ignored.
+    """
+
+    def __init__(self, envelope: dict):
+        super().__init__(envelope.get("error", "ended"))
+        self.envelope = envelope
+
+
+#: How a conversation that never committed an answer is reported.
+#:
+#: Keyed by :class:`core.agentic_v2_conversation.StopReason` values, by string
+#: rather than by import, so this module stays independent of the loop that
+#: produces them — a run can be driven by anything that ends with a named
+#: reason.
+#:
+#: The mapping is coarser than the reasons are, because
+#: :data:`core.agentic_v2_contract.ERROR_TYPES` has no member for "ran out of
+#: money" or "the model said something unusable". Both of those are true
+#: instances of *the model never handed in an answer*, which is what
+#: ``finalize_not_called`` says and what the default below gives them. The
+#: distinction is not lost: the caller supplying the conversation holds its
+#: record, which names the reason exactly.
+#:
+#: ``paid_call_refused`` is the one worth reading twice. It is the gate that is
+#: still shut, and mapping it to ``capability_unavailable`` puts it in the
+#: ``terminal_capability_absent`` disposition — recorded as a result, attempted
+#: once, and not retried. A run against a model nobody may call yet should
+#: produce 220 honest refusals quickly, not 660 attempts.
+ERROR_TYPE_FOR_A_CONVERSATION_THAT_STOPPED: dict[str, str] = {
+    "cancelled": "cancelled",
+    "paid_call_refused": "capability_unavailable",
+    "time_limit_reached": "task_wall_time_exhausted",
+    "tool_call_limit_reached": "tool_budget_exhausted",
+    "tool_desk_broke": "runner_internal_error",
+    "limit_missing": "runner_internal_error",
+}
 
 
 class AgenticV2IsolatedFixtureRunner:
@@ -353,13 +409,32 @@ def _stop_process(process, process_group: int | None) -> None:
 
 
 class AgenticV2ScriptedRunner:
-    """Exercise the V2 state machine without constructing a model client."""
+    """Exercise the V2 state machine without constructing a model client.
+
+    Two things can decide which tool is called next. ``scripted_calls`` is a
+    list written in advance, which is how every test and every probe in this
+    repository drives a run today. ``conversation`` is a model choosing, and it
+    is the seam the 220-task run needs: a callable handed the task prompt and
+    this run's own dispatch function, returning something that reports how it
+    ended and, if it ended by committing, the finalize result.
+
+    Everything either one passes through is the same — the same backend
+    admission, the same identity check, the same chain appends, the same
+    verification. That is the reason the seam is a parameter here rather than a
+    second runner elsewhere: a run place whose containment is decided in two
+    files has no containment anybody can read.
+
+    The class keeps its name. ``scripted`` is now the narrower of its two
+    modes, but renaming a class this heavily tested would be churn dressed as
+    tidiness.
+    """
 
     def __init__(
         self,
         *,
         backend_factory: Callable[..., AgenticV2Backend],
-        scripted_calls: Iterable[Mapping[str, Any]],
+        scripted_calls: Iterable[Mapping[str, Any]] = (),
+        conversation: Optional[Callable[[str, Callable[..., Any]], Any]] = None,
         profile: Mapping[str, Any],
         budget_caps: Optional[Mapping[str, Any]] = None,
         cancel_requested: Optional[Callable[[], bool]] = None,
@@ -369,8 +444,16 @@ class AgenticV2ScriptedRunner:
     ):
         if not callable(backend_factory):
             raise ValueError("agentic v2 backend_factory is required")
+        if conversation is not None and not callable(conversation):
+            raise ValueError("agentic v2 conversation must be callable")
         self.backend_factory = backend_factory
         self.scripted_calls = tuple(dict(call) for call in scripted_calls)
+        self.conversation = conversation
+        if self.conversation is not None and self.scripted_calls:
+            raise ValueError(
+                "a run is driven by a script or by a model, not both; two call "
+                "sources means no reading of the record says which chose"
+            )
         self.profile = AgenticV2Profile.from_mapping(profile)
         self.budget_caps = _validate_budget_caps(budget_caps)
         self.cancel_requested = cancel_requested or (lambda: False)
@@ -578,31 +661,72 @@ class AgenticV2ScriptedRunner:
                 record_wall_time=False,
             )
             current_state = initial_state
-            for call in self.scripted_calls:
+            #: Set by the bookkeeping when it ends a run, and read afterwards.
+            #:
+            #: Raising is enough for a scripted run, whose loop is right here.
+            #: It is not enough for a conversation: the loop in
+            #: :mod:`core.agentic_v2_conversation` catches anything a tool desk
+            #: throws and reports ``tool_desk_broke``, which is correct when the
+            #: desk really broke and wrong when the desk deliberately ended the
+            #: run. So the ending is written down before it is thrown, and the
+            #: written ending wins -- the reason a model's bad arguments are
+            #: reported as bad arguments rather than as this harness failing.
+            pending_ending: Optional[dict] = None
+
+            def dispatch_one(*, call_id: str, name: str, arguments: Any):
+                """One tool call, with the bookkeeping every call source owes.
+
+                The cancel check, the deadline, the state commitment and the two
+                chain appends happen here rather than once per caller, because a
+                caller that skipped one of them would produce a record that
+                looks like the others and is not.
+
+                Whether a *failed* tool ends the run is not a policy choice made
+                here -- it is what the trace schema already requires.
+                :func:`core.agentic_v2_provenance.verify_agentic_v2_result`
+                refuses any trace in which a tool event follows a tool result
+                with ``ok`` false, so a run that continued past a failure could
+                not produce a verifiable record of itself. Ending inside the
+                shared bookkeeping makes that structurally impossible rather
+                than merely unlikely.
+
+                It matters that the ending carries the *tool's* error. A run
+                that kept going and then failed verification would be caught by
+                the broad handler at the end of :meth:`run` and reported as
+                ``runner_internal_error``, which the ledger buckets as a runner
+                defect -- so a model that passed bad arguments would be recorded
+                as this harness being broken. The cost of the rule is real and
+                belongs where a reader will meet it: under this schema a model
+                gets one tool mistake per task, and the conversation loop's
+                ability to show it an error and let it choose again cannot
+                actually be used. Changing that means changing the trace
+                schema, which is a separate and reviewable thing to do.
+                """
+                nonlocal current_state, pending_ending
                 if self.cancel_requested():
                     lifecycle.transition(LifecycleState.CANCELLED)
-                    return finish(_failure(
+                    pending_ending = _failure(
                         "cancelled", lifecycle, audit_chain, public_chain,
                         stage="control",
-                    ))
+                    )
+                    raise _EndTheRun(pending_ending)
                 if self.clock() >= deadline:
                     lifecycle.transition(LifecycleState.FAILED)
-                    return finish(_failure(
+                    pending_ending = _failure(
                         "task_wall_time_exhausted",
                         lifecycle,
                         audit_chain,
                         public_chain,
                         stage="control",
-                    ))
+                    )
+                    raise _EndTheRun(pending_ending)
                 dispatch = dispatcher.dispatch(
-                    call_id=str(call.get("call_id", "")),
-                    name=str(call.get("name", "")),
-                    arguments=call.get("arguments"),
+                    call_id=call_id, name=name, arguments=arguments
                 )
                 request = {
-                    "call_id": str(call.get("call_id", "")),
-                    "name": str(call.get("name", "")),
-                    "arguments": deepcopy(call.get("arguments")),
+                    "call_id": call_id,
+                    "name": name,
+                    "arguments": deepcopy(arguments),
                 }
                 state_commitment = (
                     dispatch.result.get("state_after_sha256")
@@ -632,31 +756,83 @@ class AgenticV2ScriptedRunner:
                 if dispatch.result.get("ok") is not True:
                     if not lifecycle.terminal:
                         lifecycle.transition(LifecycleState.FAILED)
-                    return finish(_failure(
+                    pending_ending = _failure(
                         str(dispatch.result.get("error_type") or "tool_error"),
                         lifecycle,
                         audit_chain,
                         public_chain,
                         stage="runtime",
-                    ))
-                if self.clock() >= deadline:
-                    failure_lifecycle = lifecycle
-                    if not lifecycle.terminal:
-                        lifecycle.transition(LifecycleState.FAILED)
-                    elif lifecycle.state is not LifecycleState.FAILED:
-                        failure_lifecycle = AgenticV2Lifecycle(
-                            LifecycleState.FAILED
+                    )
+                    raise _EndTheRun(pending_ending)
+                return dispatch
+
+            def deadline_after_call() -> None:
+                """The task's own wall clock, checked once a call has landed.
+
+                Separate from the check inside ``dispatch_one`` because it runs
+                at a different moment: after the call's result has been judged,
+                and before a ``finalize`` is honoured. A task whose answer
+                arrives past its deadline did not finish in time.
+                """
+                if self.clock() < deadline:
+                    return
+                failure_lifecycle = lifecycle
+                if not lifecycle.terminal:
+                    lifecycle.transition(LifecycleState.FAILED)
+                elif lifecycle.state is not LifecycleState.FAILED:
+                    failure_lifecycle = AgenticV2Lifecycle(
+                        LifecycleState.FAILED
+                    )
+                raise _EndTheRun(_failure(
+                    "task_wall_time_exhausted",
+                    failure_lifecycle,
+                    audit_chain,
+                    public_chain,
+                    stage="control",
+                ))
+
+            try:
+                if self.conversation is not None:
+                    conversation = self.conversation(task_prompt, dispatch_one)
+                    # The bookkeeping's own ending outranks the loop's verdict.
+                    # The loop saw an exception come out of the desk and called
+                    # it a broken desk; this is the desk, and it knows why it
+                    # stopped.
+                    if pending_ending is not None:
+                        return finish(pending_ending)
+                    stop_reason = str(
+                        getattr(
+                            getattr(conversation, "stop_reason", ""), "value", ""
                         )
-                    return finish(_failure(
-                        "task_wall_time_exhausted",
-                        failure_lifecycle,
-                        audit_chain,
-                        public_chain,
-                        stage="control",
-                    ))
-                if dispatch.finalized:
-                    result = dict(dispatch.terminal_result or {})
-                    break
+                    )
+                    if getattr(conversation, "produced_an_answer", False):
+                        deadline_after_call()
+                        result = dict(conversation.final_result or {})
+                    else:
+                        if not lifecycle.terminal:
+                            lifecycle.transition(LifecycleState.FAILED)
+                        return finish(_failure(
+                            ERROR_TYPE_FOR_A_CONVERSATION_THAT_STOPPED.get(
+                                stop_reason, "finalize_not_called"
+                            ),
+                            lifecycle,
+                            audit_chain,
+                            public_chain,
+                            stage="runtime",
+                        ))
+                else:
+                    for call in self.scripted_calls:
+                        dispatch = dispatch_one(
+                            call_id=str(call.get("call_id", "")),
+                            name=str(call.get("name", "")),
+                            arguments=call.get("arguments"),
+                        )
+                        deadline_after_call()
+                        if dispatch.finalized:
+                            result = dict(dispatch.terminal_result or {})
+                            break
+            except _EndTheRun as ending:
+                return finish(ending.envelope)
             if result is None:
                 if not lifecycle.terminal:
                     lifecycle.transition(LifecycleState.FAILED)

--- a/batch-runner/tests/test_agentic_v2_conversation_runner.py
+++ b/batch-runner/tests/test_agentic_v2_conversation_runner.py
@@ -1,0 +1,603 @@
+"""Whether a model can drive a real V2 run, and be billed for it correctly.
+
+Every test here uses :class:`~core.agentic_v2_conversation.ScriptedVoice` and
+:class:`~core.agentic_v2_fixture_backend.AgenticV2FixtureBackend`. No model is
+called, no guest is booted, nothing is spent, and ``foundation_only`` stays on
+throughout — the ``exec_run`` refusal is not worked around in these tests, it is
+one of the things they check.
+
+What is proved here is the shape of the join, not the behaviour of a real model.
+A stand-in that always says the same thing cannot show that a model *would*
+choose well. It can show that when something chooses, the choice goes through
+the same dispatcher, lands in the same hash chains, produces the same verified
+envelope, and reaches the ledger under an id that will not collide with another
+task's.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.agentic_v2_conversation import (
+    AskForTool,
+    GaveUp,
+    LoopLimits,
+    ScriptedVoice,
+    StopReason,
+)
+from core.agentic_v2_conversation_runner import (
+    ConversationRunnerRefused,
+    PerTaskCeilings,
+    RunWideCeilings,
+    TaskConversations,
+    build_runner_factory,
+    conversation_seam,
+    model_turns_of,
+)
+from core.agentic_v2_cost_binding import bind_run_to_ledger
+from core.agentic_v2_fixture_backend import AgenticV2FixtureBackend
+from core.agentic_v2_provenance import verify_agentic_v2_result
+from core.agentic_v2_runner import AgenticV2ScriptedRunner
+from core.cost_receipts import (
+    BUCKET_PROBLEM_SOLVING,
+    CostReceiptLedger,
+    RETRY_NONE,
+    load_receipt_price_table,
+)
+
+
+PROFILE = {
+    "tool_contract_version": "2.0",
+    "policy_profile_id": "offline-full-v1",
+    "foundation_only": True,
+}
+
+CEILINGS = PerTaskCeilings(
+    max_model_turns=8,
+    max_written_tokens_per_turn=4096,
+    max_seconds=60.0,
+    max_model_calls=8,
+    max_input_tokens=100_000,
+    max_output_tokens=20_000,
+    max_repeats_of_one_request=2,
+)
+
+
+def _write(call_id="w-1", path="report.txt", content="the answer", **counts):
+    return AskForTool(
+        call_id=call_id,
+        tool_name="workspace_apply",
+        arguments={"operation": "write", "path": path, "content": content},
+        why="write the deliverable",
+        **counts,
+    )
+
+
+def _finalize(call_id="f-1", deliverables=("report.txt",), **counts):
+    return AskForTool(
+        call_id=call_id,
+        tool_name="finalize",
+        arguments={"deliverables": list(deliverables), "summary": "done"},
+        why="hand it in",
+        **counts,
+    )
+
+
+def _backend_factory(tmp_path):
+    return lambda **kwargs: AgenticV2FixtureBackend(root=tmp_path, **kwargs)
+
+
+def _run(tmp_path, replies, *, task_id="task-1", conversations=None, **kwargs):
+    """One conversation-driven run, returning the envelope and the outcome."""
+    held = conversations if conversations is not None else TaskConversations(CEILINGS)
+    limits = held.limits_for(task_id, 1)
+    voice = ScriptedVoice(replies=list(replies))
+    runner = AgenticV2ScriptedRunner(
+        backend_factory=_backend_factory(tmp_path),
+        conversation=conversation_seam(
+            voice=voice,
+            limits=limits,
+            on_outcome=lambda outcome: held.record(task_id, 1, outcome),
+        ),
+        profile=PROFILE,
+        **kwargs,
+    )
+    result = runner.run("Write the report", task_id=task_id)
+    return result, held.outcome_of(task_id, 1), held
+
+
+# ── a model drives a real run ────────────────────────────────────────────
+
+
+class TestTheModelDrivesTheRun:
+    def test_a_conversation_produces_a_successful_run(self, tmp_path):
+        result, outcome, _ = _run(tmp_path, [_write(), _finalize()])
+        assert result["success"] is True
+        assert outcome.stop_reason is StopReason.FINISHED_NORMALLY
+        assert [file["filename"] for file in result["files"]] == ["report.txt"]
+
+    def test_the_file_the_model_wrote_is_the_file_that_comes_back(self, tmp_path):
+        result, _, _ = _run(
+            tmp_path, [_write(content="ninety-four percent"), _finalize()]
+        )
+        assert result["files"][0]["content"] == b"ninety-four percent"
+
+    def test_a_conversation_driven_run_verifies(self, tmp_path):
+        """The same check every scripted run passes, with a model choosing."""
+        result, _, _ = _run(tmp_path, [_write(), _finalize()])
+        verify_agentic_v2_result(result)
+
+    def test_the_envelope_carries_no_extra_key_for_the_conversation(self, tmp_path):
+        result, _, _ = _run(tmp_path, [_write(), _finalize()])
+        assert set(result) == {
+            "success",
+            "text",
+            "deliverable_text",
+            "files",
+            "agentic_v2",
+        }
+
+    def test_the_run_is_still_foundation_only(self, tmp_path):
+        result, _, _ = _run(tmp_path, [_write(), _finalize()])
+        assert result["agentic_v2"]["foundation_only"] is True
+
+
+# ── the model's calls go through the runner's bookkeeping ────────────────
+
+
+class TestNothingReachesPastTheRunner:
+    def test_the_model_s_calls_are_in_the_hash_chains(self, tmp_path):
+        """A desk holding the dispatcher directly would leave these empty."""
+        result, _, _ = _run(tmp_path, [_write(), _finalize()])
+        events = result["agentic_v2"]["public_trace"]["events"]
+        kinds = [entry["kind"] for entry in events]
+        assert kinds.count("tool_result_public") == 2
+
+    def test_the_chain_commits_a_state_for_each_call(self, tmp_path):
+        result, _, _ = _run(tmp_path, [_write(), _finalize()])
+        for entry in result["agentic_v2"]["public_trace"]["events"]:
+            if entry["kind"] == "tool_result_public":
+                assert len(entry["state_sha256"]) == 64
+
+    def test_the_private_and_public_traces_agree_in_length(self, tmp_path):
+        result, _, _ = _run(tmp_path, [_write(), _finalize()])
+        block = result["agentic_v2"]
+        assert len(block["private_audit"]["events"]) == len(
+            block["public_trace"]["events"]
+        )
+
+    def test_the_trace_head_is_a_digest(self, tmp_path):
+        result, _, _ = _run(tmp_path, [_write(), _finalize()])
+        head = result["agentic_v2"]["public_trace"]["event_chain_head_sha256"]
+        assert len(head) == 64
+
+
+# ── a failed tool call ends the run, because the trace schema says so ────
+
+
+class TestAFailedToolEndsTheRun:
+    """The loop would let a model recover from a tool error. The trace cannot.
+
+    :func:`~core.agentic_v2_provenance.verify_agentic_v2_result` refuses any
+    trace in which a tool event follows a tool result with ``ok`` false, so a
+    run that kept going after a failure would build a record of itself that
+    cannot be verified. The runner therefore stops on the failure, and these
+    tests pin both halves of that: that it stops, and that it says *why* in the
+    tool's own words.
+
+    The cost is real and is not hidden: under this schema a model gets one tool
+    mistake per task. Lifting that means changing the trace schema.
+    """
+
+    BAD = AskForTool(
+        call_id="x-1",
+        tool_name="exec_run",
+        arguments={"command": ["echo", "hi"]},
+        why="try to run something",
+    )
+
+    def test_the_run_ends_on_the_failed_call(self, tmp_path):
+        result, _, _ = _run(tmp_path, [self.BAD, _write(), _finalize()])
+        assert result["success"] is False
+
+    def test_the_error_is_the_tool_s_own_and_not_a_runner_defect(self, tmp_path):
+        """The property that matters for a 220-task run.
+
+        If this said ``runner_internal_error`` the ledger would bucket a model's
+        bad arguments as this harness being broken, and the run's failure counts
+        would describe the wrong thing entirely.
+        """
+        result, _, _ = _run(tmp_path, [self.BAD, _write(), _finalize()])
+        assert result["error"] == "invalid_arguments"
+        assert result["error"] != "runner_internal_error"
+
+    def test_the_later_replies_were_never_asked_for(self, tmp_path):
+        """Proof the run really stopped rather than finishing quietly."""
+        voice = ScriptedVoice(replies=[self.BAD, _write(), _finalize()])
+        held = TaskConversations(CEILINGS)
+        AgenticV2ScriptedRunner(
+            backend_factory=_backend_factory(tmp_path),
+            conversation=conversation_seam(
+                voice=voice, limits=held.limits_for("task-1", 1)
+            ),
+            profile=PROFILE,
+        ).run("Write the report", task_id="task-1")
+        assert len(voice.requests_seen) == 1
+
+    def test_no_tool_event_follows_the_failed_one(self, tmp_path):
+        """The trace invariant, checked on the trace this run produced."""
+        result, _, _ = _run(tmp_path, [self.BAD, _write(), _finalize()])
+        kinds = [
+            entry["kind"]
+            for entry in result["agentic_v2"]["public_trace"]["events"]
+        ]
+        assert kinds.count("tool_result_public") == 1
+        assert kinds[-1] == "failure"
+
+    def test_a_scripted_run_ends_the_same_way_on_the_same_call(self, tmp_path):
+        """Both call sources obey one rule, so one reading of the record works."""
+        result = AgenticV2ScriptedRunner(
+            backend_factory=_backend_factory(tmp_path),
+            scripted_calls=[
+                {
+                    "call_id": "x-1",
+                    "name": "exec_run",
+                    "arguments": {"command": ["echo", "hi"]},
+                }
+            ],
+            profile=PROFILE,
+        ).run("Write the report", task_id="task-1")
+        assert result["success"] is False
+        assert result["error"] == "invalid_arguments"
+
+
+# ── a conversation that never commits an answer ──────────────────────────
+
+
+class TestAConversationThatStops:
+    def test_a_model_that_walks_away_is_not_a_success(self, tmp_path):
+        result, outcome, _ = _run(tmp_path, [GaveUp(note="not sure how")])
+        assert result["success"] is False
+        assert outcome.produced_an_answer is False
+
+    def test_walking_away_is_reported_as_finalize_not_called(self, tmp_path):
+        result, _, _ = _run(tmp_path, [GaveUp(note="not sure how")])
+        assert result["error"] == "finalize_not_called"
+
+    def test_a_model_that_writes_but_never_finalizes_is_not_a_success(
+        self, tmp_path
+    ):
+        result, _, _ = _run(tmp_path, [_write(), GaveUp(note="done enough")])
+        assert result["success"] is False
+        assert result["error"] == "finalize_not_called"
+
+    def test_a_cancelled_conversation_is_reported_as_cancelled(self, tmp_path):
+        result, _, _ = _run(
+            tmp_path,
+            [_write(), _finalize()],
+            cancel_requested=lambda: True,
+        )
+        assert result["success"] is False
+        assert result["error"] == "cancelled"
+
+    def test_a_cancelled_run_is_not_called_a_runner_defect(self, tmp_path):
+        """The conversation loop reports a thrown desk as broken; it is not."""
+        result, outcome, _ = _run(
+            tmp_path,
+            [_write(), _finalize()],
+            cancel_requested=lambda: True,
+        )
+        assert outcome.stop_reason is StopReason.TOOL_DESK_BROKE
+        assert result["error"] != "runner_internal_error"
+
+
+# ── one call source, not two ─────────────────────────────────────────────
+
+
+class TestOneCallSource:
+    def test_a_script_and_a_model_together_are_refused(self, tmp_path):
+        with pytest.raises(ValueError, match="script or by a model"):
+            AgenticV2ScriptedRunner(
+                backend_factory=_backend_factory(tmp_path),
+                scripted_calls=[{"call_id": "c-1", "name": "finalize"}],
+                conversation=lambda prompt, dispatch: None,
+                profile=PROFILE,
+            )
+
+    def test_a_conversation_that_is_not_callable_is_refused(self, tmp_path):
+        with pytest.raises(ValueError, match="must be callable"):
+            AgenticV2ScriptedRunner(
+                backend_factory=_backend_factory(tmp_path),
+                conversation="ask the model",
+                profile=PROFILE,
+            )
+
+    def test_a_scripted_run_still_works_unchanged(self, tmp_path):
+        """The seam is an addition; the old call source must be untouched."""
+        result = AgenticV2ScriptedRunner(
+            backend_factory=_backend_factory(tmp_path),
+            scripted_calls=[
+                {
+                    "call_id": "w-1",
+                    "name": "workspace_apply",
+                    "arguments": {
+                        "operation": "write",
+                        "path": "report.txt",
+                        "content": "scripted",
+                    },
+                },
+                {
+                    "call_id": "f-1",
+                    "name": "finalize",
+                    "arguments": {
+                        "deliverables": ["report.txt"],
+                        "summary": "done",
+                    },
+                },
+            ],
+            profile=PROFILE,
+        ).run("Write the report", task_id="task-1")
+        assert result["success"] is True
+
+
+# ── ceilings ─────────────────────────────────────────────────────────────
+
+
+class TestCeilings:
+    def test_fresh_limits_are_complete(self):
+        assert CEILINGS.fresh_limits().whats_missing() == []
+
+    def test_each_task_gets_a_budget_that_has_spent_nothing(self):
+        held = TaskConversations(CEILINGS)
+        first = held.limits_for("task-1", 1)
+        first.budget.record(input_tokens=500, output_tokens=100)
+        second = held.limits_for("task-2", 1)
+        assert second.budget.input_tokens_used == 0
+        assert first.budget is not second.budget
+
+    def test_the_run_wide_total_sums_every_task(self):
+        held = TaskConversations(CEILINGS)
+        for task_id in ("task-1", "task-2"):
+            held.limits_for(task_id, 1).budget.record(
+                input_tokens=500, output_tokens=100
+            )
+        assert held.spent == {
+            "model_calls": 2,
+            "input_tokens": 1000,
+            "output_tokens": 200,
+        }
+
+    def test_a_retried_task_s_first_attempt_is_not_lost(self):
+        held = TaskConversations(CEILINGS)
+        held.limits_for("task-1", 1).budget.record(
+            input_tokens=500, output_tokens=100
+        )
+        held.limits_for("task-1", 2).budget.record(
+            input_tokens=700, output_tokens=200
+        )
+        assert held.spent["input_tokens"] == 1200
+        assert len(held.budgets) == 2
+
+    def test_a_run_under_its_ceiling_may_start_the_next_task(self):
+        held = TaskConversations(CEILINGS, RunWideCeilings(max_model_calls=10))
+        held.limits_for("task-1", 1).budget.record(
+            input_tokens=1, output_tokens=1
+        )
+        assert held.run_wide_refusal() is None
+
+    def test_a_run_at_its_ceiling_refuses_the_next_task(self):
+        held = TaskConversations(CEILINGS, RunWideCeilings(max_model_calls=1))
+        held.limits_for("task-1", 1).budget.record(
+            input_tokens=1, output_tokens=1
+        )
+        assert "max_model_calls" in (held.run_wide_refusal() or "")
+
+    def test_an_unset_run_wide_ceiling_never_refuses(self):
+        held = TaskConversations(CEILINGS)
+        for index in range(5):
+            held.limits_for(f"task-{index}", 1).budget.record(
+                input_tokens=10_000, output_tokens=1_000
+            )
+        assert held.run_wide_refusal() is None
+
+
+# ── the factory the driver uses ──────────────────────────────────────────
+
+
+class TestTheRunnerFactory:
+    def _task(self, task_id="task-1"):
+        from core.agentic_v2_run_driver import TaskToRun
+
+        return TaskToRun(
+            task_id=task_id,
+            prompt="Write the report",
+            occupation="Analyst",
+            sector="Finance",
+        )
+
+    def _factory(self, tmp_path, held, replies=None):
+        return build_runner_factory(
+            backend_factory=_backend_factory(tmp_path),
+            profile=PROFILE,
+            voice=ScriptedVoice(
+                replies=list(replies if replies is not None else [_write(), _finalize()])
+            ),
+            conversations=held,
+            attempt_of=lambda task_id: 1,
+        )
+
+    def test_the_factory_builds_a_runner_that_runs(self, tmp_path):
+        held = TaskConversations(CEILINGS)
+        runner = self._factory(tmp_path, held)(self._task())
+        result = runner.run("Write the report", task_id="task-1")
+        assert result["success"] is True
+
+    def test_the_outcome_is_kept_beside_the_run(self, tmp_path):
+        held = TaskConversations(CEILINGS)
+        self._factory(tmp_path, held)(self._task()).run(
+            "Write the report", task_id="task-1"
+        )
+        assert held.outcome_of("task-1", 1).stop_reason is StopReason.FINISHED_NORMALLY
+        assert held.attempts_of("task-1") == (1,)
+
+    def test_a_factory_without_a_voice_is_refused(self, tmp_path):
+        with pytest.raises(ConversationRunnerRefused, match="needs a voice"):
+            build_runner_factory(
+                backend_factory=_backend_factory(tmp_path),
+                profile=PROFILE,
+                voice=None,
+                conversations=TaskConversations(CEILINGS),
+                attempt_of=lambda task_id: 1,
+            )
+
+    def test_a_spent_run_refuses_before_a_guest_is_booted(self, tmp_path):
+        held = TaskConversations(CEILINGS, RunWideCeilings(max_model_calls=1))
+        held.limits_for("task-0", 1).budget.record(
+            input_tokens=1, output_tokens=1
+        )
+        with pytest.raises(ConversationRunnerRefused, match="run-wide"):
+            self._factory(tmp_path, held)(self._task())
+
+    def test_the_record_survives_being_turned_into_a_dict(self, tmp_path):
+        held = TaskConversations(CEILINGS)
+        self._factory(tmp_path, held)(self._task()).run(
+            "Write the report", task_id="task-1"
+        )
+        record = held.as_dict()
+        assert record["conversations"]["task-1#1"]["produced_an_answer"] is True
+        assert record["per_task_ceilings"]["max_model_turns"] == 8
+
+
+# ── what the conversation costs, in the ledger ───────────────────────────
+
+
+@pytest.fixture
+def ledger(tmp_path):
+    book = CostReceiptLedger(
+        tmp_path / "cost.sqlite3",
+        run_id="test-run",
+        price_table=load_receipt_price_table(),
+    )
+    yield book
+    book.close()
+
+
+class TestTheConversationReachesTheLedger:
+    def _outcome(self, tmp_path, task_id="task-1"):
+        _, outcome, _ = _run(
+            tmp_path,
+            [
+                _write(input_tokens=1000, output_tokens=200),
+                _finalize(input_tokens=1500, output_tokens=120),
+            ],
+            task_id=task_id,
+        )
+        return outcome
+
+    def _turns(self, outcome, **overrides):
+        fields = {
+            "run_id": "run-a",
+            "task_id": "task-1",
+            "attempt": 1,
+            # "azure", not "azure_openai": the price table keys on
+            # ``provider:resolved_model`` and does no prefix matching, so a
+            # provider spelt another way prices nothing at all.
+            "provider": "azure",
+            "requested_model": "gpt-5.4",
+        }
+        fields.update(overrides)
+        return model_turns_of(outcome, **fields)
+
+    def test_every_turn_becomes_a_ledger_entry(self, tmp_path):
+        turns = self._turns(self._outcome(tmp_path))
+        assert len(turns) == 2
+
+    def test_the_counts_are_the_ones_the_provider_reported(self, tmp_path):
+        turns = self._turns(self._outcome(tmp_path))
+        assert turns[0].usage.input_tokens == 1000
+        assert turns[1].usage.output_tokens == 120
+
+    def test_no_count_is_a_zero_standing_in_for_an_unknown(self, tmp_path):
+        """The loop refuses a reply it cannot charge for, so this holds."""
+        turns = self._turns(self._outcome(tmp_path))
+        assert all(turn.usage.input_tokens is not None for turn in turns)
+
+    def test_call_ids_from_different_tasks_do_not_collide(self, tmp_path):
+        first = self._turns(
+            self._outcome(tmp_path / "a", "task-1"), task_id="task-1"
+        )
+        second = self._turns(
+            self._outcome(tmp_path / "b", "task-2"), task_id="task-2"
+        )
+        assert {turn.call_id for turn in first} & {
+            turn.call_id for turn in second
+        } == set()
+
+    def test_call_ids_from_two_attempts_do_not_collide(self, tmp_path):
+        outcome = self._outcome(tmp_path)
+        first = self._turns(outcome, attempt=1)
+        second = self._turns(outcome, attempt=2, preceding_error="finalize_not_called")
+        assert {turn.call_id for turn in first} & {
+            turn.call_id for turn in second
+        } == set()
+
+    def test_a_first_attempt_carries_no_retry_kind(self, tmp_path):
+        turns = self._turns(self._outcome(tmp_path))
+        assert all(turn.retry_kind == RETRY_NONE for turn in turns)
+
+    def test_a_retry_is_billed_as_a_retry(self, tmp_path):
+        turns = self._turns(
+            self._outcome(tmp_path), preceding_error="finalize_not_called"
+        )
+        assert all(turn.retry_kind != RETRY_NONE for turn in turns)
+
+    def test_an_attempt_that_should_not_have_happened_is_refused(self, tmp_path):
+        """``cancelled`` has no next attempt, so there is no kind to file it
+        under and inventing ``retry_none`` would hide a broken retry rule."""
+        with pytest.raises(ConversationRunnerRefused, match="no next attempt"):
+            self._turns(self._outcome(tmp_path), preceding_error="cancelled")
+
+    def test_the_turns_settle_into_the_ledger(self, tmp_path, ledger):
+        written = bind_run_to_ledger(
+            ledger,
+            task_id="task-1",
+            model_turns=self._turns(self._outcome(tmp_path)),
+        )
+        assert len(written["settled_call_ids"]) == 2
+        receipt = ledger.receipt_for("task-1", BUCKET_PROBLEM_SOLVING)
+        assert receipt.model_cost_usd is not None
+        assert receipt.model_cost_usd > 0
+
+    def test_a_model_with_no_price_settles_as_partial_and_not_as_zero(
+        self, tmp_path, ledger
+    ):
+        """The conversation's calls happened; what they cost is unknown.
+
+        A run whose model is missing from the price table must not report a
+        tidy ``$0``. Zero is a claim that the calls were free, and they were
+        not — the receipt has to say it does not know. Written down here
+        because the join is where a 220-task run acquires its cost, and a
+        silent zero across 220 tasks is the shape of an unnoticed bill.
+        """
+        turns = self._turns(
+            self._outcome(tmp_path), requested_model="a-model-nobody-priced"
+        )
+        bind_run_to_ledger(ledger, task_id="task-1", model_turns=turns)
+        receipt = ledger.receipt_for("task-1", BUCKET_PROBLEM_SOLVING)
+        assert receipt.status == "partial"
+        assert "price_missing" in receipt.missing_reasons
+
+    def test_the_conversation_lands_in_the_problem_solving_bucket(
+        self, tmp_path, ledger
+    ):
+        """A task run is not grading, and the two totals stay apart."""
+        written = bind_run_to_ledger(
+            ledger,
+            task_id="task-1",
+            model_turns=self._turns(self._outcome(tmp_path)),
+        )
+        assert written["bucket"] == BUCKET_PROBLEM_SOLVING
+
+    def test_an_empty_conversation_produces_no_entries(self, tmp_path):
+        _, outcome, _ = _run(tmp_path, [GaveUp(note="nothing to do")])
+        assert self._turns(outcome) == ()

--- a/batch-runner/tests/test_agentic_v2_manifest_binding.py
+++ b/batch-runner/tests/test_agentic_v2_manifest_binding.py
@@ -1,0 +1,364 @@
+"""Whether a cohort can be bound to prompts without changing the experiment.
+
+The positive path uses a catalogue this file builds, because the committed one
+pins ``prompt_sha256`` for prompts that live in a dataset snapshot nobody here
+has — ``data/gdpval-local`` in this checkout holds no parquet. That is stated
+rather than worked around: these tests prove the check bites, and no run in this
+repository has yet bound the real 220 against the real dataset.
+
+What *is* checked against the committed catalogue is everything that does not
+need the prompts: that stage five really is five tasks, that its ids are the
+ones the selection rule gives, and that a prompt which is not the pinned one is
+refused.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, replace
+
+import pytest
+
+from core.agentic_v2_manifest_binding import (
+    ANSWER_FIELDS_THAT_MUST_NOT_TRAVEL,
+    BINDING_SCHEMA_VERSION,
+    STAGE_FIVE,
+    STAGE_THIRTY,
+    STAGE_TWO_TWENTY,
+    ManifestRefused,
+    bind_stage,
+    binding_record,
+    unmet_needs,
+)
+from core.agentic_v2_preregistration import STAGE_SIZES
+from core.agentic_v2_run_driver import TaskToRun
+from core.execution_envelope_tasks import (
+    CatalogTask,
+    TaskCatalog,
+    catalog_sha256,
+    load_task_catalog,
+    select_advance_check_tasks,
+)
+
+
+DIGEST = "e" * 64
+
+
+@dataclass
+class Row:
+    """A dataset row, shaped like ``prepare_dataset.GDPValTask``."""
+
+    task_id: str
+    prompt: str
+    sector: str
+    occupation: str
+    reference_files: tuple[str, ...] = ()
+    # The expert's own answer travels on the real row too. Present here so a
+    # test can prove it is not read.
+    deliverable_text: str = "the expert's answer, which must not travel"
+    deliverable_files: tuple[str, ...] = ("expert_answer.xlsx",)
+
+
+#: One task per format family the advance-check rule walks, in its order:
+#: spreadsheet, document, presentation, image, then the text-only slot.
+_SHAPES = (
+    ((".xlsx",), "Analyst", "Finance"),
+    ((".docx",), "Writer", "Media"),
+    ((".pptx",), "Consultant", "Services"),
+    ((".png",), "Designer", "Manufacturing"),
+    ((), "Advisor", "Retail"),
+)
+
+
+def _catalog_task(index, extensions, occupation, sector, prompt, references=()):
+    return CatalogTask(
+        task_id=f"task-{index:04d}",
+        sector=sector,
+        occupation=occupation,
+        deliverable_file_extensions=tuple(extensions),
+        reference_file_count=len(references),
+        reference_file_extensions=tuple(
+            sorted({"." + name.rsplit(".", 1)[-1] for name in references})
+        ),
+        reference_file_paths=tuple(sorted(references)),
+        prompt_sha256=hashlib.sha256(prompt.encode("utf-8")).hexdigest(),
+        prompt_character_count=len(prompt),
+        rubric_item_count=4,
+        widest_rubric_criterion_characters=120,
+    )
+
+
+def _prompt_for(index):
+    return f"Prompt number {index}. Do the work and hand in the file."
+
+
+@pytest.fixture
+def bench():
+    """A five-task catalogue and the dataset rows that match it exactly."""
+    tasks = []
+    rows = []
+    for index, (extensions, occupation, sector) in enumerate(_SHAPES, start=1):
+        prompt = _prompt_for(index)
+        references = ("Costs.xlsx",) if index == 1 else ()
+        tasks.append(
+            _catalog_task(index, extensions, occupation, sector, prompt, references)
+        )
+        rows.append(
+            Row(
+                task_id=f"task-{index:04d}",
+                prompt=prompt,
+                sector=sector,
+                occupation=occupation,
+                reference_files=references,
+            )
+        )
+    catalog = TaskCatalog(
+        schema_version="gdpval-task-catalog-v1",
+        dataset_repo_id="example/benchmark",
+        dataset_revision="d" * 40,
+        dataset_file_sha256="f" * 64,
+        tasks=tuple(tasks),
+    )
+    return catalog, rows
+
+
+def _bind(bench, **kwargs):
+    catalog, rows = bench
+    kwargs.setdefault("dataset_tasks", rows)
+    kwargs.setdefault("catalog", catalog)
+    kwargs.setdefault("catalog_digest", DIGEST)
+    return bind_stage(kwargs.pop("stage", STAGE_FIVE), **kwargs)
+
+
+# ── the answer never travels ─────────────────────────────────────────────
+
+
+def test_a_bound_task_has_nowhere_to_put_the_expert_s_answer():
+    carried = {field for field in TaskToRun.__dataclass_fields__}
+    assert carried & set(ANSWER_FIELDS_THAT_MUST_NOT_TRAVEL) == set()
+
+
+def test_the_answer_on_the_row_is_not_read(bench):
+    bound = _bind(bench)
+    everything = repr(bound.as_dict()) + repr(bound.tasks)
+    assert "must not travel" not in everything
+    assert "expert_answer.xlsx" not in everything
+
+
+# ── binding ──────────────────────────────────────────────────────────────
+
+
+def test_five_tasks_bind_with_their_prompts(bench):
+    bound = _bind(bench)
+    assert len(bound.tasks) == STAGE_SIZES[STAGE_FIVE]
+    assert bound.tasks[0].prompt == _prompt_for(1)
+    assert bound.stage == STAGE_FIVE
+    assert bound.catalog_sha256 == DIGEST
+    assert bound.dataset_revision == "d" * 40
+
+
+def test_the_bound_ids_are_the_selection_rule_s(bench):
+    catalog, _ = bench
+    bound = _bind(bench)
+    assert bound.task_ids == select_advance_check_tasks(
+        catalog, catalog_fingerprint=DIGEST
+    ).task_ids
+
+
+def test_occupation_and_sector_come_from_the_pinned_catalogue(bench):
+    bound = _bind(bench)
+    assert {task.occupation for task in bound.tasks} == {
+        occupation for _, occupation, _ in _SHAPES
+    }
+
+
+def test_the_prompt_digests_are_recorded_per_task(bench):
+    bound = _bind(bench)
+    digests = dict(bound.prompt_digests)
+    assert len(digests) == 5
+    assert digests["task-0001"] == hashlib.sha256(
+        _prompt_for(1).encode("utf-8")
+    ).hexdigest()
+
+
+# ── drift ────────────────────────────────────────────────────────────────
+
+
+def test_a_changed_prompt_is_refused(bench):
+    catalog, rows = bench
+    rows[0] = replace(rows[0], prompt=_prompt_for(1) + " Also, be brief.")
+    with pytest.raises(ManifestRefused, match="different prompt"):
+        _bind((catalog, rows))
+
+
+def test_a_prompt_of_the_same_length_is_still_refused(bench):
+    """A length check would pass this; a digest does not."""
+    catalog, rows = bench
+    original = _prompt_for(1)
+    swapped = original[:-1] + ("?" if original[-1] != "?" else ".")
+    assert len(swapped) == len(original)
+    rows[0] = replace(rows[0], prompt=swapped)
+    with pytest.raises(ManifestRefused, match="different prompt"):
+        _bind((catalog, rows))
+
+
+def test_a_changed_occupation_is_refused(bench):
+    catalog, rows = bench
+    rows[0] = replace(rows[0], occupation="Someone Else")
+    with pytest.raises(ManifestRefused, match="occupation"):
+        _bind((catalog, rows))
+
+
+def test_a_changed_reference_file_list_is_refused(bench):
+    catalog, rows = bench
+    rows[0] = replace(rows[0], reference_files=("Costs.xlsx", "Extra.docx"))
+    with pytest.raises(ManifestRefused, match="reference files"):
+        _bind((catalog, rows))
+
+
+def test_reference_files_in_another_order_are_accepted(bench):
+    """The catalogue sorted them; the dataset need not have."""
+    catalog, rows = bench
+    tasks = list(catalog.tasks)
+    tasks[0] = replace(
+        tasks[0], reference_file_paths=("Costs.xlsx", "Notes.docx")
+    )
+    rows[0] = replace(rows[0], reference_files=("Notes.docx", "Costs.xlsx"))
+    bound = _bind((replace(catalog, tasks=tuple(tasks)), rows))
+    assert bound.tasks[0].reference_files == ("Costs.xlsx", "Notes.docx")
+
+
+def test_a_missing_task_is_refused(bench):
+    catalog, rows = bench
+    with pytest.raises(ManifestRefused, match="not in the dataset"):
+        _bind((catalog, rows[:-1]))
+
+
+def test_a_duplicated_dataset_row_is_refused(bench):
+    catalog, rows = bench
+    with pytest.raises(ManifestRefused, match="twice"):
+        _bind((catalog, rows + [rows[0]]))
+
+
+def test_every_drifted_task_is_named_not_just_the_first(bench):
+    catalog, rows = bench
+    rows[0] = replace(rows[0], prompt="something else entirely")
+    rows[1] = replace(rows[1], occupation="Someone Else")
+    with pytest.raises(ManifestRefused) as raised:
+        _bind((catalog, rows))
+    assert "task-0001" in str(raised.value)
+    assert "task-0002" in str(raised.value)
+
+
+# ── provenance the binding refuses to invent ─────────────────────────────
+
+
+def test_a_supplied_catalogue_without_its_digest_is_refused(bench):
+    catalog, rows = bench
+    with pytest.raises(ManifestRefused, match="without its digest"):
+        bind_stage(STAGE_FIVE, dataset_tasks=rows, catalog=catalog)
+
+
+def test_a_digest_without_a_catalogue_is_refused(bench):
+    _, rows = bench
+    with pytest.raises(ManifestRefused, match="without a catalogue"):
+        bind_stage(STAGE_FIVE, dataset_tasks=rows, catalog_digest=DIGEST)
+
+
+def test_an_unknown_stage_is_refused(bench):
+    with pytest.raises(ManifestRefused, match="not a registered stage"):
+        _bind(bench, stage="a_quick_one")
+
+
+def test_a_catalogue_too_small_for_the_escalation_records_no_seal(bench):
+    """Five tasks cannot produce the thirty-task cohort, so there is no seal."""
+    bound = _bind(bench)
+    assert bound.preregistration_seal is None
+
+
+def test_a_seal_that_cannot_be_computed_is_an_error_when_one_was_given(bench):
+    with pytest.raises(ManifestRefused, match="cannot"):
+        _bind(bench, expected_seal="a" * 64)
+
+
+def test_the_binding_seal_changes_when_a_prompt_does(bench):
+    catalog, rows = bench
+    before = _bind((catalog, list(rows))).binding_seal()
+
+    tasks = list(catalog.tasks)
+    changed = _prompt_for(1) + " Be brief."
+    tasks[0] = replace(
+        tasks[0],
+        prompt_sha256=hashlib.sha256(changed.encode("utf-8")).hexdigest(),
+        prompt_character_count=len(changed),
+    )
+    rows[0] = replace(rows[0], prompt=changed)
+    after = _bind((replace(catalog, tasks=tuple(tasks)), rows)).binding_seal()
+    assert before != after
+
+
+def test_the_record_carries_the_schema_and_both_seals(bench):
+    record = binding_record(_bind(bench))
+    assert record["schema_version"] == BINDING_SCHEMA_VERSION
+    assert len(record["binding_seal"]) == 64
+    assert record["preregistration_seal"] is None
+    assert record["stage"] == STAGE_FIVE
+
+
+# ── what is still missing ────────────────────────────────────────────────
+
+
+def test_the_binding_says_which_tasks_lack_their_input_files(bench):
+    needs = unmet_needs(_bind(bench))
+    assert needs["tasks_needing_reference_files"] == ["task-0001"]
+    assert needs["reference_file_bytes_are_in_the_guest"] is False
+    assert "not evidence about the model" in needs["what_that_means"]
+
+
+def test_a_task_with_no_reference_files_is_not_counted_as_handicapped(bench):
+    needs = unmet_needs(_bind(bench))
+    assert needs["tasks_needing_reference_files_count"] == 1
+
+
+# ── against the catalogue that is actually committed ─────────────────────
+
+
+def test_the_committed_catalogue_still_gives_five_and_thirty_and_220():
+    catalog = load_task_catalog()
+    assert len(select_advance_check_tasks(catalog).task_ids) == STAGE_SIZES[STAGE_FIVE]
+    assert len(catalog.tasks) == STAGE_SIZES[STAGE_TWO_TWENTY]
+
+
+def test_the_committed_catalogue_refuses_prompts_nobody_here_has():
+    """The snapshot in this checkout holds no parquet, so this must not pass."""
+    catalog = load_task_catalog()
+    wanted = select_advance_check_tasks(catalog).task_ids
+    pinned = catalog.by_task_id()
+    invented = [
+        Row(
+            task_id=task_id,
+            prompt="a prompt this repository does not have",
+            sector=pinned[task_id].sector,
+            occupation=pinned[task_id].occupation,
+            reference_files=pinned[task_id].reference_file_paths,
+        )
+        for task_id in wanted
+    ]
+    with pytest.raises(ManifestRefused, match="different prompt"):
+        bind_stage(
+            STAGE_FIVE,
+            dataset_tasks=invented,
+            catalog=catalog,
+            catalog_digest=catalog_sha256(),
+        )
+
+
+def test_the_thirty_stage_binds_from_the_committed_catalogue_shape():
+    """Only the shape: the ids are real, the prompts are still not here."""
+    catalog = load_task_catalog()
+    pinned = catalog.by_task_id()
+    from core.execution_envelope_tasks import select_trial_run_tasks
+
+    wanted = select_trial_run_tasks(catalog)
+    assert len(wanted) == STAGE_SIZES[STAGE_THIRTY]
+    assert all(task_id in pinned for task_id in wanted)

--- a/batch-runner/tests/test_agentic_v2_run_driver.py
+++ b/batch-runner/tests/test_agentic_v2_run_driver.py
@@ -1,0 +1,520 @@
+"""Whether the loop finishes a manifest, resumes one, and stops when it must.
+
+The runner is a stand-in, but everything it feeds is real: the real journal
+writing a real file, the real collector writing real bytes, the real report
+adapter. What is faked is the one thing that is still blocked — the model. So a
+test that says "resumed and did not re-run the finished task" is a statement
+about the code that will run the 220, not about a mock of it.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from core.agentic_v2_deliverable_collection import DELIVERABLE_ROOT
+from core.agentic_v2_preregistration import STOP_RULES
+from core.agentic_v2_run_driver import (
+    CONSECUTIVE_RUNNER_DEFECTS_THAT_STOP_A_RUN,
+    RULES_THIS_DRIVER_CANNOT_SEE,
+    RULES_THIS_DRIVER_WATCHES,
+    DriverRefused,
+    TaskToRun,
+    run_manifest,
+)
+from core.cost_receipts import STATUS_COMPLETE, STATUS_NOT_RUN, STATUS_PARTIAL
+
+
+def _tasks(count=3):
+    return [
+        TaskToRun(
+            task_id=f"task-{index:04d}",
+            prompt=f"do thing {index}",
+            occupation="Analyst",
+            sector="Finance",
+        )
+        for index in range(1, count + 1)
+    ]
+
+
+def _success(task_id, *, calls=("exec_run", "finalize")):
+    return {
+        "success": True,
+        "deliverable_text": f"answer for {task_id}",
+        "files": [{"filename": "report.xlsx", "content": b"payload"}],
+        "agentic_v2": {
+            "model_api_calls": 2,
+            "public_trace": {
+                "events": [{"tool_name": name} for name in calls]
+            },
+        },
+    }
+
+
+def _failure(error):
+    return {"success": False, "error": error, "files": []}
+
+
+class _Runner:
+    """A runner that answers from a script, and records that it was closed."""
+
+    def __init__(self, script, closed):
+        self.script = script
+        self.closed = closed
+
+    def run(self, prompt, reference_files, occupation, **kwargs):
+        task_id = kwargs["task_id"]
+        answer = self.script(task_id)
+        return answer
+
+    def close(self):
+        self.closed.append(id(self))
+
+
+def _factory(script, closed=None):
+    made = []
+    closed = [] if closed is None else closed
+
+    def build(task):
+        runner = _Runner(script, closed)
+        made.append(runner)
+        return runner
+
+    build.made = made  # type: ignore[attr-defined]
+    build.closed = closed  # type: ignore[attr-defined]
+    return build
+
+
+def _run(tmp_path, tasks, script, **kwargs):
+    factory = kwargs.pop("factory", None) or _factory(script)
+    return (
+        run_manifest(
+            tasks,
+            run_id=kwargs.pop("run_id", "run-a"),
+            runner_factory=factory,
+            journal_path=tmp_path / "journal.jsonl",
+            collect_into=tmp_path,
+            **kwargs,
+        ),
+        factory,
+    )
+
+
+# ── the stop rules this driver claims ────────────────────────────────────
+
+
+def test_every_stop_rule_is_either_watched_or_accounted_for():
+    watched = set(RULES_THIS_DRIVER_WATCHES)
+    unseen = set(RULES_THIS_DRIVER_CANNOT_SEE)
+    assert watched & unseen == set()
+    assert watched | unseen == set(range(len(STOP_RULES)))
+
+
+def test_the_driver_watches_only_two_of_the_eight():
+    """Claiming all eight would be the easy and wrong thing to do."""
+    assert len(RULES_THIS_DRIVER_WATCHES) == 2
+    assert len(STOP_RULES) == 8
+
+
+# ── the ordinary run ─────────────────────────────────────────────────────
+
+
+def test_a_whole_manifest_runs_and_every_task_gets_a_row(tmp_path):
+    outcome, _ = _run(tmp_path, _tasks(3), _success)
+    assert [row["task_id"] for row in outcome.rows] == [
+        "task-0001",
+        "task-0002",
+        "task-0003",
+    ]
+    assert outcome.summary["executed"] == 3
+    assert outcome.summary["succeeded"] == 3
+    assert outcome.summary["not_reached"] == 0
+    assert outcome.stopped is None
+
+
+def test_each_task_gets_its_own_runner_and_all_are_closed(tmp_path):
+    outcome, factory = _run(tmp_path, _tasks(3), _success)
+    assert len(factory.made) == 3
+    assert len(set(id(runner) for runner in factory.made)) == 3
+    assert len(factory.closed) == 3
+
+
+def test_a_runner_is_closed_even_when_it_raises(tmp_path):
+    def explode(task_id):
+        raise RuntimeError("the runner fell over")
+
+    factory = _factory(explode)
+    with pytest.raises(RuntimeError, match="fell over"):
+        run_manifest(
+            _tasks(1),
+            run_id="run-a",
+            runner_factory=factory,
+            journal_path=tmp_path / "journal.jsonl",
+            collect_into=tmp_path,
+        )
+    assert len(factory.closed) == 1
+
+
+def test_the_files_reach_the_submission_layout(tmp_path):
+    outcome, _ = _run(tmp_path, _tasks(1), _success)
+    landed = tmp_path / DELIVERABLE_ROOT / "task-0001" / "report.xlsx"
+    assert landed.read_bytes() == b"payload"
+    assert outcome.rows[0]["deliverable_files"] == [
+        f"{DELIVERABLE_ROOT}/task-0001/report.xlsx"
+    ]
+
+
+def test_v2_tool_calls_are_counted_from_the_public_trace(tmp_path):
+    outcome, _ = _run(tmp_path, _tasks(1), _success)
+    metrics = outcome.rows[0]["observability"]["agentic_metrics"]
+    assert metrics["tool_calls"] == 2
+    assert metrics["tool_calls_by_name"]["exec_run"] == 1
+    assert metrics["model_api_calls"] == 2
+
+
+def test_wall_time_is_measured_per_task(tmp_path):
+    ticks = iter([0.0, 1.5, 10.0, 12.0])
+    outcome, _ = _run(tmp_path, _tasks(2), _success, clock=lambda: next(ticks))
+    metrics = [
+        row["observability"]["agentic_metrics"]["task_wall_time_ms"]
+        for row in outcome.rows
+    ]
+    assert metrics == [1500.0, 2000.0]
+
+
+# ── money ────────────────────────────────────────────────────────────────
+
+
+def test_a_run_with_no_ledger_is_not_run_rather_than_free(tmp_path):
+    outcome, _ = _run(tmp_path, _tasks(1), _success)
+    metrics = outcome.rows[0]["observability"]["agentic_metrics"]
+    assert metrics["agentic_v2_cost_receipt_status"] == STATUS_NOT_RUN
+    assert "conservative_cost_usd" not in metrics
+    assert outcome.summary["cost_is_fully_accounted"] is False
+
+
+def test_a_complete_receipt_reaches_the_row_and_the_summary(tmp_path):
+    def receipt_for(task, attempt):
+        return {
+            "status": STATUS_COMPLETE,
+            "estimated_cost_usd": 0.5,
+            "known_cost_usd": 0.5,
+        }
+
+    outcome, _ = _run(tmp_path, _tasks(2), _success, receipt_for=receipt_for)
+    for row in outcome.rows:
+        metrics = row["observability"]["agentic_metrics"]
+        assert metrics["conservative_cost_usd"] == 0.5
+        assert row["problem_solving_cost"]["status"] == STATUS_COMPLETE
+    assert outcome.summary["cost_is_fully_accounted"] is True
+
+
+def test_the_attempt_index_reaches_the_pricing_callback(tmp_path):
+    seen = []
+
+    def receipt_for(task, attempt):
+        seen.append((task.task_id, attempt))
+        return None
+
+    attempts = {"n": 0}
+
+    def flaky(task_id):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            return _failure("compute_start_failed")
+        return _success(task_id)
+
+    _run(tmp_path, _tasks(1), flaky, receipt_for=receipt_for)
+    assert seen == [("task-0001", 1), ("task-0001", 2)]
+
+
+# ── retries ──────────────────────────────────────────────────────────────
+
+
+def test_an_infrastructure_failure_is_retried_and_can_succeed(tmp_path):
+    attempts = {"n": 0}
+
+    def flaky(task_id):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            return _failure("compute_start_failed")
+        return _success(task_id)
+
+    outcome, factory = _run(tmp_path, _tasks(1), flaky)
+    assert len(outcome.rows) == 1
+    assert outcome.rows[0]["status"] == "success"
+    assert outcome.rows[0]["retried"] is True
+    assert len(factory.made) == 2
+
+
+def test_only_the_last_attempt_becomes_the_row(tmp_path):
+    attempts = {"n": 0}
+
+    def flaky(task_id):
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            return _failure("compute_start_failed")
+        return _success(task_id)
+
+    outcome, _ = _run(tmp_path, _tasks(1), flaky)
+    assert len(outcome.rows) == 1
+    assert outcome.rows[0]["status"] == "success"
+
+
+def test_a_task_that_never_recovers_stops_at_the_attempt_ceiling(tmp_path):
+    outcome, factory = _run(
+        tmp_path, _tasks(1), lambda task_id: _failure("compute_start_failed")
+    )
+    assert len(factory.made) == 3
+    assert outcome.rows[0]["status"] == "error"
+    assert outcome.rows[0]["error"] == "compute_start_failed"
+
+
+def test_a_terminal_failure_is_not_retried(tmp_path):
+    outcome, factory = _run(
+        tmp_path, _tasks(1), lambda task_id: _failure("capability_unavailable")
+    )
+    assert len(factory.made) == 1
+    assert outcome.rows[0]["status"] == "error"
+    assert (
+        outcome.rows[0]["observability"]["agentic_metrics"]["agentic_v2_disposition"]
+        == "terminal_capability_absent"
+    )
+
+
+def test_a_capability_absence_does_not_stop_the_run(tmp_path):
+    """The pre-registration records this as a result, not a fault."""
+    script = lambda task_id: (  # noqa: E731
+        _failure("capability_unavailable")
+        if task_id == "task-0002"
+        else _success(task_id)
+    )
+    outcome, _ = _run(tmp_path, _tasks(3), script)
+    assert outcome.stopped is None
+    assert len(outcome.rows) == 3
+    assert outcome.summary["failed"] == 1
+
+
+# ── stopping ─────────────────────────────────────────────────────────────
+
+
+def test_three_runner_defects_running_stop_the_run(tmp_path):
+    outcome, _ = _run(
+        tmp_path, _tasks(5), lambda task_id: _failure("invalid_backend_state")
+    )
+    assert outcome.stopped is not None
+    assert outcome.stopped.rule_index == 6
+    assert outcome.stopped.rule == STOP_RULES[6]
+    assert len(outcome.rows) == CONSECUTIVE_RUNNER_DEFECTS_THAT_STOP_A_RUN
+    assert outcome.summary["not_reached"] == 2
+
+
+def test_a_good_task_between_defects_resets_the_count(tmp_path):
+    """Two defects, a good task, two more defects: four in the run, no stop."""
+    script = lambda task_id: (  # noqa: E731
+        _success(task_id)
+        if task_id == "task-0003"
+        else _failure("invalid_backend_state")
+    )
+    outcome, _ = _run(tmp_path, _tasks(5), script)
+    assert outcome.stopped is None
+    assert len(outcome.rows) == 5
+    assert outcome.summary["failed"] == 4
+
+
+def test_the_reset_only_delays_a_run_that_keeps_failing(tmp_path):
+    """Same script, one task longer, and the tail of three lands."""
+    script = lambda task_id: (  # noqa: E731
+        _success(task_id)
+        if task_id == "task-0003"
+        else _failure("invalid_backend_state")
+    )
+    outcome, _ = _run(tmp_path, _tasks(6), script)
+    assert outcome.stopped is not None
+    assert outcome.stopped.rule_index == 6
+    assert outcome.stopped.after_task == "task-0006"
+
+
+def test_a_semantic_failure_also_resets_the_count(tmp_path):
+    """The rule counts this code misbehaving, not tasks going badly."""
+    script = lambda task_id: (  # noqa: E731
+        _failure("finalize_not_called")
+        if task_id == "task-0003"
+        else _failure("invalid_backend_state")
+    )
+    outcome, _ = _run(tmp_path, _tasks(5), script)
+    assert outcome.stopped is None
+    assert len(outcome.rows) == 5
+
+
+def test_a_failed_cleanup_stops_the_run_immediately(tmp_path):
+    script = lambda task_id: (  # noqa: E731
+        _failure("compute_cleanup_failed")
+        if task_id == "task-0002"
+        else _success(task_id)
+    )
+    outcome, _ = _run(tmp_path, _tasks(4), script)
+    assert outcome.stopped is not None
+    assert outcome.stopped.rule_index == 7
+    assert outcome.stopped.after_task == "task-0002"
+    assert len(outcome.rows) == 2
+    assert outcome.summary["not_reached"] == 2
+
+
+def test_a_stopped_run_says_so_in_its_summary(tmp_path):
+    outcome, _ = _run(
+        tmp_path, _tasks(4), lambda task_id: _failure("invalid_backend_state")
+    )
+    assert outcome.summary["stopped_early"]["rule_index"] == 6
+    assert outcome.as_dict()["stopped_early"]["after_task"] == "task-0003"
+
+
+# ── collection failures ──────────────────────────────────────────────────
+
+
+def test_a_deliverable_the_collector_refuses_fails_the_task(tmp_path):
+    def bad_path(task_id):
+        answer = _success(task_id)
+        answer["files"] = [{"filename": "../escape.txt", "content": b"x"}]
+        return answer
+
+    outcome, _ = _run(tmp_path, _tasks(1), bad_path)
+    assert outcome.rows[0]["status"] == "error"
+    assert outcome.rows[0]["error"] == "invalid_backend_result"
+    assert outcome.rows[0]["deliverable_files"] == []
+    assert not (tmp_path / DELIVERABLE_ROOT / "task-0001").exists()
+
+
+def test_three_collection_failures_running_stop_the_run(tmp_path):
+    """Because the contract and the collector disagreeing is this code's fault."""
+
+    def bad_path(task_id):
+        answer = _success(task_id)
+        answer["files"] = [{"filename": "../escape.txt", "content": b"x"}]
+        return answer
+
+    outcome, _ = _run(tmp_path, _tasks(6), bad_path)
+    assert outcome.stopped is not None
+    assert outcome.stopped.rule_index == 6
+    assert len(outcome.rows) == 3
+
+
+# ── resume ───────────────────────────────────────────────────────────────
+
+
+def test_a_second_run_skips_what_the_first_finished(tmp_path):
+    tasks = _tasks(3)
+    script = lambda task_id: (  # noqa: E731
+        _failure("invalid_backend_state")
+        if task_id == "task-0003"
+        else _success(task_id)
+    )
+    first, _ = _run(tmp_path, tasks, script)
+    assert len(first.rows) == 3
+
+    second, factory = _run(tmp_path, tasks, _success)
+    assert second.skipped_on_resume == ("task-0001", "task-0002", "task-0003")
+    assert factory.made == []
+    assert second.rows == []
+
+
+def test_a_resumed_run_finishes_what_was_left(tmp_path):
+    tasks = _tasks(3)
+    attempts = {"n": 0}
+
+    def two_then_stop(task_id):
+        attempts["n"] += 1
+        if attempts["n"] > 2:
+            raise KeyboardInterrupt
+        return _success(task_id)
+
+    with pytest.raises(KeyboardInterrupt):
+        _run(tmp_path, tasks, two_then_stop)
+
+    second, factory = _run(tmp_path, tasks, _success)
+    assert second.skipped_on_resume == ("task-0001", "task-0002")
+    assert [row["task_id"] for row in second.rows] == ["task-0003"]
+    assert len(factory.made) == 1
+
+
+def test_an_interrupted_task_keeps_the_run_s_cost_partial_forever(tmp_path):
+    """The attempt that vanished was charged and nobody can price it."""
+    tasks = _tasks(2)
+
+    def receipt_for(task, attempt):
+        return {
+            "status": STATUS_COMPLETE,
+            "estimated_cost_usd": 1.0,
+            "known_cost_usd": 1.0,
+        }
+
+    def die_on_the_second(task_id):
+        if task_id == "task-0002":
+            raise KeyboardInterrupt
+        return _success(task_id)
+
+    with pytest.raises(KeyboardInterrupt):
+        _run(tmp_path, tasks, die_on_the_second, receipt_for=receipt_for)
+
+    second, _ = _run(tmp_path, tasks, _success, receipt_for=receipt_for)
+    # task-0001 was settled in the first run and is skipped here, so the only
+    # task left unpriced is the one whose first attempt disappeared.
+    assert second.skipped_on_resume == ("task-0001",)
+    assert second.summary["receipt_ceiling"] == STATUS_PARTIAL
+    assert second.summary["cost_is_fully_accounted"] is False
+    assert second.summary["unaccounted_tasks"] == ["task-0002"]
+    metrics = second.rows[0]["observability"]["agentic_metrics"]
+    assert "conservative_cost_usd" not in metrics
+    assert metrics["agentic_v2_abandoned_attempts"] == 1
+
+
+def test_a_run_with_no_ledger_leaves_every_task_unaccounted(tmp_path):
+    """Not pricing at all is a partial run, not a cheap one."""
+    outcome, _ = _run(tmp_path, _tasks(2), _success)
+    assert outcome.summary["unaccounted_tasks"] == ["task-0001", "task-0002"]
+    assert outcome.summary["cost_is_fully_accounted"] is False
+
+
+def test_the_journal_on_disk_survives_the_run(tmp_path):
+    _run(tmp_path, _tasks(2), _success)
+    lines = (tmp_path / "journal.jsonl").read_text(encoding="utf-8").splitlines()
+    kinds = [json.loads(line)["kind"] for line in lines]
+    assert kinds == ["header", "opened", "closed", "opened", "closed"]
+
+
+# ── refusals ─────────────────────────────────────────────────────────────
+
+
+def test_an_empty_manifest_is_refused(tmp_path):
+    with pytest.raises(DriverRefused, match="is not one"):
+        run_manifest(
+            [],
+            run_id="run-a",
+            runner_factory=_factory(_success),
+            journal_path=tmp_path / "journal.jsonl",
+            collect_into=tmp_path,
+        )
+
+
+def test_a_repeated_task_in_the_manifest_is_refused(tmp_path):
+    tasks = _tasks(1) * 2
+    with pytest.raises(DriverRefused, match="appears twice"):
+        run_manifest(
+            tasks,
+            run_id="run-a",
+            runner_factory=_factory(_success),
+            journal_path=tmp_path / "journal.jsonl",
+            collect_into=tmp_path,
+        )
+
+
+def test_a_runner_that_returns_something_else_is_refused(tmp_path):
+    with pytest.raises(DriverRefused, match="not a result envelope"):
+        _run(tmp_path, _tasks(1), lambda task_id: "finished, probably")
+
+
+def test_the_callback_sees_each_row_as_it_lands(tmp_path):
+    seen = []
+    _run(tmp_path, _tasks(3), _success, on_task=lambda tid, row: seen.append(tid))
+    assert seen == ["task-0001", "task-0002", "task-0003"]

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
@@ -1987,6 +1987,14 @@ So the paid leg needs one of: a cross-tenant service-principal grant, or a
 booting host inside subscription `d372e9cf…`. **Both are access changes, and
 neither is covered by the cost approval**, which is why this is reported rather
 than performed — even though the credentials to do the first are on this box.
+
+> **Superseded on 2026-09-11 — see "The block was not one" below.** The two
+> options above are not the only two, because the sentence assumes the model has
+> to be *that* account. It does not. There are `gpt-5.4` deployments in this
+> box's own subscription, and they answer. The table and the readings above are
+> all still accurate about `hjeon-fdpo-foundry-eus2`; the conclusion drawn from
+> them was too narrow, and it is left in place unedited so the correction has
+> something to point at.
 GitHub-hosted runners remain ruled out for the host role on the grounds already
 recorded here: nested virtualisation is documented as unsupported, and a
 boundary offered with no guarantee is not a boundary. That finding is not loose
@@ -2032,6 +2040,74 @@ the arithmetic near 0.18 USD; the actual charge is **not verifiable from this
 box** — the local `az` tenant is not the one that bills these workflows — so the
 window is recorded as `partial` and **not** as zero. **Zero model calls were
 made in this window; the only spend is the host.**
+
+##### The block was not one
+
+Recorded 2026-09-11, correcting the section above. Evidence:
+`tasks/0822_saturday/model_reachability_survey.json`.
+
+The premise everything above rests on is that no single place reaches both the
+guest host and a `gpt-5.4` deployment. Nobody tested it. It was inferred from
+the one model account anybody had looked for — the one the stage-one plan pins —
+and that account really is unreachable from here. The inference from "the pinned
+account is out of reach" to "a model is out of reach" is the error.
+
+`az cognitiveservices account list`, free, from the existing login, returns
+**five** accounts in subscription `4b7c60a5…`, tenant `6d93cc9b…` — the same
+subscription and tenant as `gdpval-devhost-vm`. Three carry `gpt-5.4` at version
+`2026-03-05`: `wrpo-meas` (eastus2, cap 30), `aoai-router5-ext-faf57f` (eastus2,
+cap 10), `aoai-repolis-grounding-ext` (centralus, cap 30, deployment named
+`gpt-5.4-chair`).
+
+Four calls, all HTTP 200, with an AAD token for
+`https://cognitiveservices.azure.com` from the `az` login already on this box.
+No role assigned or requested, no key read, no credential issued:
+
+| # | what it tested | endpoint | result |
+|---|---|---|---|
+| 1 | a deployment answers | `wrpo-meas.cognitiveservices…` | `gpt-5.4-2026-03-05`, 13 in / 5 out |
+| 2 | not a one-account accident | `aoai-router5-ext-faf57f…` | `gpt-5.4-2026-03-05`, 13 in / 5 out |
+| 3 | tool choice, `strict` schema | `wrpo-meas.cognitiveservices…` | `finish_reason: tool_calls`, `workspace_apply` |
+| 4 | **the path the code takes** | `wrpo-meas.openai.azure.com/openai/v1/responses` | `completed`, `function_call workspace_apply` |
+
+Call 4 is the one that settles it. The first three prove a model is reachable;
+only the fourth proves `AzureFoundryVoice` is, because that class calls
+`client.responses.create` and `core/azure_ai_clients.py` pins the `direct-v1`
+route to `https://{account}.openai.azure.com/openai/v1/`. Same API, same
+hostname shape, same strict tool schema, and the model emitted
+`workspace_apply {"operation":"write","path":"note.txt","content":"HELLO"}`.
+
+319 input / 66 output tokens at `azure:gpt-5.4-2026-03-05` is **USD 0.0018**,
+`problem_solving`. Recorded because a figure nobody writes down is not a zero.
+
+**What follows, and what does not.** The orchestrator can be this box: it
+reaches a `gpt-5.4` deployment in its own tenant and the guest host in its own
+tenant. The model itself never needs to reach anything — which is *stronger*
+containment than the design that was blocked, not a relaxation of it. A guest
+that cannot call a model endpoint is a guest with one less way out. No grant is
+needed for the model leg.
+
+Four things this does **not** establish, each of which still has to be true
+before stage F runs:
+
+1. **It is a different account from the pinned one.** Same model, same version
+   `2026-03-05`, different content-filter policy and different quota. Step 5's
+   rule applies directly: a result produced here may be *stated* beside A's
+   Codex runs only with that difference named, and any gap between them may not
+   be attributed to the environment.
+2. **These accounts belong to other work.** The names say it — `wrpo`,
+   `router5`, `repolis`, `iq-demo`. Capacity is shared. Whether a 220-task run
+   may consume one is the owner's call, not a survey's.
+3. **The guest host is deallocated** since 23:29:55Z on 2026-09-10. That it
+   answers `run-command` is recorded, not currently true.
+4. **`exec_run` is still shut.** The tool the model chose above writes a file
+   and runs no command. Opening it is the separate reviewable change step 3
+   describes, and nothing here pre-empts it.
+
+The blocks named in the table remain real for what they were about: the OIDC
+identity still cannot reach the guest host, the VM's managed identity still holds
+zero role assignments, and creating a host in `d372e9cf…` is still refused. They
+are simply no longer on the path.
 
 ##### The guard, measured: it is eight places, not one
 
@@ -2141,6 +2217,13 @@ So the named change is a role assignment on this identity in the model's
 subscription, and per the standing instruction that access expansion is
 separate from cost approval, it is **named here and left undone**. It is not
 requested, and nothing in this repository moves toward it.
+
+> **Still true, no longer on the path** — 2026-09-11. Every reading above holds:
+> that identity does hold two assignments and none of them permits those three
+> writes. What changed is that stage D no longer needs a host in that
+> subscription, because the model does not have to be in that subscription
+> either. See "The block was not one" above. The request stays unmade, which was
+> always the right outcome; it is now also unnecessary.
 
 Two things it is not. It is not a claim that a host placed here would boot a
 guest — that is C2's question, answered on a different machine in a different

--- a/tasks/0822_saturday/model_reachability_survey.json
+++ b/tasks/0822_saturday/model_reachability_survey.json
@@ -1,0 +1,141 @@
+{
+  "survey": "can the machine that reaches the guest host also reach a gpt-5.4 deployment",
+  "why_it_was_run": [
+    "The block recorded in TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md rested on one",
+    "premise: that no single place can reach both the guest host and a model.",
+    "The guest host answers to this box's signed-in admin in tenant",
+    "6d93cc9b; the Foundry account hjeon-fdpo-foundry-eus2 answers to the",
+    "GitHub OIDC application in tenant 16b3c013. That premise was tested",
+    "rather than assumed, and it is false. It was never tested before because",
+    "the only model account anybody had looked for was the pinned one."
+  ],
+  "date": "2026-09-11",
+  "run_from": "the local box, not a workflow",
+  "identity": {
+    "user": "admin@MngEnvMCAP756842.onmicrosoft.com",
+    "tenant": "6d93cc9b-abb8-4dab-9406-892843d0de0b",
+    "subscription": "4b7c60a5-b0e5-468e-9a2d-f0dcb2cc60d1",
+    "note": "the same signed-in identity that drives az vm run-command against gdpval-devhost-vm",
+    "credential": "AAD access token for https://cognitiveservices.azure.com, from the existing az login",
+    "no_new_access": [
+      "no role was assigned or requested",
+      "no API key was listed, read or created",
+      "no cross-tenant login, no service principal, no credential issued",
+      "every resource below was already visible to this identity"
+    ]
+  },
+
+  "what_was_found": {
+    "cognitive_services_accounts_visible": 5,
+    "accounts_carrying_gpt_5_4": [
+      {
+        "account": "wrpo-meas",
+        "resource_group": "rg-wrpo-meas",
+        "region": "eastus2",
+        "deployment_name": "gpt-5.4",
+        "model_version": "2026-03-05",
+        "sku": "GlobalStandard",
+        "capacity": 30
+      },
+      {
+        "account": "aoai-router5-ext-faf57f",
+        "resource_group": "rg-foundry-router-5series",
+        "region": "eastus2",
+        "deployment_name": "gpt-5.4",
+        "model_version": "2026-03-05",
+        "sku": "GlobalStandard",
+        "capacity": 10
+      },
+      {
+        "account": "aoai-repolis-grounding-ext",
+        "resource_group": "rg-repolis-grounding-ext",
+        "region": "centralus",
+        "deployment_name": "gpt-5.4-chair",
+        "model_version": "2026-03-05",
+        "sku": "GlobalStandard",
+        "capacity": 30
+      }
+    ]
+  },
+
+  "calls_made": [
+    {
+      "purpose": "is a gpt-5.4 deployment reachable at all",
+      "endpoint": "https://wrpo-meas.cognitiveservices.azure.com/",
+      "api": "chat/completions, api-version 2025-04-01-preview",
+      "http": 200,
+      "answered_as": "gpt-5.4-2026-03-05",
+      "input_tokens": 13,
+      "output_tokens": 5
+    },
+    {
+      "purpose": "the same, on a second account, so one working account is not one accident",
+      "endpoint": "https://aoai-router5-ext-faf57f.cognitiveservices.azure.com/",
+      "api": "chat/completions, api-version 2025-04-01-preview",
+      "http": 200,
+      "answered_as": "gpt-5.4-2026-03-05",
+      "input_tokens": 13,
+      "output_tokens": 5
+    },
+    {
+      "purpose": "does it choose a tool, with the strict schema the contract declares",
+      "endpoint": "https://wrpo-meas.cognitiveservices.azure.com/",
+      "api": "chat/completions",
+      "http": 200,
+      "finish_reason": "tool_calls",
+      "returned": "workspace_apply {\"operation\":\"write\",\"path\":\"note.txt\",\"content\":\"HELLO\"}",
+      "input_tokens": 152,
+      "output_tokens": 28
+    },
+    {
+      "purpose": "the path the code actually takes -- Responses API on the direct-v1 hostname",
+      "endpoint": "https://wrpo-meas.openai.azure.com/openai/v1/responses",
+      "why_this_one_matters": [
+        "core.agentic_v2_model_voice.AzureFoundryVoice calls client.responses.create,",
+        "not chat/completions, and core.azure_ai_clients pins the direct-v1 route to",
+        "https://{account}.openai.azure.com/openai/v1/. The three calls above prove a",
+        "model is reachable; only this one proves the code path is."
+      ],
+      "http": 200,
+      "status": "completed",
+      "returned": "function_call workspace_apply {\"operation\":\"write\",\"path\":\"note.txt\",\"content\":\"HELLO\"}",
+      "input_tokens": 141,
+      "output_tokens": 28
+    }
+  ],
+
+  "cost": {
+    "calls": 4,
+    "input_tokens": 319,
+    "output_tokens": 66,
+    "priced_as": "azure:gpt-5.4-2026-03-05",
+    "usd": "0.0018",
+    "status": "known",
+    "bucket": "problem_solving",
+    "note": "small, and recorded anyway. A figure nobody wrote down is not a zero."
+  },
+
+  "what_this_does_not_show": [
+    "Nothing about hjeon-fdpo-foundry-eus2, which is still unreachable from here and is still the account the stage-one plan pins. A run against wrpo-meas is the same model at the same version, 2026-03-05, in a different account with its own content-filter policy and its own quota. That is a difference to state, not to wave away: a result from here may not be set beside a run made through the pinned account and called the same environment.",
+    "Nothing about whether these accounts are free to use. They belong to other work -- the names say repolis, iq-demo, wrpo, router5 -- and their capacity is shared. Whether a 220-task run may consume one is the owner's call, not this survey's.",
+    "Nothing about the guest host, which is deallocated. That it answered run-command before is recorded elsewhere and would have to be true again.",
+    "Nothing about exec_run, which is still shut. The tool the model chose above was workspace_apply, which writes a file and runs no command."
+  ],
+
+  "what_is_still_blocked": {
+    "unchanged": [
+      "The GitHub OIDC identity still cannot reach the guest host.",
+      "The VM's managed identity still holds zero role assignments, and cannot hold one in another tenant regardless.",
+      "Creating a host inside subscription d372e9cf is still refused."
+    ],
+    "no_longer_true": [
+      "That the paid leg needs either a cross-tenant service-principal grant or a",
+      "booting host inside the model's subscription. It needs neither. The",
+      "orchestrator can be this box, which reaches a gpt-5.4 deployment in its own",
+      "tenant and the guest host in its own tenant. The model never needs to reach",
+      "anything -- which is better containment than the design that was blocked,",
+      "not a relaxation of it: a guest that cannot call a model endpoint is a",
+      "guest with one less way out."
+    ]
+  }
+}


### PR DESCRIPTION
Joins the three V2 pieces that existed separately: the conversation loop
(`agentic_v2_conversation.py`), the run place (`agentic_v2_runner.py`), and the
manifest driver. This is the structural half of "model call → tool choice →
isolated `exec_run` → result files → next model call".

## What is here

| file | role |
|---|---|
| `core/agentic_v2_conversation_runner.py` | the seam: per-task budgets, a run-wide cap, conversation records kept beside the run, ledger entries |
| `core/agentic_v2_run_driver.py` | walks a fixed manifest, resumes, stops when it should |
| `core/agentic_v2_manifest_binding.py` | binds a stage cohort (5 / 30 / 220) to pinned prompts, refusing drift |
| `core/agentic_v2_runner.py` | takes the call source as a parameter; a failed tool now ends the run |

The join is **one parameter on the existing runner**, not a second runner — a
second one would have put containment decisions in two files. The model's calls
go through the runner's own dispatch, so each gets the cancel check, the
deadline, the state commitment and both chain appends a scripted call gets.

## A contract conflict, stated rather than papered over

The conversation loop is built to show a model its tool error and let it choose
again. `verify_agentic_v2_result` forbids any tool event after a failed tool
result. Joined naively, a model's bad arguments produced an unverifiable trace,
which `run()` caught and reported as `runner_internal_error` — which the ledger
buckets as a **runner defect**. A model mistake would have been filed as this
harness being broken, on however many of the 220 tasks it hit.

A failed tool call now ends the run inside the dispatch wrapper, carrying the
tool's own error. The invariant holds by construction and the ending is honest:
bad arguments land as `invalid_arguments`.

**The cost is real and is recorded in the code**: under this trace schema a
model gets **one tool mistake per task**, and the loop's recover-from-error
ability cannot be used. Lifting that means changing the trace schema — a
separate, reviewable change, not something to slip in here.

## Cost

An unpriced model settles as `partial` with `price_missing`, never as `$0`.
Pinned by a test, because a silent zero across 220 tasks is the shape of an
unnoticed bill.

## What this does not do

- no model client, no deployment named — the voice is a parameter and no caller
  passes a real one
- `foundation_only` and `production_activation` untouched; `exec_run` stays shut
- **does not forward `admitted_identity`**, though the runner accepts one, so
  `test_nothing_in_this_repository_declares_a_non_default_identity` keeps saying
  what it says today: the guest is mapped and not run
- zero model calls, zero new Azure spend

## Verification

`pytest -k agentic` — **1975 passed, 3 skipped**, 0 failed.

## What was blocking this, and is not

The last commit here is documentation, and it retracts a conclusion this
repository had been carrying: that the paid leg needed a cross-tenant
service-principal grant or a host inside the model's subscription. Neither is
true. Five Cognitive Services accounts are visible to this box's own login, in
the same subscription and tenant as `gdpval-devhost-vm`; three carry `gpt-5.4`
at version `2026-03-05`. Four probes returned HTTP 200 on an AAD token from the
existing `az` login — including one against the Responses API on the
`*.openai.azure.com` hostname, which is the exact path `AzureFoundryVoice`
takes, and which returned a `function_call` for `workspace_apply`.

No role was assigned or requested, no key read, no credential issued. 319 in /
66 out, **USD 0.0018**, recorded rather than rounded to zero. Endpoint-by-endpoint
record in `tasks/0822_saturday/model_reachability_survey.json`.

Four things that does **not** establish, each still open:

1. it is a **different account** from the one the stage-one plan pins — same
   model and version, different content filter and quota, so a result from it
   may not be set beside A's Codex runs and called the same environment
2. those accounts belong to other work and their capacity is shared
3. the guest host is deallocated
4. `exec_run` is still shut — the tool the model chose writes a file and runs
   no command

The role assignment named in the activation document stays unrequested. It was
never the right thing to ask for.
