### PR TITLE
feat(azure): read the throughput a deployment declares, without naming it

### DIFF
--- a/.github/workflows/azure-deployment-capacity.yml
+++ b/.github/workflows/azure-deployment-capacity.yml
@@ -1,0 +1,160 @@
+# Read what throughput the deployment is *declared* to have, without naming it.
+#
+# Why a separate workflow: run `34540053904` (exp034, thirty tasks) was
+# dispatched to narrow one question -- of request rate, a token reservation, the
+# deployment's throughput and the interval between calls, which one is refusing
+# our requests. Response evidence ruled out two. Ruling on the other two needs a
+# rate measured against a ceiling, and nothing in this repository had ever
+# recorded the ceiling. The ledger now records when each call happened, which
+# gives the numerator; this gives the denominator to divide it by.
+#
+# Every call this makes is an ARM control-plane READ. It creates nothing,
+# changes nothing, and calls no model endpoint, so running it cannot reproduce
+# the refusal it exists to explain and cannot spend anything.
+#
+# This is also the only place the question can be asked. The script reads
+# whatever subscription and identity the `az` session holds, and a login taken
+# on a development box or in an agent container is a different one of each: the
+# Foundry account this asks about is not in the subscription such a login
+# reaches. `az` then refuses the lookup, the run stops at
+# `control_plane_read_never_completed`, and the note beside it says nothing was
+# measured -- which is the truth, because the account was never looked up. That
+# outcome is kept strictly apart from "Azure answered and the deployment was not
+# there", because the two license opposite conclusions.
+#
+# The read may also simply be refused. The RBAC diagnostic beside this one
+# exists because this identity was already refused at the Foundry project, and a
+# reader role on the account is not implied by anything. A refusal is recorded as
+# "not readable with the permissions we have" and is not a reason to ask for more.
+name: Azure Deployment Capacity
+
+on:
+  workflow_dispatch:
+    inputs:
+      deployment:
+        description: The deployment name, as the experiment YAML records it
+        required: false
+        default: gpt-5.4
+        type: string
+      emit_json:
+        description: Emit the redacted report as JSON instead of prose
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: azure-deployment-capacity
+  cancel-in-progress: false
+
+jobs:
+  measure:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      PYTHONDONTWRITEBYTECODE: "1"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+
+      # The same pinned action, client id, tenant and subscription the paid runs
+      # authenticate with. A capacity read taken as some other identity would
+      # measure a ceiling nobody's calls are being counted against.
+      - name: Azure Login (OIDC)
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Verify Azure OIDC session identity
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_AI_EXPECTED_CLIENT_ID: ${{ vars.AZURE_AI_EXPECTED_CLIENT_ID }}
+          AZURE_AI_EXPECTED_TENANT_ID: ${{ vars.AZURE_AI_EXPECTED_TENANT_ID }}
+          AZURE_AI_EXPECTED_SUBSCRIPTION_ID: ${{ vars.AZURE_AI_EXPECTED_SUBSCRIPTION_ID }}
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          python3 scripts/azure_oidc_identity_preflight.py --verify-session
+
+      # No model credential is passed in. If one were, a future edit could turn
+      # this read-only job into one that spends, and nothing here would notice.
+      #
+      # The Foundry account name is a repository VARIABLE, and GitHub does not
+      # mask a variable the way it masks a secret: whatever a step lists under
+      # env: is reprinted verbatim in the step header, and the logs of a public
+      # repository are public. So this step does not ask for
+      # AZURE_AI_EXPECTED_DIRECT_ACCOUNT or AZURE_AI_EXPECTED_PROJECT_ACCOUNT.
+      # It does not need them: the account name lives inside the endpoint, which
+      # is a secret and therefore masked, and the route derives the account from
+      # it. The script pulls it back out for redaction.
+      #
+      # direct-v1 is the profile deliberately, not by omission. A deployment
+      # lives on a Cognitive Services account and never on a project, so this is
+      # the same account either profile ends up calling.
+      - name: Read the limits this deployment declares
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_AI_ROUTE_PROFILE: direct-v1
+          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.FOUNDRY_PROJECT_ENDPOINT }}
+          DEPLOYMENT: ${{ inputs.deployment }}
+          EMIT_JSON: ${{ inputs.emit_json }}
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          ARGS=()
+          if [ "${EMIT_JSON}" = "true" ]; then
+            ARGS+=(--json)
+          fi
+          # Deliberately not --require-limits: reporting that Azure states no
+          # limit this tool can read is a finding about the deployment, not a
+          # failure of the run. Turning it into a red X would push the next
+          # reader toward making the number up.
+          python3 scripts/azure_deployment_capacity.py \
+            --deployment "${DEPLOYMENT}" \
+            --output "${RUNNER_TEMP}/deployment_capacity.json" \
+            "${ARGS[@]}"
+
+      # Kept so a later reader can divide a measured token rate by the ceiling
+      # that was declared on the day it was measured. A deployment's limits can
+      # be changed, and a denominator with no date cannot be told apart from one
+      # that is still true.
+      - name: Keep the redacted record
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: deployment-capacity
+          path: ${{ runner.temp }}/deployment_capacity.json
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Confirm no model call was made
+        if: always()
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          # A grep, not a promise. If a future edit reaches for the inference
+          # path from this read, this step is what says so.
+          if grep -nE 'responses\.create|chat\.completions|AzureOpenAI|llm_client|code_interpreter' \
+              scripts/azure_deployment_capacity.py; then
+            echo "FATAL: the capacity read references a model call path"
+            exit 1
+          fi
+          echo "control-plane-reads-only=confirmed"

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ batch-runner/scripts/*
 !batch-runner/scripts/stage3_partial_inventory.py
 !batch-runner/scripts/check_grader_hash_freeze.py
 !batch-runner/scripts/azure_rbac_diagnostic.py
+!batch-runner/scripts/azure_deployment_capacity.py
 !batch-runner/scripts/analyze_repeat_variation.py
 !batch-runner/scripts/analyze_audio_repeat_variation.py
 !batch-runner/scripts/measure_audio_grading_accuracy.py

--- a/batch-runner/core/azure_control_plane.py
+++ b/batch-runner/core/azure_control_plane.py
@@ -1,0 +1,242 @@
+"""The control-plane reads, and the promise that a report never names a resource.
+
+Why this is its own module
+--------------------------
+These pieces were written once, for :mod:`scripts.azure_rbac_diagnostic`, to
+answer why the Code Interpreter arm was refused with http 403. A second question
+now needs the same machinery -- what throughput the deployment is declared to
+have -- and a security property is the worst possible thing to own two copies
+of. The second copy passes its own tests on the day it is written and then stops
+tracking the first one, so a fix made in the place someone was looking never
+reaches the place that was actually running.
+
+There is a layering reason as well. The capacity a deployment declares is the
+denominator a run divides its token counts into, so the run itself will want to
+record it, and a run cannot reasonably import from a diagnostic script.
+
+What is here and what is not
+----------------------------
+Only the parts that are about *reading Azure safely*: how an ``az`` read fails,
+how its output is parsed without ever being echoed, where a resource group comes
+from, and how a rendered report is stripped of identifiers and then checked for
+survivors. Everything about roles -- the least-privilege ladder, the scope
+shapes, the permission matching -- stays in the diagnostic, because it answers
+one question and this module answers none.
+
+Every call made from here is an ARM control-plane READ. Nothing here creates,
+updates or deletes, and nothing here calls a model endpoint, so importing it
+cannot spend money.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess  # nosec B404 - control-plane reads via the pinned az CLI
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+from core.azure_ai_clients import PROJECT_ENDPOINT_ENV
+
+# The provider path a Foundry account lives under. Both the project a role is
+# read at and the deployment a capacity is read from hang off an account of
+# this type.
+FOUNDRY_PROVIDER = "Microsoft.CognitiveServices"
+FOUNDRY_ACCOUNT_TYPE = f"{FOUNDRY_PROVIDER}/accounts"
+
+
+def resource_group_of(resource_id: str) -> str | None:
+    """Pull the resource group out of an ARM resource id, or say it is absent."""
+    if not isinstance(resource_id, str):
+        return None
+    match = re.search(r"/resourceGroups/([^/]+)", resource_id, re.IGNORECASE)
+    if match is None:
+        return None
+    return match.group(1)
+
+
+# -------------------------------------------------------------------------
+# Redaction
+# -------------------------------------------------------------------------
+
+SENSITIVE_ENV: tuple[tuple[str, str], ...] = (
+    ("AZURE_SUBSCRIPTION_ID", "<subscriptionId>"),
+    ("AZURE_TENANT_ID", "<tenantId>"),
+    ("AZURE_CLIENT_ID", "<principalId>"),
+    ("AZURE_AI_EXPECTED_SUBSCRIPTION_ID", "<subscriptionId>"),
+    ("AZURE_AI_EXPECTED_TENANT_ID", "<tenantId>"),
+    ("AZURE_AI_EXPECTED_CLIENT_ID", "<principalId>"),
+    ("AZURE_AI_EXPECTED_PROJECT_ACCOUNT", "<accountName>"),
+    ("AZURE_AI_EXPECTED_PROJECT_NAME", "<projectName>"),
+    ("AZURE_AI_EXPECTED_DIRECT_ACCOUNT", "<accountName>"),
+    (PROJECT_ENDPOINT_ENV, "<projectEndpoint>"),
+    ("AZURE_OPENAI_V1_ENDPOINT", "<directEndpoint>"),
+    ("AZURE_OPENAI_ENDPOINT", "<directEndpoint>"),
+)
+
+# Values this short are ordinary words. Redacting them would corrupt the report
+# without protecting anything, so they are excluded from the leak check and the
+# caller is told the value was too short to defend.
+MINIMUM_REDACTABLE_LENGTH = 6
+
+
+def collect_secrets(
+    env: Mapping[str, str], *, extra: Mapping[str, str] | None = None
+) -> dict[str, str]:
+    """Every value that must not survive into the report, and its placeholder."""
+    secrets: dict[str, str] = {}
+    for name, placeholder in SENSITIVE_ENV:
+        value = env.get(name, "")
+        if isinstance(value, str) and len(value.strip()) >= MINIMUM_REDACTABLE_LENGTH:
+            secrets[value.strip()] = placeholder
+    for value, placeholder in (extra or {}).items():
+        if isinstance(value, str) and len(value.strip()) >= MINIMUM_REDACTABLE_LENGTH:
+            secrets[value.strip()] = placeholder
+    return secrets
+
+
+def sensitive_values(
+    env: Mapping[str, str], *, extra: Mapping[str, str] | None = None
+) -> frozenset[str]:
+    """The same values with no length floor, lowercased, for detection only.
+
+    Substitution needs the floor, because replacing a three-letter resource
+    name everywhere would corrupt ordinary words. Detection does not: a field
+    this repository copies out of Azure verbatim can simply be withheld when it
+    contains one, which is safe at any length.
+    """
+    found: set[str] = set()
+    for name, _ in SENSITIVE_ENV:
+        value = env.get(name, "")
+        if isinstance(value, str) and value.strip():
+            found.add(value.strip().lower())
+    for value in extra or {}:
+        if isinstance(value, str) and value.strip():
+            found.add(value.strip().lower())
+    return frozenset(found)
+
+
+def redact(text: str, secrets: Mapping[str, str]) -> str:
+    """Replace every known secret value with its placeholder, longest first."""
+    result = text
+    for value in sorted(secrets, key=len, reverse=True):
+        if value:
+            result = re.sub(re.escape(value), secrets[value], result, flags=re.IGNORECASE)
+    return result
+
+
+def leaked_placeholders(text: str, secrets: Mapping[str, str]) -> tuple[str, ...]:
+    """Which secret values survived redaction. Empty is the only safe answer."""
+    lowered = text.lower()
+    return tuple(
+        sorted(
+            {
+                secrets[value]
+                for value in secrets
+                if value and value.lower() in lowered
+            }
+        )
+    )
+
+
+# -------------------------------------------------------------------------
+# The az control-plane reads
+# -------------------------------------------------------------------------
+
+
+class AzureReadFailure(RuntimeError):
+    """An az read failed. Carries a classification, never the provider text.
+
+    ``completed`` separates the two ways a read can fail, which are different
+    facts and support different conclusions:
+
+    * ``completed=True``  -- az ran the query, returned parseable output, and
+      the thing being looked for was not in it. Azure answered.
+    * ``completed=False`` -- az did not answer at all: it exited non-zero, or
+      returned something that would not parse. The question never reached the
+      resource, so nothing at all was learned about it.
+
+    Only the first supports an inference about what this identity can see. The
+    default is the second, so a new raise site has to opt in to the stronger
+    claim rather than inherit it.
+    """
+
+    def __init__(
+        self, what: str, *, exit_code: int | None, completed: bool = False
+    ) -> None:
+        self.what = what
+        self.exit_code = exit_code
+        self.completed = completed
+        detail = "no exit code" if exit_code is None else f"exit {exit_code}"
+        super().__init__(f"{what} could not be read ({detail})")
+
+
+AzRunner = Callable[[Sequence[str]], Any]
+
+
+def default_runner(arguments: Sequence[str]) -> Any:
+    """Run one ``az`` read and parse its JSON.
+
+    The subprocess output is parsed, never echoed. An az error message can name
+    the resource it failed on, which is precisely what must not reach a log.
+    """
+    completed = subprocess.run(  # nosec B603 B607 - fixed argv, no shell
+        ["az", *arguments, "--only-show-errors", "--output", "json"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=180,
+    )
+    if completed.returncode != 0:
+        raise AzureReadFailure(
+            " ".join(arguments[:2]), exit_code=completed.returncode
+        )
+    stdout = completed.stdout.strip()
+    if not stdout:
+        return []
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        raise AzureReadFailure(" ".join(arguments[:2]), exit_code=None) from None
+
+
+def as_mappings(payload: Any) -> list[Mapping[str, Any]]:
+    if not isinstance(payload, list):
+        return []
+    return [item for item in payload if isinstance(item, Mapping)]
+
+
+def resolve_resource_group(
+    runner: AzRunner, *, account: str, subscription_id: str
+) -> str:
+    """Ask Azure where the Foundry account lives.
+
+    No secret and no repository variable records the resource group, so it has
+    to come from Azure itself.
+
+    An answered query that does not contain the account is a finding in its own
+    right: the account is either absent from this subscription or withheld from
+    this principal, and the control plane returns both the same way. That is the
+    ``completed=True`` raise below. A query az never completed is not that
+    finding, and is raised without the flag by the runner.
+    """
+    payload = runner(
+        [
+            "resource",
+            "list",
+            "--name",
+            account,
+            "--resource-type",
+            FOUNDRY_ACCOUNT_TYPE,
+            "--subscription",
+            subscription_id,
+        ]
+    )
+    for resource in as_mappings(payload):
+        group = resource.get("resourceGroup")
+        if isinstance(group, str) and group.strip():
+            return group.strip()
+        derived = resource_group_of(str(resource.get("id", "")))
+        if derived:
+            return derived
+    raise AzureReadFailure("the Foundry account", exit_code=None, completed=True)

--- a/batch-runner/scripts/azure_deployment_capacity.py
+++ b/batch-runner/scripts/azure_deployment_capacity.py
@@ -1,0 +1,625 @@
+#!/usr/bin/env python3
+"""Record what throughput the deployment is *declared* to have, without naming it.
+
+Why this exists
+---------------
+Run ``34540053904`` (exp034, thirty tasks) was dispatched to narrow one
+question: of request rate, a token reservation, the deployment's throughput and
+the interval between calls, which one is refusing our requests. Response
+evidence ruled out two. It could not touch the other two, for two reasons, and
+this script is the second of them.
+
+The first was that the cost ledger recorded how many tokens each call used and
+never recorded when, so the tokens settled in the window before a refusal could
+not be counted. That is fixed: ``cost_calls`` now carries ``reserved_at`` and
+``concluded_at``, and a rolling window can be drawn.
+
+The second is that a count in that window means nothing on its own. Two hundred
+thousand tokens a minute is either comfortably inside the ceiling or over it,
+and nothing in this repository recorded which. A numerator without a denominator
+is not a measurement.
+
+So this reads the denominator: what Azure says the deployment's limits are.
+
+What it reads, and what it refuses to infer
+-------------------------------------------
+``properties.rateLimits`` is Azure stating a limit -- a count, a key and the
+number of seconds it renews over. Those are converted to per-minute figures,
+which is arithmetic on quantities the payload supplies.
+
+``sku.capacity`` is recorded exactly as returned and is deliberately NOT turned
+into tokens per minute. The conversion is real but it is a per-model convention
+that lives in documentation, not in the payload: the same integer means
+different throughput for different models, and multiplying it by a remembered
+constant would produce a number indistinguishable in the report from one Azure
+actually stated. A figure that looks measured and was guessed is worse than an
+absent one, because the absent one gets chased.
+
+If the deployment states no rate limits at all, the verdict says so and the
+per-minute fields stay null. This tool would rather report that the denominator
+is unavailable than supply one.
+
+A caveat that belongs in the report, not in a footnote
+------------------------------------------------------
+A shared-capacity sku -- anything Global or shared-standard -- can refuse a
+request while the deployment is under its own declared limit, because the
+capacity it draws on is not exclusively this deployment's. So a declared ceiling
+bounds the question rather than settling it: usage measured *at* the ceiling
+implicates the deployment's throughput, and usage measured well under it does
+not exonerate the deployment. The verdict carries the sku name so the next
+reader can tell which of those they are looking at.
+
+Where it has to be run
+----------------------
+Through its workflow, in CI. It reads whatever subscription and identity the
+``az`` session holds, and a login taken on a development box or in an agent
+container is a different one of each -- so the account is never looked up and
+the run stops at ``control_plane_read_never_completed``, which says nothing was
+measured. That is the honest outcome and it is kept strictly apart from "az
+answered and the deployment was not there", because the two license opposite
+conclusions.
+
+This read may also simply be refused. The RBAC diagnostic beside it exists
+because this identity was already refused at the Foundry project, and a reader
+role on the account is not implied by anything. A refusal is recorded as
+"not readable with the permissions we have" and is not a reason to ask for more.
+
+What it does and does not do
+----------------------------
+Every call it makes is an ARM control-plane READ. It never creates, updates or
+deletes anything, and it never calls a model endpoint, so running it cannot
+re-trigger the refusal it exists to explain and cannot spend money.
+
+What it prints
+--------------
+The deployment name, its model name and version, its sku name, and the limits
+Azure stated. Those are values this repository already commits to git in the
+experiment YAML. It never prints the subscription id, the resource group, the
+account name, the project name, the principal object id or the tenant id, and
+it refuses to print at all if a known secret value survives into the report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+REPOSITORY_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPOSITORY_ROOT not in sys.path:
+    sys.path.insert(0, REPOSITORY_ROOT)
+
+from core.azure_ai_clients import (  # noqa: E402
+    ROUTE_PROFILE_ENV,
+    AzureAIRouteSettings,
+    ClassifiedEndpoint,
+)
+from core.azure_control_plane import (  # noqa: E402
+    AzRunner,
+    AzureReadFailure,
+    as_mappings,
+    collect_secrets,
+    default_runner,
+    leaked_placeholders,
+    redact,
+    resolve_resource_group,
+)
+
+SECONDS_PER_MINUTE = 60
+
+# The rate-limit keys Azure uses. ``key`` is free-ish text -- deployments have
+# been seen with "request", "token" and per-feature variants -- so these are
+# matched as prefixes rather than equality, and anything unrecognised is kept in
+# the report under its own name rather than dropped. A limit nobody knows how to
+# read is still a limit, and dropping it would quietly shrink the evidence.
+TOKEN_LIMIT_PREFIX = "token"
+REQUEST_LIMIT_PREFIX = "request"
+
+# Sku names whose capacity is drawn from a pool this deployment does not own.
+# Matched case-insensitively as substrings, because Microsoft has shipped
+# "GlobalStandard", "GlobalBatch", "DataZoneStandard" and more, and the property
+# they share is the one that matters here.
+SHARED_CAPACITY_MARKERS: tuple[str, ...] = ("global", "datazone", "shared")
+
+VERDICT_CAPACITY_RECORDED = "capacity_recorded"
+VERDICT_LIMITS_NOT_STATED = "limits_not_stated"
+VERDICT_DEPLOYMENT_ABSENT = "deployment_absent_or_withheld"
+VERDICT_CANNOT_READ_ACCOUNT = "cannot_read_control_plane"
+VERDICT_NEVER_COMPLETED = "control_plane_read_never_completed"
+VERDICT_UNMEASURED = "unmeasured"
+
+
+def _utc_now() -> datetime:
+    """The wall clock, in UTC.
+
+    The same choice, for the same reason, as the ledger this figure is the
+    denominator for: a capacity read and the calls it will be divided into
+    happen in different processes, and only a wall clock orders those against
+    each other. It is stamped at all because a deployment's limits can be
+    changed between the read and the run, and a denominator with no date cannot
+    be told apart from one that is still true.
+    """
+    return datetime.now(timezone.utc)
+
+
+def _stamp(clock: Callable[[], datetime]) -> str:
+    moment = clock()
+    if not isinstance(moment, datetime):
+        raise ValueError("the clock returned something that is not a datetime")
+    if moment.tzinfo is None or moment.tzinfo.utcoffset(moment) is None:
+        raise ValueError(
+            "the clock returned a datetime with no timezone; a moment without "
+            "one cannot be compared against a moment from another process"
+        )
+    return moment.astimezone(timezone.utc).isoformat(timespec="seconds")
+
+
+# -------------------------------------------------------------------------
+# Reading the limits out of what Azure returned
+# -------------------------------------------------------------------------
+
+
+def per_minute(count: Any, renewal_period_seconds: Any) -> float | None:
+    """Scale a stated count over a stated period to one minute, or decline.
+
+    Declines rather than assumes whenever either half is missing or unusable.
+    A limit whose renewal period Azure did not state is not a per-minute limit
+    with an obvious period; it is a limit of unknown shape, and the only honest
+    rendering of it is the raw pair, which the caller keeps.
+    """
+    if isinstance(count, bool) or not isinstance(count, (int, float)):
+        return None
+    if isinstance(renewal_period_seconds, bool) or not isinstance(
+        renewal_period_seconds, (int, float)
+    ):
+        return None
+    if count < 0 or renewal_period_seconds <= 0:
+        return None
+    return float(count) * SECONDS_PER_MINUTE / float(renewal_period_seconds)
+
+
+def normalize_rate_limits(payload: Any) -> list[dict[str, Any]]:
+    """Every rate limit Azure stated, with a per-minute figure where possible."""
+    limits: list[dict[str, Any]] = []
+    for entry in as_mappings(payload if isinstance(payload, list) else []):
+        key = entry.get("key")
+        count = entry.get("count")
+        period = entry.get("renewalPeriod")
+        limits.append(
+            {
+                "key": str(key) if isinstance(key, str) and key.strip() else None,
+                "count": count if isinstance(count, (int, float)) else None,
+                "renewal_period_seconds": (
+                    period if isinstance(period, (int, float)) else None
+                ),
+                "per_minute": per_minute(count, period),
+            }
+        )
+    return limits
+
+
+def _first_per_minute(limits: Sequence[Mapping[str, Any]], prefix: str) -> float | None:
+    """The per-minute figure for the first limit whose key starts with ``prefix``."""
+    for limit in limits:
+        key = limit.get("key")
+        if not isinstance(key, str):
+            continue
+        if key.strip().lower().startswith(prefix) and limit.get("per_minute") is not None:
+            value = limit["per_minute"]
+            if isinstance(value, (int, float)):
+                return float(value)
+    return None
+
+
+def draws_on_shared_capacity(sku_name: Any) -> bool | None:
+    """Whether this sku's throughput is pooled. ``None`` when the sku is unnamed.
+
+    ``None`` rather than ``False``: not knowing which kind of sku this is, and
+    knowing it is a dedicated one, support different readings of a refusal.
+    """
+    if not isinstance(sku_name, str) or not sku_name.strip():
+        return None
+    lowered = sku_name.strip().lower()
+    return any(marker in lowered for marker in SHARED_CAPACITY_MARKERS)
+
+
+def read_deployments(
+    runner: AzRunner, *, account: str, resource_group: str, subscription_id: str
+) -> list[Mapping[str, Any]]:
+    """Every deployment on the account, as the control plane reports them."""
+    payload = runner(
+        [
+            "cognitiveservices",
+            "account",
+            "deployment",
+            "list",
+            "--name",
+            account,
+            "--resource-group",
+            resource_group,
+            "--subscription",
+            subscription_id,
+        ]
+    )
+    return as_mappings(payload)
+
+
+def select_deployment(
+    deployments: Sequence[Mapping[str, Any]], *, deployment: str
+) -> Mapping[str, Any]:
+    """The named deployment, or a completed failure saying it was not there.
+
+    Matched case-insensitively. Azure preserves the case a deployment was
+    created with and the experiment YAML records the case somebody typed; a
+    mismatch between the two is a spelling difference, not a missing resource,
+    and reporting it as a missing resource would send the next reader looking
+    for a deployment that exists.
+    """
+    wanted = deployment.strip().lower()
+    for entry in deployments:
+        name = entry.get("name")
+        if isinstance(name, str) and name.strip().lower() == wanted:
+            return entry
+    raise AzureReadFailure(
+        "the named deployment", exit_code=None, completed=True
+    )
+
+
+# -------------------------------------------------------------------------
+# The report
+# -------------------------------------------------------------------------
+
+
+def _account_for_capacity(
+    settings: AzureAIRouteSettings,
+) -> tuple[ClassifiedEndpoint, str]:
+    """Which endpoint's account holds the deployment, and which one it was.
+
+    A deployment lives on a Cognitive Services account, never on a project, so
+    the project endpoint is not a candidate even under the project-ci profile --
+    under that profile the route already derives the account endpoint, and this
+    takes the same one the run would call.
+    """
+    if settings.direct_v1 is not None:
+        return settings.direct_v1, settings.direct_v1.kind.value
+    if settings.legacy is not None:
+        return settings.legacy, settings.legacy.kind.value
+    raise ValueError(
+        "the route resolved no account endpoint, so there is no account to read "
+        "a deployment's capacity from"
+    )
+
+
+def measure(
+    env: Mapping[str, str],
+    *,
+    deployment: str,
+    runner: AzRunner,
+    clock: Callable[[], datetime] = _utc_now,
+) -> dict[str, Any]:
+    """Read the deployment's declared limits and say how far the read got."""
+    if not isinstance(deployment, str) or not deployment.strip():
+        raise ValueError("a deployment name is required")
+
+    # from_env is what the run itself uses, so this reads the account the run
+    # actually calls rather than a rule retyped here that agrees until one of
+    # the two is edited.
+    settings = AzureAIRouteSettings.from_env(env)
+    endpoint, account_source = _account_for_capacity(settings)
+
+    subscription_id = env.get("AZURE_SUBSCRIPTION_ID", "").strip()
+    if not subscription_id:
+        raise ValueError("AZURE_SUBSCRIPTION_ID is required")
+
+    problems: list[str] = []
+    report: dict[str, Any] = {
+        "measured_at": _stamp(clock),
+        "route_profile": settings.profile.value,
+        "account_source": account_source,
+        "deployment": deployment.strip(),
+        "model_name": None,
+        "model_version": None,
+        "sku_name": None,
+        "sku_capacity": None,
+        # Recorded so no reader has to wonder whether the null below is an
+        # oversight. The unit is not in the payload, so it is not in the report.
+        "sku_capacity_unit_stated_by_azure": False,
+        "draws_on_shared_capacity": None,
+        "tokens_per_minute": None,
+        "requests_per_minute": None,
+        "rate_limits": [],
+        "deployments_seen": None,
+        "read_failures": problems,
+        "verdict": VERDICT_UNMEASURED,
+        # The account name lives inside the endpoint secret rather than in a
+        # variable of its own, so redacting the endpoint string would not catch
+        # it on its own.
+        "secret_values": {endpoint.account: "<accountName>"},
+    }
+
+    try:
+        resource_group = resolve_resource_group(
+            runner, account=endpoint.account, subscription_id=subscription_id
+        )
+    except AzureReadFailure as failure:
+        if failure.completed:
+            problems.append(
+                "Azure answered and the account was not in the answer, so this "
+                "identity cannot see it and no deployment could be read "
+                f"({failure.what})"
+            )
+            report["verdict"] = VERDICT_CANNOT_READ_ACCOUNT
+        else:
+            problems.append(
+                "az did not answer the account lookup, which is how a "
+                "subscription this session is not signed into fails, so the "
+                f"account was never looked up and nothing was measured "
+                f"({failure.what})"
+            )
+            report["verdict"] = VERDICT_NEVER_COMPLETED
+        return report
+
+    # Read from Azure rather than from the environment, so collect_secrets could
+    # not have known it.
+    report["secret_values"][resource_group] = "<resourceGroup>"
+
+    try:
+        deployments = read_deployments(
+            runner,
+            account=endpoint.account,
+            resource_group=resource_group,
+            subscription_id=subscription_id,
+        )
+    except AzureReadFailure as failure:
+        problems.append(
+            "az did not answer the deployment list, so this account's "
+            "deployments were never enumerated and nothing was measured "
+            f"({failure.what})"
+        )
+        report["verdict"] = VERDICT_NEVER_COMPLETED
+        return report
+
+    # A count, never the names. How many deployments an account holds is not an
+    # identifier; what they are called is chosen by the owner and can be.
+    report["deployments_seen"] = len(deployments)
+
+    try:
+        entry = select_deployment(deployments, deployment=deployment)
+    except AzureReadFailure as failure:
+        problems.append(
+            "Azure answered with this account's deployments and the named one "
+            "was not among them, so it is either absent or withheld from this "
+            f"identity ({failure.what})"
+        )
+        report["verdict"] = VERDICT_DEPLOYMENT_ABSENT
+        return report
+
+    properties = entry.get("properties")
+    properties = properties if isinstance(properties, Mapping) else {}
+    model = properties.get("model")
+    model = model if isinstance(model, Mapping) else {}
+    sku = entry.get("sku")
+    sku = sku if isinstance(sku, Mapping) else {}
+
+    name = model.get("name")
+    version = model.get("version")
+    report["model_name"] = name if isinstance(name, str) and name.strip() else None
+    report["model_version"] = (
+        version if isinstance(version, str) and version.strip() else None
+    )
+
+    sku_name = sku.get("name")
+    sku_capacity = sku.get("capacity")
+    report["sku_name"] = (
+        sku_name if isinstance(sku_name, str) and sku_name.strip() else None
+    )
+    report["sku_capacity"] = (
+        sku_capacity
+        if isinstance(sku_capacity, (int, float)) and not isinstance(sku_capacity, bool)
+        else None
+    )
+    report["draws_on_shared_capacity"] = draws_on_shared_capacity(sku_name)
+
+    limits = normalize_rate_limits(properties.get("rateLimits"))
+    report["rate_limits"] = limits
+    report["tokens_per_minute"] = _first_per_minute(limits, TOKEN_LIMIT_PREFIX)
+    report["requests_per_minute"] = _first_per_minute(limits, REQUEST_LIMIT_PREFIX)
+
+    if report["tokens_per_minute"] is None and report["requests_per_minute"] is None:
+        problems.append(
+            "the deployment was found and states no rate limit this tool can "
+            "read, so the denominator is unavailable. sku.capacity is recorded "
+            "above and is deliberately not converted: the payload does not say "
+            "what one unit of it buys"
+        )
+        report["verdict"] = VERDICT_LIMITS_NOT_STATED
+        return report
+
+    report["verdict"] = VERDICT_CAPACITY_RECORDED
+    return report
+
+
+def render(report: Mapping[str, Any]) -> str:
+    """The report as prose, with every figure labelled by where it came from."""
+    lines: list[str] = []
+    lines.append("azure deployment capacity")
+    lines.append(f"  read at:        {report.get('measured_at')}")
+    lines.append(f"  route profile:  {report.get('route_profile')}")
+    lines.append(f"  account from:   {report.get('account_source')} endpoint")
+    lines.append(f"  deployment:     {report.get('deployment')}")
+    lines.append(f"  verdict:        {report.get('verdict')}")
+
+    model_name = report.get("model_name")
+    if model_name:
+        lines.append("")
+        lines.append(f"  model:          {model_name} {report.get('model_version') or ''}".rstrip())
+
+    sku_name = report.get("sku_name")
+    if sku_name or report.get("sku_capacity") is not None:
+        lines.append(f"  sku:            {sku_name or 'unnamed'}")
+        lines.append(
+            f"  sku.capacity:   {report.get('sku_capacity')} "
+            "(raw; Azure does not state the unit, so it is not converted)"
+        )
+    shared = report.get("draws_on_shared_capacity")
+    if shared is True:
+        lines.append(
+            "  NOTE: this sku draws on pooled capacity, so it can refuse a "
+            "request while under its own declared limit. A declared ceiling "
+            "bounds the question and does not settle it."
+        )
+    elif shared is None and sku_name:
+        lines.append(
+            "  NOTE: the sku was not named, so whether its capacity is pooled "
+            "is unknown."
+        )
+
+    limits = list(report.get("rate_limits") or ())
+    if limits:
+        lines.append("")
+        lines.append("limits Azure stated:")
+        for limit in limits:
+            rate = limit.get("per_minute")
+            shown = "not convertible" if rate is None else f"{rate:g} per minute"
+            lines.append(
+                f"  - {limit.get('key') or 'unnamed'}: {limit.get('count')} "
+                f"per {limit.get('renewal_period_seconds')}s  ->  {shown}"
+            )
+
+    lines.append("")
+    lines.append("the denominator this run recorded:")
+    tokens = report.get("tokens_per_minute")
+    requests = report.get("requests_per_minute")
+    lines.append(
+        f"  tokens/minute:   {'unavailable' if tokens is None else f'{tokens:g}'}"
+    )
+    lines.append(
+        f"  requests/minute: {'unavailable' if requests is None else f'{requests:g}'}"
+    )
+
+    seen = report.get("deployments_seen")
+    if seen is not None:
+        lines.append("")
+        lines.append(f"deployments on the account: {seen} (names withheld)")
+
+    failures = list(report.get("read_failures") or ())
+    if failures:
+        lines.append("")
+        lines.append("reads that did not succeed:")
+        lines.extend(f"  - {entry}" for entry in failures)
+
+    lines.append("")
+    lines.append(
+        "This read was control-plane only. It called no model endpoint, so it "
+        "neither reproduces a refusal nor spends anything."
+    )
+    return "\n".join(lines)
+
+
+# -------------------------------------------------------------------------
+# CLI
+# -------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Read a deployment's declared limits")
+    parser.add_argument(
+        "--deployment",
+        required=True,
+        help="The deployment name, as the experiment YAML records it",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the redacted report as JSON instead of prose",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help=(
+            "Write the redacted JSON report here as well, so a run can keep it "
+            "beside the ledger the figure is the denominator for"
+        ),
+    )
+    parser.add_argument(
+        "--require-limits",
+        action="store_true",
+        help=(
+            "Exit non-zero unless Azure stated a limit. Off by default so that "
+            "reporting an unavailable denominator is not an error"
+        ),
+    )
+    return parser
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+    runner: AzRunner | None = None,
+    clock: Callable[[], datetime] | None = None,
+    stream: Any = None,
+) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    values = os.environ if env is None else env
+    out = sys.stdout if stream is None else stream
+
+    try:
+        report = measure(
+            values,
+            deployment=args.deployment,
+            runner=runner or default_runner,
+            clock=clock or _utc_now,
+        )
+    except ValueError as exc:
+        # Safe to print: these messages name environment variables and settings,
+        # never their values.
+        print(f"deployment capacity read refused to run: {exc}", file=sys.stderr)
+        return 2
+    except Exception:
+        print("deployment capacity read failed", file=sys.stderr)
+        return 2
+
+    extra = dict(report.pop("secret_values", {}) or {})
+    secrets = collect_secrets(values, extra=extra)
+    serialized = json.dumps(report, indent=2, sort_keys=True)
+    body = serialized if args.json else render(report)
+    body = redact(body, secrets)
+
+    survivors = leaked_placeholders(body, secrets)
+    if survivors:
+        # Fail closed. A report that still carries an identifier is worse than
+        # no report, because the log is public and cannot be unpublished.
+        print(
+            "deployment capacity read withheld its report: redaction did not "
+            f"clear {len(survivors)} identifier(s)",
+            file=sys.stderr,
+        )
+        return 3
+
+    if args.output:
+        payload = redact(serialized, secrets)
+        if leaked_placeholders(payload, secrets):
+            print(
+                "deployment capacity read withheld its file: redaction did not "
+                "clear every identifier",
+                file=sys.stderr,
+            )
+            return 3
+        with open(args.output, "w", encoding="utf-8") as handle:
+            handle.write(payload + "\n")
+
+    print(body, file=out)
+
+    if args.require_limits and report["verdict"] != VERDICT_CAPACITY_RECORDED:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/batch-runner/scripts/azure_deployment_capacity.py
+++ b/batch-runner/scripts/azure_deployment_capacity.py
@@ -84,6 +84,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
@@ -124,6 +125,10 @@ REQUEST_LIMIT_PREFIX = "request"
 # "GlobalStandard", "GlobalBatch", "DataZoneStandard" and more, and the property
 # they share is the one that matters here.
 SHARED_CAPACITY_MARKERS: tuple[str, ...] = ("global", "datazone", "shared")
+
+# What a property name has to look like before it is repeated back. Azure's own
+# schema names all pass; anything else is withheld rather than printed.
+SCHEMA_KEY_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
 
 VERDICT_CAPACITY_RECORDED = "capacity_recorded"
 VERDICT_LIMITS_NOT_STATED = "limits_not_stated"
@@ -225,6 +230,29 @@ def draws_on_shared_capacity(sku_name: Any) -> bool | None:
         return None
     lowered = sku_name.strip().lower()
     return any(marker in lowered for marker in SHARED_CAPACITY_MARKERS)
+
+
+def schema_keys(payload: Any) -> list[str]:
+    """The property names Azure returned, so an empty answer is diagnosable.
+
+    "This deployment declares no limits" and "the limits are under a name this
+    tool does not look for" produce the same empty report, and telling them
+    apart afterwards would otherwise mean reading the payload -- which means
+    another run, in CI, because that is the only place the account is visible.
+    Recording the names it did carry settles it from the first run.
+
+    Names only, sorted, and only ones shaped like schema identifiers. These are
+    Azure's own property names rather than anything anybody chose, but the
+    filter is cheap and this report's whole promise is that nothing chosen by a
+    person survives into it.
+    """
+    if not isinstance(payload, Mapping):
+        return []
+    return sorted(
+        key
+        for key in payload
+        if isinstance(key, str) and SCHEMA_KEY_PATTERN.match(key)
+    )
 
 
 def read_deployments(
@@ -332,6 +360,7 @@ def measure(
         "tokens_per_minute": None,
         "requests_per_minute": None,
         "rate_limits": [],
+        "properties_seen": [],
         "deployments_seen": None,
         "read_failures": problems,
         "verdict": VERDICT_UNMEASURED,
@@ -404,6 +433,7 @@ def measure(
     model = model if isinstance(model, Mapping) else {}
     sku = entry.get("sku")
     sku = sku if isinstance(sku, Mapping) else {}
+    report["properties_seen"] = schema_keys(properties)
 
     name = model.get("name")
     version = model.get("version")
@@ -489,6 +519,20 @@ def render(report: Mapping[str, Any]) -> str:
                 f"  - {limit.get('key') or 'unnamed'}: {limit.get('count')} "
                 f"per {limit.get('renewal_period_seconds')}s  ->  {shown}"
             )
+
+    # Only when there is nothing to show instead. A reader who got their
+    # denominator does not need the schema; a reader who did not has one
+    # question, and this is the answer to it.
+    properties_seen = list(report.get("properties_seen") or ())
+    if properties_seen and not limits:
+        lines.append("")
+        lines.append("no limits were stated. the deployment's properties carried:")
+        lines.append(f"  {', '.join(properties_seen)}")
+        lines.append(
+            "  (listed because a deployment that declares no limits and a "
+            "payload that declares them under a name this tool does not look "
+            "for read identically)"
+        )
 
     lines.append("")
     lines.append("the denominator this run recorded:")

--- a/batch-runner/scripts/azure_rbac_diagnostic.py
+++ b/batch-runner/scripts/azure_rbac_diagnostic.py
@@ -120,6 +120,18 @@ __all__ = [
     "sensitive_values",
 ]
 
+# Private by name, public by use.
+#
+# `scripts/azure_boot_host_survey.py` loads this file by path and binds these
+# two off the loaded module. They were local functions with leading underscores
+# when it was written, so the underscore recorded nothing about who depends on
+# them -- and moving the implementations into core.azure_control_plane renamed
+# them out from under a caller whose own file did not change. Keeping the names
+# costs one line each. Dropping them cost twenty-two tests in a file this change
+# never touched.
+_as_mappings = as_mappings
+_default_runner = default_runner
+
 
 @dataclass(frozen=True)
 class RoleCandidate:

--- a/batch-runner/scripts/azure_rbac_diagnostic.py
+++ b/batch-runner/scripts/azure_rbac_diagnostic.py
@@ -61,9 +61,8 @@ import argparse
 import json
 import os
 import re
-import subprocess  # nosec B404 - control-plane reads via the pinned az CLI
 import sys
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from typing import Any
 
@@ -77,12 +76,49 @@ from core.azure_ai_clients import (  # noqa: E402
     classify_endpoint,
 )
 
+# How to read Azure without naming it. These live in core/ because a second
+# reader -- the deployment capacity this run divides its token counts into --
+# needs the same failure classification and the same redaction, and a security
+# property with two copies is a security property with one stale copy.
+from core.azure_control_plane import (  # noqa: E402
+    FOUNDRY_ACCOUNT_TYPE,
+    FOUNDRY_PROVIDER,
+    MINIMUM_REDACTABLE_LENGTH,
+    SENSITIVE_ENV,
+    AzRunner,
+    AzureReadFailure,
+    as_mappings,
+    collect_secrets,
+    default_runner,
+    leaked_placeholders,
+    redact,
+    resolve_resource_group,
+    resource_group_of,
+    sensitive_values,
+)
+
 # The action that decides whether the principal can fix this itself.
 ROLE_ASSIGNMENT_WRITE = "Microsoft.Authorization/roleAssignments/write"
 
-# The provider path a Foundry project lives under.
-FOUNDRY_PROVIDER = "Microsoft.CognitiveServices"
-FOUNDRY_ACCOUNT_TYPE = f"{FOUNDRY_PROVIDER}/accounts"
+__all__ = [
+    "FOUNDRY_ACCOUNT_TYPE",
+    "FOUNDRY_PROVIDER",
+    "MINIMUM_REDACTABLE_LENGTH",
+    "SENSITIVE_ENV",
+    "AzRunner",
+    "AzureReadFailure",
+    "as_mappings",
+    "collect_secrets",
+    "default_runner",
+    "diagnose",
+    "leaked_placeholders",
+    "main",
+    "redact",
+    "render",
+    "resolve_resource_group",
+    "resource_group_of",
+    "sensitive_values",
+]
 
 
 @dataclass(frozen=True)
@@ -215,16 +251,6 @@ def project_scope(
         f"/providers/{FOUNDRY_ACCOUNT_TYPE}/{account.strip()}"
         f"/projects/{project.strip()}"
     )
-
-
-def resource_group_of(resource_id: str) -> str | None:
-    """Pull the resource group out of an ARM resource id, or say it is absent."""
-    if not isinstance(resource_id, str):
-        return None
-    match = re.search(r"/resourceGroups/([^/]+)", resource_id, re.IGNORECASE)
-    if match is None:
-        return None
-    return match.group(1)
 
 
 # -------------------------------------------------------------------------
@@ -373,63 +399,12 @@ def forbidden_roles_held(held: Sequence[HeldRole]) -> tuple[str, ...]:
 # -------------------------------------------------------------------------
 # Redaction
 # -------------------------------------------------------------------------
-
-SENSITIVE_ENV: tuple[tuple[str, str], ...] = (
-    ("AZURE_SUBSCRIPTION_ID", "<subscriptionId>"),
-    ("AZURE_TENANT_ID", "<tenantId>"),
-    ("AZURE_CLIENT_ID", "<principalId>"),
-    ("AZURE_AI_EXPECTED_SUBSCRIPTION_ID", "<subscriptionId>"),
-    ("AZURE_AI_EXPECTED_TENANT_ID", "<tenantId>"),
-    ("AZURE_AI_EXPECTED_CLIENT_ID", "<principalId>"),
-    ("AZURE_AI_EXPECTED_PROJECT_ACCOUNT", "<accountName>"),
-    ("AZURE_AI_EXPECTED_PROJECT_NAME", "<projectName>"),
-    ("AZURE_AI_EXPECTED_DIRECT_ACCOUNT", "<accountName>"),
-    (PROJECT_ENDPOINT_ENV, "<projectEndpoint>"),
-    ("AZURE_OPENAI_V1_ENDPOINT", "<directEndpoint>"),
-    ("AZURE_OPENAI_ENDPOINT", "<directEndpoint>"),
-)
-
-# Values this short are ordinary words. Redacting them would corrupt the report
-# without protecting anything, so they are excluded from the leak check and the
-# caller is told the value was too short to defend.
-MINIMUM_REDACTABLE_LENGTH = 6
-
-
-def collect_secrets(
-    env: Mapping[str, str], *, extra: Mapping[str, str] | None = None
-) -> dict[str, str]:
-    """Every value that must not survive into the report, and its placeholder."""
-    secrets: dict[str, str] = {}
-    for name, placeholder in SENSITIVE_ENV:
-        value = env.get(name, "")
-        if isinstance(value, str) and len(value.strip()) >= MINIMUM_REDACTABLE_LENGTH:
-            secrets[value.strip()] = placeholder
-    for value, placeholder in (extra or {}).items():
-        if isinstance(value, str) and len(value.strip()) >= MINIMUM_REDACTABLE_LENGTH:
-            secrets[value.strip()] = placeholder
-    return secrets
-
-
-def sensitive_values(
-    env: Mapping[str, str], *, extra: Mapping[str, str] | None = None
-) -> frozenset[str]:
-    """The same values with no length floor, lowercased, for detection only.
-
-    Substitution needs the floor, because replacing a three-letter resource
-    name everywhere would corrupt ordinary words. Detection does not: a field
-    this repository copies out of Azure verbatim can simply be withheld when it
-    contains one, which is safe at any length.
-    """
-    found: set[str] = set()
-    for name, _ in SENSITIVE_ENV:
-        value = env.get(name, "")
-        if isinstance(value, str) and value.strip():
-            found.add(value.strip().lower())
-    for value in extra or {}:
-        if isinstance(value, str) and value.strip():
-            found.add(value.strip().lower())
-    return frozenset(found)
-
+#
+# The values to strip, how to strip them and how to check that the stripping
+# worked all live in ``core.azure_control_plane`` and are imported above. What
+# stays here is the one piece of redaction that is about roles rather than about
+# Azure: a role display name is free text somebody typed, and people do name
+# custom roles after the resource they apply to.
 
 # A role display name is the one field Azure hands back as free text a human
 # wrote. Built-in names are tame; a custom role can be called anything, and
@@ -451,130 +426,13 @@ def safe_role_name(name: str, values: frozenset[str]) -> str:
     return candidate
 
 
-def redact(text: str, secrets: Mapping[str, str]) -> str:
-    """Replace every known secret value with its placeholder, longest first."""
-    result = text
-    for value in sorted(secrets, key=len, reverse=True):
-        if value:
-            result = re.sub(re.escape(value), secrets[value], result, flags=re.IGNORECASE)
-    return result
-
-
-def leaked_placeholders(text: str, secrets: Mapping[str, str]) -> tuple[str, ...]:
-    """Which secret values survived redaction. Empty is the only safe answer."""
-    lowered = text.lower()
-    return tuple(
-        sorted(
-            {
-                secrets[value]
-                for value in secrets
-                if value and value.lower() in lowered
-            }
-        )
-    )
-
-
 # -------------------------------------------------------------------------
-# The az control-plane reads
+# The az reads this diagnostic makes
 # -------------------------------------------------------------------------
-
-
-class AzureReadFailure(RuntimeError):
-    """An az read failed. Carries a classification, never the provider text.
-
-    ``completed`` separates the two ways a read can fail, which are different
-    facts and support different conclusions:
-
-    * ``completed=True``  -- az ran the query, returned parseable output, and
-      the thing being looked for was not in it. Azure answered.
-    * ``completed=False`` -- az did not answer at all: it exited non-zero, or
-      returned something that would not parse. The question never reached the
-      resource, so nothing at all was learned about it.
-
-    Only the first supports an inference about what this identity can see. The
-    default is the second, so a new raise site has to opt in to the stronger
-    claim rather than inherit it.
-    """
-
-    def __init__(
-        self, what: str, *, exit_code: int | None, completed: bool = False
-    ) -> None:
-        self.what = what
-        self.exit_code = exit_code
-        self.completed = completed
-        detail = "no exit code" if exit_code is None else f"exit {exit_code}"
-        super().__init__(f"{what} could not be read ({detail})")
-
-
-AzRunner = Callable[[Sequence[str]], Any]
-
-
-def _default_runner(arguments: Sequence[str]) -> Any:
-    """Run one ``az`` read and parse its JSON.
-
-    The subprocess output is parsed, never echoed. An az error message can name
-    the resource it failed on, which is precisely what must not reach a log.
-    """
-    completed = subprocess.run(  # nosec B603 B607 - fixed argv, no shell
-        ["az", *arguments, "--only-show-errors", "--output", "json"],
-        capture_output=True,
-        text=True,
-        check=False,
-        timeout=180,
-    )
-    if completed.returncode != 0:
-        raise AzureReadFailure(
-            " ".join(arguments[:2]), exit_code=completed.returncode
-        )
-    stdout = completed.stdout.strip()
-    if not stdout:
-        return []
-    try:
-        return json.loads(stdout)
-    except json.JSONDecodeError:
-        raise AzureReadFailure(" ".join(arguments[:2]), exit_code=None) from None
-
-
-def _as_mappings(payload: Any) -> list[Mapping[str, Any]]:
-    if not isinstance(payload, list):
-        return []
-    return [item for item in payload if isinstance(item, Mapping)]
-
-
-def resolve_resource_group(
-    runner: AzRunner, *, account: str, subscription_id: str
-) -> str:
-    """Ask Azure where the Foundry account lives.
-
-    No secret and no repository variable records the resource group, so it has
-    to come from Azure itself.
-
-    An answered query that does not contain the account is a finding in its own
-    right: the account is either absent from this subscription or withheld from
-    this principal, and the control plane returns both the same way. That is the
-    ``completed=True`` raise below. A query az never completed is not that
-    finding, and is raised without the flag by the runner.
-    """
-    payload = runner(
-        [
-            "resource",
-            "list",
-            "--name",
-            account,
-            "--resource-type",
-            FOUNDRY_ACCOUNT_TYPE,
-            "--subscription",
-            subscription_id,
-        ]
-    )
-    for resource in _as_mappings(payload):
-        group = resource.get("resourceGroup")
-        if isinstance(group, str) and group.strip():
-            return group.strip()
-        derived = resource_group_of(str(resource.get("id", "")))
-        if derived:
-            return derived
-    raise AzureReadFailure("the Foundry account", exit_code=None, completed=True)
+#
+# ``AzureReadFailure``, the runner and ``resolve_resource_group`` are imported
+# from ``core.azure_control_plane``. The two reads below are the ones that only
+# a role diagnostic makes.
 
 
 def read_assignments(
@@ -594,7 +452,7 @@ def read_assignments(
             "--include-groups",
         ]
     )
-    return _as_mappings(payload)
+    return as_mappings(payload)
 
 
 def read_definitions(
@@ -606,7 +464,7 @@ def read_definitions(
         payload = runner(
             ["role", "definition", "list", "--name", name, "--scope", scope]
         )
-        definitions.extend(_as_mappings(payload))
+        definitions.extend(as_mappings(payload))
     return definitions
 
 
@@ -937,7 +795,7 @@ def main(
     out = sys.stdout if stream is None else stream
 
     try:
-        report = diagnose(values, runner=runner or _default_runner)
+        report = diagnose(values, runner=runner or default_runner)
     except ValueError as exc:
         # Safe to print: these messages name environment variables, not values.
         print(f"azure rbac diagnostic refused to run: {exc}", file=sys.stderr)

--- a/batch-runner/tests/test_the_deployment_says_how_much_throughput_it_has.py
+++ b/batch-runner/tests/test_the_deployment_says_how_much_throughput_it_has.py
@@ -1,0 +1,652 @@
+"""What the capacity read may claim, and what it must refuse to.
+
+Two separate promises are pinned here, and the second matters more than the
+first.
+
+The first is that a number in this report came from Azure. The read exists
+because exp034's refusals could not be attributed without a denominator, and a
+denominator that was inferred rather than read would answer the question with
+the assumption it was run to test. The sharpest of these tests is the one that
+supplies a ``sku.capacity`` and no rate limits, and insists the tokens-per-minute
+figure stays empty: the conversion is real, it is documented, and it is still not
+in the payload, so it is not this tool's to make.
+
+The second is that no identifier survives into the report. This runs against a
+public repository, so a log naming the account or the resource group cannot be
+unpublished. The tests check that from both directions -- that a real identifier
+never survives, and that the guard enforcing it does not fire on a report which
+never carried one.
+"""
+
+import importlib.util
+import io
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+
+BATCH_RUNNER = Path(__file__).resolve().parents[1]
+REPOSITORY_ROOT = BATCH_RUNNER.parent
+SCRIPT = BATCH_RUNNER / "scripts" / "azure_deployment_capacity.py"
+WORKFLOW = REPOSITORY_ROOT / ".github" / "workflows" / "azure-deployment-capacity.yml"
+
+SPEC = importlib.util.spec_from_file_location("azure_deployment_capacity", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+capacity = importlib.util.module_from_spec(SPEC)
+sys.modules["azure_deployment_capacity"] = capacity
+SPEC.loader.exec_module(capacity)
+
+from core.azure_control_plane import AzureReadFailure  # noqa: E402
+
+# Values shaped like the real ones and belonging to nobody.
+ACCOUNT = "contoso-foundry-eastus"
+RESOURCE_GROUP = "rg-benchmark-inference"
+SUBSCRIPTION = "11111111-2222-3333-4444-555555555555"
+DEPLOYMENT = "gpt-5.4"
+
+ENV = {
+    "AZURE_AI_ROUTE_PROFILE": "direct-v1",
+    "AZURE_OPENAI_V1_ENDPOINT": f"https://{ACCOUNT}.services.ai.azure.com/openai/v1/",
+    "AZURE_SUBSCRIPTION_ID": SUBSCRIPTION,
+}
+
+MOMENT = datetime(2026, 9, 11, 6, 0, 0, tzinfo=timezone.utc)
+
+
+def _clock(moment=MOMENT):
+    return lambda: moment
+
+
+def _deployment(
+    *,
+    name=DEPLOYMENT,
+    sku_name="GlobalStandard",
+    capacity_units=250,
+    rate_limits=(
+        {"key": "request", "renewalPeriod": 10, "count": 150},
+        {"key": "token", "renewalPeriod": 60, "count": 250_000},
+    ),
+):
+    entry = {
+        "name": name,
+        "sku": {},
+        "properties": {"model": {"name": "gpt-5.4", "version": "2026-01-01"}},
+    }
+    if sku_name is not None:
+        entry["sku"]["name"] = sku_name
+    if capacity_units is not None:
+        entry["sku"]["capacity"] = capacity_units
+    if rate_limits is not None:
+        entry["properties"]["rateLimits"] = list(rate_limits)
+    return entry
+
+
+def _runner(deployments=None, *, account_found=True):
+    """A stand-in for az that answers both reads from canned payloads."""
+    payload = [_deployment()] if deployments is None else deployments
+
+    def run(arguments):
+        if arguments[0] == "resource":
+            if not account_found:
+                return []
+            return [{"resourceGroup": RESOURCE_GROUP}]
+        assert arguments[:4] == [
+            "cognitiveservices",
+            "account",
+            "deployment",
+            "list",
+        ]
+        return payload
+
+    return run
+
+
+def _measure(runner=None, *, env=None, deployment=DEPLOYMENT, clock=None):
+    return capacity.measure(
+        dict(ENV if env is None else env),
+        deployment=deployment,
+        runner=runner or _runner(),
+        clock=clock or _clock(),
+    )
+
+
+def _run(argv, *, runner=None, env=None, clock=None):
+    stream = io.StringIO()
+    code = capacity.main(
+        argv,
+        env=dict(ENV if env is None else env),
+        runner=runner or _runner(),
+        clock=clock or _clock(),
+        stream=stream,
+    )
+    return code, stream.getvalue()
+
+
+# -------------------------------------------------------------------------
+# The denominator itself
+# -------------------------------------------------------------------------
+
+
+def test_a_stated_token_limit_becomes_the_denominator():
+    report = _measure()
+    assert report["tokens_per_minute"] == 250_000
+    assert report["verdict"] == capacity.VERDICT_CAPACITY_RECORDED
+
+
+def test_a_limit_stated_over_ten_seconds_is_scaled_to_a_minute():
+    # 150 requests per 10 seconds is 900 per minute. The period is in the
+    # payload, so this is arithmetic rather than a convention.
+    report = _measure()
+    assert report["requests_per_minute"] == 900
+
+
+def test_the_sku_capacity_is_recorded_and_never_converted():
+    """The point of the whole exercise.
+
+    250 capacity units is a real throughput figure, and the multiplier that
+    turns it into tokens per minute is documented. It is documented *elsewhere*,
+    it differs per model, and the payload does not carry it -- so converting
+    here would put a guess in the field a reader takes for a measurement.
+    """
+    report = _measure(_runner([_deployment(rate_limits=None)]))
+    assert report["sku_capacity"] == 250
+    assert report["sku_capacity_unit_stated_by_azure"] is False
+    assert report["tokens_per_minute"] is None
+    assert report["requests_per_minute"] is None
+    assert report["verdict"] == capacity.VERDICT_LIMITS_NOT_STATED
+    assert any("not converted" in problem for problem in report["read_failures"])
+
+
+def test_a_limit_with_no_renewal_period_is_kept_but_not_converted():
+    report = _measure(
+        _runner([_deployment(rate_limits=[{"key": "token", "count": 250_000}])])
+    )
+    assert report["tokens_per_minute"] is None
+    # Kept, not dropped: a limit nobody knows how to read is still a limit, and
+    # dropping it would quietly shrink the evidence a later reader has.
+    assert report["rate_limits"] == [
+        {
+            "key": "token",
+            "count": 250_000,
+            "renewal_period_seconds": None,
+            "per_minute": None,
+        }
+    ]
+
+
+def test_a_limit_with_a_zero_period_is_declined_rather_than_divided_by_zero():
+    report = _measure(
+        _runner(
+            [
+                _deployment(
+                    rate_limits=[
+                        {"key": "token", "count": 100, "renewalPeriod": 0}
+                    ]
+                )
+            ]
+        )
+    )
+    assert report["tokens_per_minute"] is None
+    assert report["verdict"] == capacity.VERDICT_LIMITS_NOT_STATED
+
+
+@pytest.mark.parametrize(
+    "sku_name, pooled",
+    [
+        ("GlobalStandard", True),
+        ("GlobalBatch", True),
+        ("DataZoneStandard", True),
+        ("Standard", False),
+        ("ProvisionedManaged", False),
+    ],
+)
+def test_a_pooled_sku_is_told_apart_from_a_dedicated_one(sku_name, pooled):
+    report = _measure(_runner([_deployment(sku_name=sku_name)]))
+    assert report["draws_on_shared_capacity"] is pooled
+
+
+def test_an_unnamed_sku_is_unknown_rather_than_dedicated():
+    """``None``, not ``False``.
+
+    Not knowing whether the capacity is pooled and knowing it is dedicated
+    support different readings of a refusal, so they get different values.
+    """
+    report = _measure(_runner([_deployment(sku_name=None)]))
+    assert report["draws_on_shared_capacity"] is None
+
+
+def test_a_pooled_sku_says_in_prose_that_a_ceiling_only_bounds_the_question():
+    _, body = _run(["--deployment", DEPLOYMENT])
+    assert "pooled capacity" in body
+    assert "bounds the question and does not settle it" in body
+
+
+def test_a_dedicated_sku_makes_no_such_claim():
+    code, body = _run(
+        ["--deployment", DEPLOYMENT],
+        runner=_runner([_deployment(sku_name="ProvisionedManaged")]),
+    )
+    assert code == 0
+    assert "pooled capacity" not in body
+
+
+# -------------------------------------------------------------------------
+# Answered-and-absent is not the same fact as never-answered
+# -------------------------------------------------------------------------
+
+
+def test_a_deployment_absent_from_an_answered_list_is_a_finding():
+    report = _measure(_runner([_deployment(name="gpt-audio-1.5")]))
+    assert report["verdict"] == capacity.VERDICT_DEPLOYMENT_ABSENT
+    assert report["deployments_seen"] == 1
+
+
+def test_a_deployment_list_az_never_answered_is_not_that_finding():
+    def run(arguments):
+        if arguments[0] == "resource":
+            return [{"resourceGroup": RESOURCE_GROUP}]
+        raise AzureReadFailure("the deployment list", exit_code=1)
+
+    report = _measure(run)
+    assert report["verdict"] == capacity.VERDICT_NEVER_COMPLETED
+    # Nothing was enumerated, so the count stays absent rather than reading 0.
+    assert report["deployments_seen"] is None
+
+
+def test_an_account_azure_answered_without_is_a_finding_about_this_identity():
+    report = _measure(_runner(account_found=False))
+    assert report["verdict"] == capacity.VERDICT_CANNOT_READ_ACCOUNT
+
+
+def test_an_account_lookup_az_never_answered_says_nothing_was_measured():
+    def run(arguments):
+        raise AzureReadFailure("az resource list", exit_code=2)
+
+    report = _measure(run)
+    assert report["verdict"] == capacity.VERDICT_NEVER_COMPLETED
+    assert any("never looked up" in problem for problem in report["read_failures"])
+
+
+def test_the_two_account_failures_do_not_share_a_verdict():
+    absent = _measure(_runner(account_found=False))["verdict"]
+
+    def never(arguments):
+        raise AzureReadFailure("az resource list", exit_code=2)
+
+    assert absent != _measure(never)["verdict"]
+
+
+# -------------------------------------------------------------------------
+# Which account gets read
+# -------------------------------------------------------------------------
+
+
+def test_the_account_comes_from_the_route_the_run_itself_resolves():
+    """Not from a rule retyped here.
+
+    Under project-ci there is no direct endpoint in the environment at all: the
+    route derives one from the project's account. Reading the right account in
+    that case is only possible by going through the same resolution the run uses,
+    so this asserts the derived account is what gets queried.
+    """
+    env = {
+        "AZURE_AI_ROUTE_PROFILE": "project-ci",
+        "FOUNDRY_PROJECT_ENDPOINT": (
+            f"https://{ACCOUNT}.services.ai.azure.com/api/projects/benchmark-proj"
+        ),
+        "AZURE_SUBSCRIPTION_ID": SUBSCRIPTION,
+    }
+    asked = []
+
+    def run(arguments):
+        asked.append(list(arguments))
+        if arguments[0] == "resource":
+            return [{"resourceGroup": RESOURCE_GROUP}]
+        return [_deployment()]
+
+    report = _measure(run, env=env)
+    assert report["verdict"] == capacity.VERDICT_CAPACITY_RECORDED
+    assert report["route_profile"] == "project-ci"
+    assert report["account_source"] == "direct-v1"
+    assert ACCOUNT in asked[0]
+
+
+def test_a_deployment_lives_on_an_account_so_the_project_is_never_queried():
+    env = {
+        "AZURE_AI_ROUTE_PROFILE": "project-ci",
+        "FOUNDRY_PROJECT_ENDPOINT": (
+            f"https://{ACCOUNT}.services.ai.azure.com/api/projects/benchmark-proj"
+        ),
+        "AZURE_SUBSCRIPTION_ID": SUBSCRIPTION,
+    }
+    asked = []
+
+    def run(arguments):
+        asked.append(list(arguments))
+        if arguments[0] == "resource":
+            return [{"resourceGroup": RESOURCE_GROUP}]
+        return [_deployment()]
+
+    _measure(run, env=env)
+    assert not any("benchmark-proj" in argument for call in asked for argument in call)
+
+
+def test_a_missing_subscription_is_refused_rather_than_inherited():
+    env = {key: value for key, value in ENV.items() if key != "AZURE_SUBSCRIPTION_ID"}
+    with pytest.raises(ValueError, match="AZURE_SUBSCRIPTION_ID"):
+        _measure(env=env)
+
+
+def test_a_missing_route_profile_is_refused():
+    env = {key: value for key, value in ENV.items() if key != "AZURE_AI_ROUTE_PROFILE"}
+    with pytest.raises(ValueError):
+        _measure(env=env)
+
+
+def test_the_deployment_name_is_matched_whatever_case_it_was_typed_in():
+    report = _measure(deployment="GPT-5.4")
+    assert report["verdict"] == capacity.VERDICT_CAPACITY_RECORDED
+
+
+def test_a_deployment_name_is_required():
+    with pytest.raises(ValueError, match="deployment name"):
+        _measure(deployment="   ")
+
+
+# -------------------------------------------------------------------------
+# When the figure was true
+# -------------------------------------------------------------------------
+
+
+def test_the_report_records_when_the_capacity_was_read():
+    report = _measure()
+    assert report["measured_at"].startswith("2026-09-11T06:00:00")
+
+
+def test_a_clock_with_no_timezone_is_refused_rather_than_assumed_to_be_utc():
+    naive = lambda: datetime(2026, 9, 11, 6, 0, 0)  # noqa: E731
+    with pytest.raises(ValueError, match="timezone"):
+        _measure(clock=naive)
+
+
+def test_a_clock_in_another_zone_is_stored_as_utc():
+    kst = timezone(timedelta(hours=9))
+    report = _measure(clock=lambda: datetime(2026, 9, 11, 15, 0, 0, tzinfo=kst))
+    assert report["measured_at"].startswith("2026-09-11T06:00:00")
+
+
+# -------------------------------------------------------------------------
+# What must never be printed
+# -------------------------------------------------------------------------
+
+
+def test_the_account_name_never_reaches_the_report():
+    code, body = _run(["--deployment", DEPLOYMENT])
+    assert code == 0
+    assert ACCOUNT not in body
+    assert ACCOUNT.lower() not in body.lower()
+
+
+def test_the_resource_group_never_reaches_the_report():
+    code, body = _run(["--deployment", DEPLOYMENT])
+    assert code == 0
+    assert RESOURCE_GROUP not in body
+
+
+def test_the_subscription_id_never_reaches_the_report():
+    code, body = _run(["--deployment", DEPLOYMENT])
+    assert code == 0
+    assert SUBSCRIPTION not in body
+
+
+def test_the_names_of_the_other_deployments_are_never_printed():
+    """A count, not a list.
+
+    How many deployments an account holds is not an identifier. What they are
+    called is chosen by whoever made them, and people name things after the
+    project they belong to.
+    """
+    code, body = _run(
+        ["--deployment", DEPLOYMENT],
+        runner=_runner(
+            [_deployment(), _deployment(name="internal-hr-summariser-prod")]
+        ),
+    )
+    assert code == 0
+    assert "internal-hr-summariser-prod" not in body
+    assert "deployments on the account: 2" in body
+
+
+def test_an_account_name_that_reached_the_body_is_redacted(monkeypatch):
+    """The second layer, checked on its own.
+
+    Nothing writes the account into the report today. This asserts that if
+    something did, redaction would still catch it -- which is what makes the
+    withholding test below a last resort rather than the only defence.
+    """
+    report = _measure()
+    report["deployment"] = ACCOUNT
+    monkeypatch.setattr(capacity, "measure", lambda *a, **k: report)
+    code, body = _run(["--deployment", DEPLOYMENT])
+    assert code == 0
+    assert ACCOUNT not in body
+    assert "<accountName>" in body
+
+
+def test_the_report_is_withheld_when_redaction_is_broken(monkeypatch):
+    report = _measure()
+    report["deployment"] = ACCOUNT
+    monkeypatch.setattr(capacity, "measure", lambda *a, **k: report)
+    monkeypatch.setattr(capacity, "redact", lambda text, secrets: text)
+    code, body = _run(["--deployment", DEPLOYMENT])
+    assert code == 3
+    assert body == ""
+
+
+def test_breaking_redaction_on_a_report_with_nothing_to_leak_still_prints(monkeypatch):
+    monkeypatch.setattr(capacity, "redact", lambda text, secrets: text)
+    code, body = _run(["--deployment", DEPLOYMENT])
+    assert code == 0
+    assert "capacity_recorded" in body
+
+
+# -------------------------------------------------------------------------
+# The CLI
+# -------------------------------------------------------------------------
+
+
+def test_the_json_output_carries_the_same_verdict_as_the_prose():
+    code, body = _run(["--deployment", DEPLOYMENT, "--json"])
+    assert code == 0
+    assert json.loads(body)["verdict"] == capacity.VERDICT_CAPACITY_RECORDED
+
+
+def test_the_json_output_never_carries_the_secret_values_key():
+    code, body = _run(["--deployment", DEPLOYMENT, "--json"])
+    assert code == 0
+    assert "secret_values" not in json.loads(body)
+
+
+def test_an_unavailable_denominator_is_reported_rather_than_treated_as_an_error():
+    code, body = _run(
+        ["--deployment", DEPLOYMENT], runner=_runner([_deployment(rate_limits=None)])
+    )
+    assert code == 0
+    assert "unavailable" in body
+
+
+def test_require_limits_turns_an_unavailable_denominator_into_a_failure():
+    code, _ = _run(
+        ["--deployment", DEPLOYMENT, "--require-limits"],
+        runner=_runner([_deployment(rate_limits=None)]),
+    )
+    assert code == 1
+
+
+def test_the_written_file_is_the_redacted_record(tmp_path):
+    target = tmp_path / "capacity.json"
+    code, _ = _run(["--deployment", DEPLOYMENT, "--output", str(target)])
+    assert code == 0
+    written = json.loads(target.read_text(encoding="utf-8"))
+    assert written["tokens_per_minute"] == 250_000
+    assert ACCOUNT not in target.read_text(encoding="utf-8")
+    assert RESOURCE_GROUP not in target.read_text(encoding="utf-8")
+
+
+def test_no_file_is_written_when_the_report_would_leak(monkeypatch, tmp_path):
+    """A withheld report must not leave the leak behind on disk.
+
+    The file is the copy a run keeps and uploads, so writing it before the leak
+    check would publish exactly what refusing to print was protecting.
+    """
+    report = _measure()
+    report["deployment"] = ACCOUNT
+    monkeypatch.setattr(capacity, "measure", lambda *a, **k: report)
+    monkeypatch.setattr(capacity, "redact", lambda text, secrets: text)
+    target = tmp_path / "capacity.json"
+    code, _ = _run(["--deployment", DEPLOYMENT, "--output", str(target)])
+    assert code == 3
+    assert not target.exists()
+
+
+# -------------------------------------------------------------------------
+# It cannot spend anything
+# -------------------------------------------------------------------------
+
+
+MODEL_CALL_PATTERN = re.compile(
+    r"responses\.create|chat\.completions|AzureOpenAI|llm_client|code_interpreter"
+)
+
+
+def test_the_script_references_no_model_call_path():
+    assert MODEL_CALL_PATTERN.search(SCRIPT.read_text(encoding="utf-8")) is None
+
+
+def test_every_az_call_it_makes_is_a_read():
+    verbs = []
+
+    def run(arguments):
+        verbs.append(list(arguments))
+        if arguments[0] == "resource":
+            return [{"resourceGroup": RESOURCE_GROUP}]
+        return [_deployment()]
+
+    _measure(run)
+    assert verbs
+    for call in verbs:
+        assert "list" in call
+        assert not {"create", "update", "delete", "set"} & set(call)
+
+
+def test_the_script_the_workflow_runs_is_committed_and_not_ignored():
+    """``batch-runner/scripts/*`` is ignored wholesale in this repository.
+
+    Each script that belongs in git is un-ignored by name, one line at a time,
+    so a new one is invisible to ``git add`` until somebody adds that line. A
+    script that works locally and was never committed does not fail visibly: the
+    job checks out, installs Python, logs into Azure, and only then reports that
+    a file is missing -- which reads as an Azure problem.
+    """
+    inside_git = subprocess.run(
+        ["git", "rev-parse", "--is-inside-work-tree"],
+        cwd=REPOSITORY_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if inside_git.returncode != 0:
+        pytest.skip("not a git checkout, so tracking cannot be checked here")
+    tracked = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", str(SCRIPT.relative_to(REPOSITORY_ROOT))],
+        cwd=REPOSITORY_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert tracked.returncode == 0, (
+        "the capacity script is not tracked by git; add an un-ignore line for it "
+        "to .gitignore, or the workflow will run a file that is not there"
+    )
+
+
+# -------------------------------------------------------------------------
+# The workflow that is the only place this can be asked
+# -------------------------------------------------------------------------
+
+
+def _workflow():
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def test_the_workflow_exists_and_parses():
+    assert _workflow()
+
+
+def test_the_workflow_is_dispatched_by_hand_only():
+    # ``on`` parses as the boolean True in YAML 1.1, which is why this is not a
+    # plain key lookup.
+    triggers = _workflow()[True]
+    assert set(triggers) == {"workflow_dispatch"}
+
+
+def test_the_workflow_asks_for_no_write_permission_on_the_repository():
+    assert _workflow()["permissions"] == {"contents": "read", "id-token": "write"}
+
+
+def test_the_workflow_passes_no_model_credential():
+    text = WORKFLOW.read_text(encoding="utf-8")
+    for forbidden in ("AZURE_OPENAI_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+        assert forbidden not in text
+
+
+def _every_env_mapping(node):
+    """Every ``env:`` mapping in the workflow, at the job level or in a step."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "env" and isinstance(value, dict):
+                yield value
+            yield from _every_env_mapping(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _every_env_mapping(item)
+
+
+def test_the_workflow_does_not_name_the_account_in_a_step_header():
+    """Repository variables are not masked the way secrets are.
+
+    Whatever a step lists under ``env:`` is reprinted verbatim in the step
+    header, and this repository's logs are public. The account name is inside
+    the endpoint secret, which is masked, so the workflow has no reason to ask
+    for the variable that spells it out.
+
+    Checked against the parsed mappings rather than the file text, so that the
+    comment explaining why these are absent does not read as their presence.
+    """
+    forbidden = (
+        "AZURE_AI_EXPECTED_DIRECT_ACCOUNT",
+        "AZURE_AI_EXPECTED_PROJECT_ACCOUNT",
+        "AZURE_AI_EXPECTED_PROJECT_NAME",
+    )
+    mappings = list(_every_env_mapping(_workflow()))
+    assert mappings, "the workflow declares no env at all, so this proves nothing"
+    for mapping in mappings:
+        for key, value in mapping.items():
+            for name in forbidden:
+                assert name != key
+                assert name not in str(value)
+
+
+def test_the_workflow_keeps_the_grep_that_checks_for_a_model_call():
+    """And keeps the same pattern this file checks the source with.
+
+    Pinned as one string rather than a handful of substrings: two copies of a
+    guard that drift apart leave both sides passing while the narrower one is
+    the only thing actually running in CI.
+    """
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert MODEL_CALL_PATTERN.pattern in text
+    assert "azure_deployment_capacity.py" in text

--- a/batch-runner/tests/test_the_deployment_says_how_much_throughput_it_has.py
+++ b/batch-runner/tests/test_the_deployment_says_how_much_throughput_it_has.py
@@ -574,6 +574,97 @@ def test_the_script_the_workflow_runs_is_committed_and_not_ignored():
 
 
 # -------------------------------------------------------------------------
+# Making an empty answer diagnosable
+# -------------------------------------------------------------------------
+
+
+def test_an_empty_limits_read_says_which_properties_were_there():
+    """Two different facts otherwise look identical.
+
+    A deployment that genuinely declares no limits and a payload that declares
+    them under a name this tool does not look for both produce an empty report.
+    Telling them apart afterwards would mean reading the payload again, in CI,
+    because CI is the only place the account is visible -- so the names it did
+    carry are recorded the first time.
+    """
+    code, body = _run(
+        ["--deployment", DEPLOYMENT], runner=_runner([_deployment(rate_limits=None)])
+    )
+    assert code == 0
+    assert "model" in body
+    assert "the deployment's properties carried" in body
+
+
+def test_the_property_names_are_not_repeated_when_the_limits_were_read():
+    code, body = _run(["--deployment", DEPLOYMENT])
+    assert code == 0
+    assert "properties carried" not in body
+
+
+def test_only_names_shaped_like_azure_schema_are_repeated_back():
+    """The filter is cheap and the promise it protects is not.
+
+    These are Azure's own property names rather than anything a person chose,
+    so nothing here is expected to be withheld. The report's whole claim is
+    that no chosen string survives into it, and a claim that holds only while
+    an upstream schema stays boring is not the claim being made.
+    """
+    entry = _deployment(rate_limits=None)
+    entry["properties"]["contoso-foundry-eastus"] = "surprise"
+    report = _measure(_runner([entry]))
+    assert report["properties_seen"] == ["model"]
+    assert ACCOUNT not in report["properties_seen"]
+
+
+# -------------------------------------------------------------------------
+# What else was already binding to the module this change moved things out of
+# -------------------------------------------------------------------------
+
+DIAGNOSTIC = BATCH_RUNNER / "scripts" / "azure_rbac_diagnostic.py"
+SURVEY = BATCH_RUNNER / "scripts" / "azure_boot_host_survey.py"
+BOUND_OFF_THE_DIAGNOSTIC = re.compile(r"\brbac\.([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def _diagnostic_module():
+    # Loaded under a name of its own. The boot-host survey loads the same file
+    # under its own key, and stamping on that entry would make this check the
+    # reason another test file fails.
+    name = "azure_rbac_diagnostic_binding_check"
+    spec = importlib.util.spec_from_file_location(name, DIAGNOSTIC)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_every_name_the_boot_host_survey_binds_off_the_diagnostic_still_exists():
+    """Private by name, public by use.
+
+    The boot-host survey loads the diagnostic by path and reaches into it for
+    helpers that were written as local functions with leading underscores. The
+    underscore recorded nothing about who depended on them, so moving those
+    implementations into ``core.azure_control_plane`` renamed them out from under
+    a caller whose own file had not changed -- and its tests, not the
+    diagnostic's, were the ones that went red.
+
+    Read out of the survey's source rather than listed here, so a name added
+    there later is covered without anybody remembering to come back.
+    """
+    if not SURVEY.exists():
+        pytest.skip("the boot host survey is not in this checkout")
+    module = _diagnostic_module()
+    used = set(BOUND_OFF_THE_DIAGNOSTIC.findall(SURVEY.read_text(encoding="utf-8")))
+    assert used, "nothing was found to bind, so this proves nothing"
+    missing = sorted(name for name in used if not hasattr(module, name))
+    assert not missing, (
+        "the boot host survey binds names the diagnostic no longer has: "
+        f"{missing}. Keep them as aliases rather than editing a file this "
+        "change does not own."
+    )
+
+
+# -------------------------------------------------------------------------
 # The workflow that is the only place this can be asked
 # -------------------------------------------------------------------------
 


### PR DESCRIPTION
## 무엇이 없었나

직전 PR(#521)로 원장이 **"이 호출이 몇 시에 나갔고 몇 시에 끝났는지"**를 적기 시작했습니다. 이제 거절 직전 1분 동안 정산된 토큰을 셀 수 있습니다.

그건 **분자**입니다. 분자 하나만으로는 아무것도 못 정합니다.

> 분당 20만 토큰이 **한도 안쪽인지 바깥쪽인지**, 이 저장소는 한 번도 적어둔 적이 없습니다.

이 PR은 **분모**를 읽습니다. Azure가 이 배포에 대해 **스스로 선언한 한도**입니다.

## 무엇을 읽고, 무엇을 안 읽나

| Azure가 준 값 | 이 도구가 하는 일 |
|---|---|
| `properties.rateLimits` | **환산합니다.** "10초에 150회" → **분당 900회**. 개수도 기간도 응답 안에 있으니 산수입니다 |
| `sku.capacity` | **그대로 적고, 절대 환산하지 않습니다** |

두 번째 줄이 이 PR의 전부입니다.

`sku.capacity: 250`을 분당 토큰으로 바꾸는 환산은 **실재합니다.** 그리고 그 환산표는 **문서에 있지, 응답에는 없습니다.** 모델마다 같은 숫자가 다른 처리량을 뜻합니다.

외워둔 상수를 곱하면, 그 숫자는 **Azure가 실제로 말한 숫자와 같은 칸에 같은 글꼴로** 앉습니다. 그런데 이 읽기가 존재하는 이유가 바로 **exp034 분석의 분모가 추측이었다는 것**입니다.

**측정된 것처럼 보이는 추측은 빈칸보다 나쁩니다.** 빈칸은 누군가 쫓아가서 채우지만, 그럴듯한 숫자는 아무도 안 쫓아갑니다.

그래서 한도를 안 알려주는 배포는 `limits_not_stated`라고 적고 분당 칸을 **비워 둡니다.**

> 이 도구가 까다롭게 군다고 느껴지면 **먼저 깨봐야 할 테스트**가 이겁니다 — `test_the_sku_capacity_is_recorded_and_never_converted`. capacity는 주고 한도는 안 주고, **답이 비어 있는지**를 확인합니다.

## 한도를 알아도 끝이 아닌 경우

`GlobalStandard` 같은 **공유 용량** sku는, 이 배포가 **자기 한도 안쪽인데도 거절당할 수 있습니다.** 그 용량이 이 배포 전용이 아니기 때문입니다.

그래서 선언된 한도는 질문을 **가두기만 하고 끝내지는 못합니다.**

- 측정값이 한도에 **붙어 있으면** → 처리량이 원인일 수 있습니다
- 측정값이 한도보다 **한참 낮아도** → 이 배포는 **무죄가 아닙니다**

보고서가 이 경우 산문으로 그렇게 말합니다. sku 이름이 없으면 `None`으로 적습니다 — **"공유인지 모름"과 "전용임"은 거절을 다르게 읽게 하니까요.**

## 빈칸이 두 가지 뜻이던 문제

한도가 안 나오면 보고서는 빈칸을 냅니다. 그런데 그 빈칸은 **두 가지 중 어느 쪽인지 구분이 안 됐습니다.**

1. 이 배포가 **정말로 한도를 선언 안 함**
2. 한도가 **이 도구가 안 찾아보는 이름 밑에** 들어 있음

둘이 화면에 **똑같이** 찍혔습니다. 그리고 나중에 가려내려면 응답 원문을 봐야 하는데, **이 계정이 보이는 곳은 CI뿐이라 CI를 한 번 더 돌려야** 했습니다. 돈은 안 들어도 하루가 갑니다.

그래서 보고서가 **응답에 실제로 있던 속성 이름들**을 같이 적습니다. 한도를 못 읽었을 때만 찍습니다 — 분모를 받아간 사람한테는 필요 없는 정보니까요. **첫 실행에서 바로 판가름납니다.**

이름은 **Azure 스키마 형태인 것만** 통과시킵니다. Azure가 붙인 이름은 전부 통과하고, 이 보고서의 약속은 **사람이 고른 이름은 아무것도 안 나간다**는 것이니까요.

## 못 읽었을 때 두 가지를 구분합니다

| | 뜻 |
|---|---|
| `deployment_absent_or_withheld` | **Azure가 대답했고**, 그 대답에 이 배포가 없었습니다 |
| `control_plane_read_never_completed` | **az가 대답을 안 했습니다.** 질문이 리소스까지 못 갔습니다 |

첫 번째는 이 자격증명이 무엇을 볼 수 있는지 말해 줍니다. 두 번째는 **아무것도 말해 주지 않습니다.**

CI 밖에서 로그인한 세션이 만드는 게 두 번째입니다. 그래서 **이건 워크플로로만 물을 수 있습니다.**

이 읽기는 **거절당할 수도 있습니다.** 옆의 RBAC 진단이 존재하는 이유가 이 자격증명이 이미 Foundry 프로젝트에서 거절당했기 때문입니다. 거절당하면 **"지금 권한으로는 못 읽음"으로 기록하고, 그건 권한을 더 달라고 할 근거가 아닙니다.**

## 이름은 안 찍습니다

구독 ID, 테넌트, 주체 ID, **계정 이름, 리소스 그룹** — 보고서에 안 들어갑니다.

같은 계정의 **다른 배포들은 개수로만** 적습니다. 개수는 식별자가 아니지만 **이름은 만든 사람이 붙인 것**이고, 사람들은 소속 프로젝트 이름을 붙입니다.

알려진 값이 지우기를 뚫고 살아남으면 **보고서를 아예 출력 안 하고 파일도 안 씁니다.** 로그가 공개라 되돌릴 수 없으니까요.

워크플로는 계정 이름 **저장소 변수를 요청하지 않습니다.** GitHub은 변수를 시크릿처럼 가려주지 않고, `env:`에 적은 건 **단계 헤더에 그대로** 다시 찍힙니다.

## 코드를 옮긴 이유 (복사가 아니라)

`core/azure_control_plane.py`는 `scripts/azure_rbac_diagnostic.py`에서 **그대로 옮긴** 것이지 다시 쓴 게 아닙니다.

**보안 속성은 사본을 두 개 갖기에 가장 나쁜 종류입니다.** 사본은 만든 날엔 자기 테스트를 통과하고, 그 뒤로 원본을 안 따라갑니다. 그러면 누군가 보고 있던 쪽에서 고친 게 **실제로 돌아가는 쪽에는 안 닿습니다.**

진단 스크립트는 역할(role) 관련은 전부 그대로 갖고, 나머지를 import합니다. **진단의 기존 80개 테스트가 그대로 통과**하는 게, 이게 다시 쓴 게 아니라 옮긴 것이라는 증거입니다.

스크립트가 아니라 모듈인 이유는, **실행 자체가 이 분모를 기록하고 싶어질 것**이고 실행이 진단 스크립트를 import할 수는 없기 때문입니다.

## 옮기다가 남의 파일을 깼습니다

이 브랜치가 **한 글자도 안 건드린** 파일에서 테스트 **22개가 깨졌습니다.**

`scripts/azure_boot_host_survey.py`가 진단 스크립트를 **경로로 읽어서** `_as_mappings`, `_default_runner` 두 이름을 꺼내 씁니다. 옮기면서 그 두 개의 밑줄이 없어졌고, **부르는 쪽 파일은 그대로인데 이름이 사라졌습니다.**

밑줄은 "안 쓰는 것"이라는 뜻이 **아니었습니다.** 의존이 다른 파일에 있고 실행 시점에 연결되니, 밑줄이 기록한 정보가 애초에 없었던 겁니다.

두 줄짜리 별칭으로 되돌렸습니다. **남의 파일은 안 고쳤습니다.**

그리고 다음번엔 이쪽에서 걸리게 테스트를 하나 박았습니다 — 그 survey 파일을 읽어서 `rbac.<이름>` 형태로 꺼내 쓰는 이름을 **전부 찾아내고**, 하나씩 아직 있는지 확인합니다. 목록을 손으로 적지 않았으니 **그 파일이 자라도 알아서 따라갑니다.**

이게 잡힌 건 전체 테스트를 돌렸기 때문이지, 새로 쓴 파일을 돌려서가 아닙니다. 새 파일은 **처음부터 끝까지 초록색**이었습니다.

## 돈 이야기

**한 푼도 안 씁니다.** 전부 ARM 제어 평면 **읽기**입니다. 만들지도, 바꾸지도, 지우지도 않고, **모델 엔드포인트를 호출하지 않습니다.** 그래서 이 읽기는 자기가 설명하려는 그 거절을 **재현할 수도 없습니다.**

테스트가 소스를 grep하고, 워크플로가 CI에서 **같은 패턴으로 다시** grep합니다. 두 곳에 **같은 문자열로 못 박아서**, 한쪽만 좁혀진 채 통과하는 일이 안 생깁니다.

## 검증

| | |
|---|---|
| 새 테스트 | **53개 전부 통과** |
| 진단 스크립트 기존 테스트 | **80개 그대로 통과** (옮긴 것이라는 증거) |
| survey 기존 테스트 | **40개 통과** (한 번 22개가 깨졌다가 복구됨) |
| 일부러 한 줄씩 망가뜨림 | **15군데 전부** 그 이름의 테스트가 잡음 |
| 망가뜨린 뒤 복원 | 매번 **바이트 단위로 동일** |

망가뜨려 본 15가지: capacity 환산하기 · 기간 없으면 1분으로 치기 · 기간 무시하기 · 이름 없는 sku를 전용이라 하기 · 타임존 없는 시계 받기 · 두 실패 판정 합치기 · 다른 배포 이름 싣기 · 유출 검사 전에 파일 쓰기 · 대소문자 가려 이름 맞추기 · 계정 대신 프로젝트 읽기 · 워크플로에 계정 변수 추가하기 · 워크플로 grep 좁히기 · 속성 이름 아무거나 다 찍기 · 한도 읽었는데도 속성 이름 찍기 · survey가 쓰는 별칭 지우기.

**16번째 검사**는 따로 적어둘 값어치가 있습니다. 이 저장소는 `batch-runner/scripts/*`를 통째로 무시하고 **한 줄씩 이름으로 예외 처리**합니다. 그 줄이 없으면 새 스크립트는 `git add`에 **안 보입니다.**

그러면 워크플로는 체크아웃하고, 파이썬 깔고, **Azure에 로그인까지 한 다음** "파일 없음"을 냅니다 — **Azure 문제처럼 읽힙니다.** 그래서 git이 실제로 이 파일을 추적하는지 테스트가 확인합니다.

## 다음

분자(#521)와 분모(이 PR)가 둘 다 들어갔습니다. 둘 다 **돈이 안 듭니다.**

그래서 **exp035(220문제)** 실행이 이 근거를 **부산물로** 남깁니다. 이걸 알아내자고 유료 실행을 따로 걸지 않습니다.
