### PR TITLE
experiment: run the whole benchmark against Foundry, and close two predictions

### DIFF
--- a/batch-runner/experiments/exp035_codex_foundry_full220.yaml
+++ b/batch-runner/experiments/exp035_codex_foundry_full220.yaml
@@ -1,0 +1,585 @@
+# Codex against Foundry — the whole benchmark
+# ==========================================
+#
+# The last of three stages: five, then thirty, then two hundred and twenty.
+# `exp033_codex_foundry_fixed5.yaml` and `exp034_codex_foundry_trial30.yaml`
+# are left exactly as they were. A stage is a separate run with its own
+# record, not an edit to the stage before it.
+#
+# How a task is run does not change from exp034: one fresh Codex session per
+# task, that task's reference files staged into an isolated working directory,
+# the agent's own tools, and whatever files it leaves behind collected as the
+# deliverables. The prompt is byte-for-byte exp033's. One setting changes and
+# it cannot alter a result; it is named below.
+#
+# What the thirty tasks actually showed
+# -------------------------------------
+#
+# Run `34540053904`, read from the run log and the 434 MB artifact rather than
+# from a summary line:
+#
+#   22 of 30 succeeded, 8 errored
+#   107 deliverable files, every one of them belonging to one of the 22
+#   no success produced zero files, and no failure produced a file
+#
+# The eight failures split two ways, and the split matters more than the
+# count:
+#
+#   5  rate refusals   02aa1805  105f8ad0  1d4672c8  0353ee0c  0e4fe8cd
+#      all four attempts exhausted; the provider's sentence each time was
+#      `Your requests to gpt-5.4 for gpt-5.4 in eastus2 have exceeded rate
+#      limit.`
+#   3  content stops   11e1b169  0818571f  1bff4551
+#      `Incomplete response returned, reason: content_filter`
+#
+# Fourteen of the thirty were retried at least once, and seven of those
+# fourteen went on to succeed — a coin flip, not a formality. The other
+# fifteen successes needed no retry, and one task failed on its first attempt
+# without being retried at all. Those three groups account for all thirty:
+#
+#   16 resolved at attempt 1     15 succeeded, 1 failed
+#    6 resolved at attempt 2      5 succeeded, 1 failed
+#    1 resolved at attempt 3      it succeeded
+#    7 resolved at attempt 4      2 succeeded, 5 failed
+#
+# The waiting between attempts is fixed by the backoff and can therefore be
+# added up exactly: 14 x 60s + 8 x 120s + 7 x 240s = 3,480 seconds, 58.0
+# minutes of the 186.5-minute inference step spent not calling anything.
+#
+# The first prediction, answered: yes, twice
+# ------------------------------------------
+#
+# exp034 raised `max_retries` from 2 to 3 and wrote down the question that
+# would settle whether the extra budget bought anything: **did a fourth
+# attempt ever convert a task that three attempts had not?**
+#
+#   3a4c347c   succeeded on attempt 4 after 293,363 ms
+#   3baa0009   succeeded on attempt 4 after 228,568 ms
+#
+# Seven tasks reached a fourth attempt and two of them converted there.
+# Without it exp034 scores 20 of 30 instead of 22. The fourth attempt is the
+# first one that waits 240 seconds, and 3baa0009 is the task that had failed
+# for a different reason in each of the two five-task runs.
+#
+# So `max_retries: 3` is not an open question any more and moves from this
+# file's `changed` list to its `fixed` list. It is kept because it was
+# measured, not because it was inherited.
+#
+# The second prediction, answered: refuted
+# ----------------------------------------
+#
+# exp034 wrote down, before the run, that failures might pile up on tasks with
+# short statements — the five-task evidence separated the groups perfectly and
+# five points is nothing. Thirty points say no.
+#
+#   short (< 2,000 characters)   11 of 30 = 36.7% under the null
+#   all 8 failures               2 short, against 2.9 expected   P(X>=2) = 0.854
+#   the 5 rate refusals only     1 short, against 1.8 expected   P(X>=1) = 0.898
+#   the 3 content stops only     1 short, against 1.1 expected   P(X>=1) = 0.746
+#   median statement length      2,249.5 succeeded   2,235.0 failed
+#
+# The longest statement in the thirty (6,029 characters, `0e4fe8cd`) failed,
+# and the shortest (801, `4520f882`) succeeded. There is nothing here to
+# chase.
+#
+# There is also a mechanism note worth keeping, because it explains why the
+# statistic could not have come out any other way for most of the failures: a
+# rate refusal arrives before the model has produced anything at all. The
+# length of the statement cannot be a cause of 5 of the 8. Only the 3 content
+# stops were ever candidates, and at three points nothing is testable. The
+# prediction was worth writing down and is now worth closing.
+#
+# Content stops stay failures
+# ---------------------------
+#
+# Three tasks in thirty were stopped by the provider's content filter. They
+# are recorded as failures and they stay failures. They are not reworded, not
+# excluded from the task list, and not retried past.
+#
+# The retry policy already refuses to retry past one, and exp034 shows it
+# working. The run's own banner names the triggers — `on rate_limited,
+# turn_start_failed` — and `1bff4551` was filtered on its first attempt and
+# never tried again. The other two, `11e1b169` and `0818571f`, were filtered
+# on a second attempt that a rate refusal had triggered, so the filter is what
+# ended them either way. No content stop in this run consumed a retry of its
+# own.
+#
+# This is a benchmark result about a model reaching a deployment through a
+# filter that deployment applies. Raising the score by removing it would make
+# the number mean something other than what it says.
+#
+# The two hundred and twenty tasks
+# --------------------------------
+#
+# Every task in the committed score-free catalogue, sorted by id. No
+# selection rule runs here because nothing is being selected; the previous two
+# stages used `select_trial_run_tasks` to take a subset and this one is the
+# set. Re-deriving the list needs the catalogue and nothing else:
+#
+#   catalog_sha256    5f1eca853979b2b4efe6c6ba656545c3a416da920e3faf067d52f5d8ac4ae0eb
+#   dataset_revision  11e7900cdcac61bc4daf59e65feb238acda98fbf
+#
+# The catalogue holds 9 industries and 44 occupations. The README and
+# CLAUDE.md both say 11 and 55. That disagreement is older than this file and
+# is not resolved by it; the number that governs this run is the one in the
+# catalogue, which is what the ids below were read from.
+#
+# All thirty of exp034's tasks are in this list, including the eight that
+# failed and the three the filter stopped. A task that failed at thirty is
+# not dropped at two hundred and twenty.
+#
+# What changes, and what it costs the comparison
+# ----------------------------------------------
+#
+# One setting, and it is not an experimental variable:
+#
+#   execution.relay_max_runs   6  ->  10     more legs for seven times the work
+#
+# `relay_max_runs` decides only how many times the workflow may hand the run
+# to a fresh leg after the previous one hits its wall clock. It cannot add an
+# attempt and cannot change any task's result — a leg picks the task list up
+# where the last one left it. Everything that touches a result is unchanged
+# from exp034, so this run does compare to it.
+#
+# The wall clock, fixed before the run
+# ------------------------------------
+#
+#   220 tasks x at most 4 attempts each = 880 turns, worst case
+#   1 turn per attempt, 1800s wall clock each
+#   at most 1 task at a time (this pipeline does not run tasks concurrently)
+#   Self-QA off, so no second call per task
+#   at most 420s of waiting between a task's attempts — 60s, 120s, then 240s
+#
+# What is expected comes from exp034's own clock. Its inference step ran
+# 23:02:57 to 02:09:26, 186.5 minutes for 30 tasks, which is 6.22 minutes a
+# task including every wait and every retry. At that rate 220 tasks is about
+# 1,368 minutes, 22.8 hours. A leg's step 2 runs under a 290-minute watchdog,
+# so that is 4.7 legs and five would do it. `relay_max_runs: 10` is the most
+# the workflow accepts — its config read refuses anything outside 0..10
+# before a single task starts — and it gives eleven legs, 53.2 hours, about
+# two and a third times the headroom.
+#
+# The worst case is a different number and it is not reachable:
+#
+#   220 x (4 x 1800 + 420) = 1,676,400 seconds = 465.7 hours
+#
+# Eleven legs is the ceiling this workflow has, so 465.7 hours is out of reach
+# by construction rather than by choice. If every task in the benchmark took
+# its full budget this run would stop with tasks still pending and need a leg
+# started by hand. That is the honest bound, written here so that a stall
+# reads as this arithmetic rather than as a fault.
+#
+# One thing the relay does not have
+# ---------------------------------
+#
+# There is no no-progress guard. A leg that completes zero tasks still
+# dispatches the next one, and the chain stops only when `relay_run` exceeds
+# `relay_max_runs`. Eleven legs of a deployment refusing everything would
+# spend eleven watchdogs finding that out.
+#
+# This is stated rather than fixed, because fixing it means editing
+# `.github/workflows/batch-run.yml`, which is shared and frozen while this
+# stage is in flight. The run is watched instead: if a leg lands with no task
+# advanced, it is stopped by hand rather than by the workflow.
+#
+# Resume stays off, for exp034's two reasons
+# ------------------------------------------
+#
+# The first is exp033's: a resume round gives some tasks more attempts than
+# others depending on where their failures happened to fall.
+#
+# The second is worse and is the reason this key is written out rather than
+# omitted. `_get_failed_task_ids` in `step2_run_inference.py` selects tasks to
+# resume by **status** — `{"error", "qa_failed", "pending"}` — and never looks
+# at why the task failed. A resume round would therefore re-run the three
+# tasks the provider stopped for content, which is not recovering a lost
+# result: it replaces a benchmark outcome with a different one and raises the
+# score by the difference. The default in `core/experiment_config.py` is 3, so
+# an experiment file that simply omits this key retries filtered tasks
+# quietly. This one does not omit it.
+#
+# The dispatch, and why it is dry
+# -------------------------------
+#
+# This run is dispatched with `dry_run: true`, the same as exp034. The name is
+# misleading and the misreading is expensive, so here is exactly what that
+# input does in `.github/workflows/batch-run.yml`:
+#
+#   runs anyway   step 2 inference, step 3 format, step 4 parquet,
+#                 step 6 report (model-free, --dry-run), artifact upload
+#                 (`if: always()`)
+#   skipped       step 5 validate, the results pull request, the HuggingFace
+#                 upload
+#
+# exp034 ran under this input and made real paid calls for 3 hours 6 minutes.
+# `dry_run` has never once meant that inference was skipped.
+#
+# The three skipped steps fire only on the final leg and none of them touches
+# a result. Turning them on would mean the first execution of an upload path
+# this three-stage sequence has never exercised, landing at the end of a
+# 23-hour paid run. They can be run afterwards from the artifact for nothing.
+# `output.publish_to_hf` below is `false` and stays consistent with that;
+# nothing in `codex_foundry` mode reads that key to decide an upload, so it is
+# a record of intent rather than a switch.
+#
+# What this run will not produce
+# ------------------------------
+#
+# A dollar figure. The cost ledger will come back `status: "partial"` with
+# `estimated_cost_usd: null` and `missing_reasons: ["call_reachability_unknown"]`,
+# exactly as exp034's did, because this deployment is absent from
+# `experiments/execution_envelope/model_price_table.json`. What it will record
+# is real and is not a price: exp034 logged 59 model calls, 9,308,069 input
+# tokens of which 7,537,280 were cached, 397,131 output and 141,341 reasoning,
+# summed across all thirty rows.
+#
+# The 59 reconciles independently against the log, which never sees the
+# ledger: 30 first attempts plus the retries, and the retries are fixed by
+# where each task resolved — 6 tasks x 1 + 1 x 2 + 7 x 3 = 29. Two counts of
+# the same thing, taken from two files, agreeing.
+#
+# An absent number stays absent. It is not zero, and it is not an estimate
+# dressed as a measurement.
+
+experiment:
+  id: "exp035_codex_foundry_full220"
+  name: "Codex command-line tool against Foundry — the whole benchmark"
+  description: >-
+    The final stage of the Codex-against-Foundry sequence: all two hundred and
+    twenty tasks in the committed catalogue, run one fresh session at a time
+    against the confirmed deployment. Nothing that touches a result changes
+    from exp034.
+  author: "Hyeonsang Jeon"
+  created_at: "2026-09-11"
+
+control:
+  fixed:
+    - model
+    - temperature
+    - self_qa
+    - execution_environment
+    # Moved here from exp034's `changed` list. Two tasks in thirty converted
+    # on their fourth attempt, so the budget is kept because it was measured.
+    - retry_budget
+  changed:
+    # The stage, and nothing else. `relay_max_runs` also rises but it cannot
+    # reach a result, so it is not listed as a variable.
+    - tasks
+
+data:
+  source: "HyeonSang/exp035_codex_foundry_full220"
+  filter:
+    sector: null
+    occupation: null
+    sample_size: null
+    # Every task id in experiments/execution_envelope/gdpval_task_catalog.json,
+    # sorted. Written out in full rather than described, so the list cannot
+    # quietly change.
+    task_ids:
+      - "0112fc9b-c3b2-4084-8993-5a4abb1f54f1"
+      - "01d7e53e-0513-4109-a242-8ccaf442cd21"
+      - "02314fc6-a24e-42f4-a8cd-362cae0f0ec1"
+      - "02aa1805-c658-4069-8a6a-02dec146063a"
+      - "0353ee0c-18b5-4ad3-88e8-e001d223e1d7"
+      - "0419f1c3-d669-45d0-81cd-f4d5923b06a5"
+      - "045aba2e-4093-42aa-ab7f-159cc538278c"
+      - "05389f78-589a-473c-a4ae-67c61050bfca"
+      - "0818571f-5ff7-4d39-9d2c-ced5ae44299e"
+      - "0e386e32-df20-4d1f-b536-7159bc409ad5"
+      - "0e4fe8cd-16d0-4f41-8247-6385b4762582"
+      - "0ec25916-1b5c-4bfe-93d3-4e103d860f3a"
+      - "0ed38524-a4ad-405f-9dee-7b2252659aad"
+      - "0fad6023-767b-42c1-a1b3-027cd4f583cb"
+      - "105f8ad0-8dd2-422f-9e88-2be5fbd2b215"
+      - "1137e2bb-bdf9-4876-b572-f29b7de5e595"
+      - "11593a50-734d-4449-b5b4-f8986a133fd8"
+      - "116e791e-890c-42b1-ba90-1db02e8bfd45"
+      - "11dcc268-cb07-4d3a-a184-c6d7a19349bc"
+      - "11e1b169-5fb6-4d79-8a83-82ddf4987a85"
+      - "15d37511-75c5-4c7f-81f1-16e00c0d95f3"
+      - "15ddd28d-8445-4baa-ac7f-f41372e1344e"
+      - "17111c03-aac7-45c2-857d-c06d8223d6ad"
+      - "1752cb53-5983-46b6-92ee-58ac85a11283"
+      - "19403010-3e5c-494e-a6d3-13594e99f6af"
+      - "1a78e076-445e-4c5d-b8ce-387d2fe5e715"
+      - "1aecc095-4d76-4b89-b752-1a0f870502cd"
+      - "1b1ade2d-f9f6-4a04-baa5-aa15012b53be"
+      - "1b9ec237-bf9c-41f9-8fa9-0e685fcd93c6"
+      - "1bff4551-1d54-4e37-b2e0-d5c3f2ea4a45"
+      - "1d4672c8-b0a7-488f-905f-9ab4e25a19f7"
+      - "1e5a1d7f-12c1-48c6-afd9-82257b3f2409"
+      - "211d0093-2c64-4bd0-828c-0201f18924e7"
+      - "22c0809b-f8db-489e-93b3-b4da225e3e0e"
+      - "24d1e93f-9018-45d4-b522-ad89dfd78079"
+      - "2696757c-1f8a-4959-8f0d-f5597b9e70fc"
+      - "27e8912c-8bd5-44ba-ad87-64066ea05264"
+      - "2c249e0f-4a8c-4f8e-b4f4-6508ba29b34f"
+      - "2d06bc0a-89c6-4e89-9417-5ffe725c1bc6"
+      - "2ea2e5b5-257f-42e6-a7dc-93763f28b19d"
+      - "2fa8e956-7b35-4c13-95dc-027f02be318b"
+      - "327fbc21-7d26-4964-bf7c-f4f41e55c54d"
+      - "3600de06-3f71-4e48-9480-e4828c579924"
+      - "36d567ba-e205-4313-9756-931c6e4691fe"
+      - "38889c3b-e3d4-49c8-816a-3cc8e5313aba"
+      - "3940b7e7-ec4f-4cea-8097-3ab4cfdcaaa6"
+      - "3a4c347c-4aec-43c7-9a54-eb1f816ab1f9"
+      - "3baa0009-5a60-4ae8-ae99-4955cb328ff3"
+      - "3c19c6d1-672c-467a-8437-6fe21afb8eae"
+      - "3f625cb2-f40e-4ead-8a97-6924356d5989"
+      - "3f821c2d-ab97-46ec-a0fb-b8f73c2682bc"
+      - "401a07f1-d57e-4bb0-889b-22de8c900f0e"
+      - "403b9234-6299-4b5f-a106-70c1bc11ec4c"
+      - "40a8c4b1-b169-4f92-a38b-7f79685037ec"
+      - "40a99a31-42d6-4f23-b3ec-8f591afe25b6"
+      - "4122f866-01fa-400b-904d-fa171cdab7c7"
+      - "41f6ef59-88c9-4b2c-bcc7-9ceb88422f48"
+      - "43dc9778-450b-4b46-b77e-b6d82b202035"
+      - "4520f882-715a-482d-8e87-1cb3cbdfe975"
+      - "45c6237b-f9c9-4526-9a8d-6a5c404624ec"
+      - "46b34f78-6c06-4416-87e2-77b6d8b20ce9"
+      - "46bc7238-3501-4839-b989-e2bd47853676"
+      - "46fc494e-a24f-45ce-b099-851d5c181fd4"
+      - "476db143-163a-4537-9e21-fe46adad703b"
+      - "47ef842d-8eac-4b90-bda8-dd934c228c96"
+      - "4b894ae3-1f23-4560-b13d-07ed1132074e"
+      - "4b98ccce-9e42-44e9-9115-6fc3e79de288"
+      - "4c18ebae-dfaa-4b76-b10c-61fcdf26734c"
+      - "4c4dc603-c21c-4284-8fb1-1b827c1fddf4"
+      - "4d1a8410-e9c5-4be5-ab43-cc55563c594c"
+      - "4d61a19a-8438-4d4c-9fc2-cf167e36dcd6"
+      - "4de6a529-4f61-41a1-b2dc-64951ba03457"
+      - "5349dd7b-bf0a-4544-9a17-75b7013767e6"
+      - "552b7dd0-96f4-437c-a749-0691e0e4b381"
+      - "55ddb773-23a4-454c-8704-d432fe1b99d9"
+      - "575f8679-b4c1-47a2-8e96-d570d4ed9269"
+      - "57b2cdf2-ad62-4591-aa91-aad489740320"
+      - "58ac1cc5-5754-4580-8c9c-8c67e1a9d619"
+      - "5a2d70da-0a42-4a6b-a3ca-763e03f070a5"
+      - "5ad0c554-a7a2-48cd-b41a-ebc1bff4a9de"
+      - "5d0feb24-e8b6-4ace-b64f-d5cd1a8b563d"
+      - "5e2b6aab-f9fb-4dd6-a1a5-874ef1743909"
+      - "5f6c57dd-feb6-4e70-b152-4969d92d1608"
+      - "60221cd0-686e-4a08-985e-d9bb2fa18501"
+      - "6074bba3-7e3a-4b1c-b8c6-a15bb6695c3b"
+      - "61717508-4df7-41be-bf97-318dfb2475c0"
+      - "61b0946a-5c1c-4bf6-8607-84d7c7e0dfe0"
+      - "61e7b9c6-0051-429f-a341-fda9b6578a84"
+      - "61f546a8-c374-467f-95cc-d0d9b5656eb6"
+      - "6241e678-4ba3-4831-b3c7-78412697febc"
+      - "62f04c2f-e0f7-4710-876c-54ee9c2e8256"
+      - "6436ff9e-c5f2-47ba-9aaa-49d89b0594ab"
+      - "650adcb1-ed19-4f88-8117-77640f7b94b6"
+      - "664a42e5-3240-413a-9a57-ea93c6303269"
+      - "68d8d901-dd0b-4a7e-bf9a-1074fddf1a96"
+      - "6974adea-8326-43fa-8187-2724b15d9546"
+      - "69a8ef86-4e69-4fe2-9168-080f1e978e67"
+      - "6a900a40-8d2b-4064-a5b1-13a60bc173d8"
+      - "6d2c8e55-fe20-45c6-bdaf-93e676868503"
+      - "6dcae3f5-bf1c-48e0-8b4b-23e6486a934c"
+      - "7151c60a-d4cb-4fc4-8169-3d4cb446e6b9"
+      - "74d6e8b0-f334-4e7e-af55-c095d5d4d1a6"
+      - "74ed1dc7-1468-48a8-9071-58775c0d667a"
+      - "75401f7c-396d-406d-b08e-938874ad1045"
+      - "76418a2c-a3c0-4894-b89d-2493369135d9"
+      - "76d10872-9ffa-4ede-83ee-e0f1ec5e2b8d"
+      - "772e7524-174e-4c88-957e-6e510b61ea69"
+      - "788d2bc6-82df-4dc7-8467-a0f31405dc14"
+      - "7b08cd4d-df60-41ae-9102-8aaa49306ba2"
+      - "7bbfcfe9-132d-4194-82bb-d6f29d001b01"
+      - "7d7fc9a7-21a7-4b83-906f-416dea5ad04f"
+      - "7de33b48-5163-4f50-b5f3-8deea8185e57"
+      - "7ed932dd-244f-4d61-bf02-1bc3bab1af14"
+      - "8077e700-2b31-402d-bd09-df4d33c39653"
+      - "8079e27d-b6f3-4f75-a9b5-db27903c798d"
+      - "81db15ff-ceea-4f63-a1cd-06dc88114709"
+      - "8314d1b1-5b0f-42a4-b5d5-91c0867b0913"
+      - "8384083a-c31b-4194-80ba-4d335a444918"
+      - "83d10b06-26d1-4636-a32c-23f92c57f30b"
+      - "84322284-5c2c-4873-b507-b147449d209d"
+      - "854f3814-681c-4950-91ac-55b0db0e3781"
+      - "85d95ce5-b20c-41e2-834e-e788ce9622b6"
+      - "87da214f-fd92-4c58-9854-f4d0d10adce0"
+      - "8a7b6fca-60cc-4ae3-b649-971753cbf8b9"
+      - "8c823e32-537c-42b2-84ba-635d63c2853a"
+      - "8c8fc328-69fc-4559-a13f-82087baef0a1"
+      - "8f9e8bcd-6102-40da-ab76-23f51d8b21fa"
+      - "90edba97-74f0-425a-8ff6-8b93182eb7cb"
+      - "90f37ff3-e4ed-4a0b-94bb-bed0f7def1ef"
+      - "91060ff0-3eb5-4ddf-9edb-f6758b95499e"
+      - "93b336f3-61f3-4287-86d2-87445e1e0f90"
+      - "94925f49-36bc-42da-b45b-61078d329300"
+      - "99ac6944-4ec6-4848-959c-a460ac705c6f"
+      - "9a0d8d36-6233-4c76-9107-0d1f783c7340"
+      - "9a8c8e28-ce76-408b-83c3-488422892e58"
+      - "9e39df84-ac57-4c9b-a2e3-12b8abf2c797"
+      - "9e8607e7-a38a-491f-ace1-e5ea7dc477cb"
+      - "9efbcd35-186d-49b6-ac24-28ee2bc9a263"
+      - "a0552909-bc66-4a3a-8970-ee0d17b49718"
+      - "a079d38f-c529-436a-beca-3e291f9e62a3"
+      - "a0ef404e-82a6-4507-bff1-633d7c8e0004"
+      - "a10ec48c-168e-476c-8fe3-23b2a5f616ac"
+      - "a1963a68-1bea-4bb1-b7e0-145c92a57449"
+      - "a328feea-47db-4856-b4be-2bdc63dd88fb"
+      - "a45bc83b-22f9-4def-8d89-9c5661b2b86f"
+      - "a46d5cd2-55fe-48fa-a4c6-6aaf6b9991b5"
+      - "a4a9195c-5ebe-4b8d-a0c2-4a6b7a49da8b"
+      - "a69be28f-9a84-47c9-992e-b90446cdca9d"
+      - "a73fbc98-90d4-4134-a54f-2b1d0c838791"
+      - "a74ead3b-f67d-4b1c-9116-f6bb81b29d4f"
+      - "a941b6d8-4289-4500-b45a-f8e4fc94a724"
+      - "a95a5829-34bb-40f3-993b-558aed6dcdef"
+      - "a97369c7-e5cf-40ca-99e8-d06f81c57d53"
+      - "a99d85fc-eff8-48d2-a7d4-42a75d62f18d"
+      - "aa071045-bcb0-4164-bb85-97245d56287e"
+      - "aad21e4c-1d43-45fc-899a-97754a1b1b63"
+      - "ab81b076-e5d8-473a-9bdb-7ea7c38f6ebc"
+      - "ae0c1093-5ea8-4b84-a81e-53ebf7a4321d"
+      - "afe56d05-dac8-47d7-a233-ad1d035ca5bd"
+      - "b1a79ce1-86b0-41fb-97dc-9206dfd7b044"
+      - "b3573f20-5d3e-4954-948f-9461fda693d2"
+      - "b39a5aa7-cd1b-47ad-b249-90afd22f8f21"
+      - "b57efde3-26d6-4742-bbff-2b63c43b4baa"
+      - "b5d2e6f1-62a2-433a-bcdd-95b260cdd860"
+      - "b78fd844-db76-448e-a783-5e9877cb74c2"
+      - "b7a5912e-0e63-41f5-8c22-9cdb8f46ab01"
+      - "b9665ca1-4da4-4ff9-86f2-40b9a8683048"
+      - "bb499d9c-0263-4684-9238-75e8e86077b1"
+      - "bb863dd9-31c2-4f64-911a-ce11f457143b"
+      - "bbe0a93b-ebf0-40b0-98dc-8d9243099034"
+      - "bd72994f-5659-4084-9fab-fc547d1efe3b"
+      - "be830ca0-b352-4658-a5bd-57139d6780ba"
+      - "bf68f2ad-eac5-490a-adec-d847eb45bd6f"
+      - "c2e8f271-7858-412f-b460-472463ad81d9"
+      - "c3525d4d-2012-45df-853e-2d2a0e902991"
+      - "c357f0e2-963d-4eb7-a6fa-3078fe55b3ba"
+      - "c44e9b62-7cd8-4f72-8ad9-f8fbddb94083"
+      - "c6269101-fdc8-4602-b345-eac7597c0c81"
+      - "c657103b-b348-4496-a848-b2b7165d28b2"
+      - "c7d83f01-2874-4876-b7fd-52582ec99e1a"
+      - "c94452e4-39cd-4846-b73a-ab75933d1ad7"
+      - "c9bf9801-9640-45fa-8166-1ab01f2d98e4"
+      - "cd9efc18-d14a-4f69-8531-5d178a08084d"
+      - "ce864f41-8584-49ba-b24f-9c9104b47bf0"
+      - "cebf301e-5ea7-41ae-b117-ad8f43e7ac22"
+      - "cecac8f9-8203-4ebd-ad49-54436a8c4171"
+      - "d025a41c-c439-4ee1-bc79-dd5c94b27a2d"
+      - "d3d255b2-f5f2-4841-9f62-2083ec9ef3da"
+      - "d4525420-a427-4ef2-b4e9-2dcc2d31b3b6"
+      - "d7cfae6f-4a82-4289-955e-c799dfe1e0f4"
+      - "dd724c67-8118-4b99-ab50-4761af705c3b"
+      - "dfb4e0cd-a0b7-454e-b943-0dd586c2764c"
+      - "e14e32ba-d310-4d45-9b8a-6d73d0ece1ae"
+      - "e21cd746-404d-4602-b9d2-01d2812c5b87"
+      - "e222075d-5d62-4757-ae3c-e34b0846583b"
+      - "e4f664ea-0e5c-4e4e-a0d3-a87a33da947a"
+      - "e6429658-4de1-42dd-a9e0-2d2b9b02fb10"
+      - "e996036e-8287-4e7f-8d0a-90a57cb53c45"
+      - "eb54f575-93f9-408b-b9e0-f1208a0b6759"
+      - "ec2fccc9-b7f6-4c73-bf51-896fdb433cec"
+      - "ec591973-04d5-48c0-981c-1ab2fcec2dc1"
+      - "ed2bc14c-99ac-4a2a-8467-482a1a5d67f3"
+      - "ee09d943-5a11-430a-b7a2-971b4e9b01b5"
+      - "ef8719da-18e5-4bfe-b986-399652d77376"
+      - "efca245f-c24f-4f75-a9d5-59201330ab7a"
+      - "f1be6436-ffff-4fee-9e66-d550291a1735"
+      - "f2986c1f-2bbf-4b83-bc93-624a9d617f45"
+      - "f3351922-dbdd-45da-85c5-e7110696bbe5"
+      - "f5d428fd-b38e-41f0-8783-35423dab80f6"
+      - "f841ddcf-2a28-4f6d-bac3-61b607219d3e"
+      - "f84ea6ac-8f9f-428c-b96c-d0884e30f7c7"
+      - "f9a1c16c-53fd-4c8f-88cc-5c325ec2f0bb"
+      - "f9f82549-fdde-4462-aff8-e70fba5b8c66"
+      - "fccaa4a1-1c39-49ac-b701-55361a19966b"
+      - "fd3ad420-6f7d-43b1-a990-c0c5c047d071"
+      - "fd6129bd-f095-429b-873c-dcc3137be2c3"
+      - "fe0d3941-e32c-4bf1-a643-b566d2b4cb3c"
+      - "feb5eefc-39f1-4451-9ef9-bffe011b71dd"
+      - "ff85ee58-bc9f-4aa2-806d-87edeabb1b81"
+      - "ffed32d8-d192-4e3f-8cd4-eda5a730aec3"
+
+condition_a:
+  name: "Codex command-line tool, Foundry deployment"
+  model:
+    provider: "azure"
+    # The deployment Codex is pointed at. `execution.codex.model` below must
+    # name the same one: `CodexAgentRunner.run` refuses a mismatch rather than
+    # calling one deployment and recording another.
+    deployment: "gpt-5.4"
+    # Codex owns the request. It sets its own sampling and does not take a
+    # temperature or a seed from here, so these are the inherited defaults and
+    # are not claims about what was sent.
+    temperature: 0.0
+    seed: 42
+    reasoning_effort: null
+  prompt:
+    # Byte-for-byte exp033's and exp034's. The whole point of a stage is that
+    # the thing being scaled up is the thing that was tried smaller, and a
+    # reworded instruction would make the prompt the variable instead of the
+    # scale.
+    system: |
+      You are completing a professional work task. You have a terminal and a
+      working directory. Do the task and leave the finished deliverables in
+      the working directory as real files.
+    prefix: null
+    body: null
+    suffix: null
+
+  # Off, for the reason exp033 gives: the reviewer would be an Azure client
+  # built here, a second sign-in beside the one Codex performs through its
+  # provider auth command, on a run whose point is that the model reaches the
+  # deployment exactly one documented way.
+  qa:
+    enabled: false
+    max_retries: 0
+    model: null
+    min_score: 6
+    prompt: ""
+
+execution:
+  mode: "codex_foundry"
+
+  codex:
+    # No address here and no variable name either. The address comes from this
+    # run's Azure route, derived by `AzureAIRouteSettings.from_env`.
+    endpoint_from_route: true
+    model: "gpt-5.4"
+    # Both 0 on purpose. Retries live in `max_retries` below, where they are
+    # counted. These two numbers are in the settings fingerprint, so the record
+    # says which run had them.
+    request_max_retries: 0
+    stream_max_retries: 0
+
+  # Wall clock for one turn. Unchanged from exp033 and exp034.
+  timeout: 1800
+  # Attempts after an infrastructure failure, per task: four at most, each a
+  # fresh session, each counted in the record. Unchanged from exp034, and now
+  # kept on evidence: 3a4c347c and 3baa0009 both converted on their fourth
+  # attempt, which is the first one that waits 240s. The model's own judgement
+  # never causes an attempt: Self-QA is off.
+  max_retries: 3
+  # Off. Two reasons, both in the header: it hands out uneven attempt counts,
+  # and it selects by status rather than by reason, so it would re-run the
+  # three tasks the provider stopped for content.
+  resume_max_rounds: 0
+  # Legs, not attempts. Leg zero plus ten relays, each running step 2 under
+  # the 290-minute watchdog: 53.2 hours against the 22.8 that exp034's
+  # measured rate predicts for 220 tasks. Ten is the ceiling — the workflow's
+  # config read refuses anything outside 0..10. This cannot change a result —
+  # a leg picks up the same task list where the last one left it. Note that
+  # the workflow has no no-progress guard, so this number is also the cost of
+  # a deployment that refuses everything.
+  #
+  # Writing this key at all means the dispatch must not pass wall_timeout=0:
+  # with the watchdog off nothing ends a leg early enough to hand over, and
+  # the workflow refuses that combination rather than discovering it at the
+  # 350-minute step cap. The dispatch input's default of 290 is what this run
+  # relies on, the same as exp034; no execution.wall_timeout is declared here.
+  relay_max_runs: 10
+
+output:
+  # Read by core/experiment_config.py into the settings fingerprint; nothing in
+  # codex_foundry mode reads it to decide an upload. This run is dispatched
+  # with dry_run: true, which is what actually skips the HuggingFace step, so
+  # the two agree.
+  publish_to_hf: false
+  submit_to_evals: false

--- a/batch-runner/tests/test_the_self_qa_comment_says_what_the_value_buys.py
+++ b/batch-runner/tests/test_the_self_qa_comment_says_what_the_value_buys.py
@@ -131,20 +131,21 @@ def test_the_corrected_comment_says_what_the_value_buys(qa_budgets):
 
 
 def test_the_silent_ones_are_still_silent(qa_budgets):
-    """Twenty say nothing, which is not a claim and so not a defect.
+    """Twenty-one say nothing, which is not a claim and so not a defect.
 
     Pinned so that a later sweep adding a comment to all of them is a visible
     decision rather than a side effect.
 
-    It was eighteen, then nineteen for exp033. exp034 is the twentieth, and it
-    is a new file for the same reason exp033 was: the thirty-task stage of the
-    same sequence, self-review off and budget zero, so there is nothing for a
-    comment to describe. The number counts files, so adding one moves it, and
-    moving it here in the same change that adds the file is the visible
-    decision this pin asks for.
+    It was eighteen, then nineteen for exp033, then twenty for exp034. exp035
+    is the twenty-first, and it is a new file for the same reason the other two
+    were: the two-hundred-and-twenty-task stage of the same sequence,
+    self-review off and budget zero, so there is nothing for a comment to
+    describe. The number counts files, so adding one moves it, and moving it
+    here in the same change that adds the file is the visible decision this pin
+    asks for.
     """
     silent = [c for _, _, v, c in qa_budgets if v <= 1 and not c.strip()]
-    assert len(silent) == 20
+    assert len(silent) == 21
 
 
 def test_the_infra_retry_comment_was_not_swept_up():


### PR DESCRIPTION
## 무엇을 하는 PR인가

220문제 전체를 Foundry 배포에 돌리는 실험 설정 파일을 추가합니다. 5문제(exp033) → 30문제(exp034) → **220문제(exp035)** 3단계의 마지막입니다. 앞 두 파일은 손대지 않습니다 — 단계는 앞 단계를 고치는 게 아니라 **각자 기록을 가진 별도 실행**이기 때문입니다.

**결과에 영향을 줄 수 있는 설정은 하나도 안 바뀝니다.** 프롬프트는 exp033과 바이트 단위로 같고, 배포·시도 횟수·자가검증 끔·resume 끔 전부 동일합니다. 220개 문제 ID는 어디서 복사한 게 아니라 **커밋된 카탈로그 파일에서 직접 읽어서** 만들었습니다(`catalog_sha256`을 파일에 적어뒀습니다). 목록이 카탈로그와 어긋날 수가 없습니다.

## exp034에서 미리 적어둔 질문 두 개에 답이 나왔고, 방향이 서로 반대입니다

**질문 1 — "네 번째 시도가 실제로 값을 했나?" → 했습니다, 두 번.**

7개 문제가 네 번째 시도까지 갔고 그중 2개가 거기서 성공했습니다 — `3a4c347c`(293,363 ms), `3baa0009`(228,568 ms). 네 번째는 **240초를 기다리는 첫 시도**입니다. 이게 없었으면 exp034 점수는 22가 아니라 **20**이었습니다.

그래서 `max_retries: 3`을 exp034의 `changed` 목록에서 `fixed` 목록으로 옮깁니다. **물려받아서가 아니라 재보고 남기는** 겁니다.

**질문 2 — "문제 설명이 짧으면 더 실패하나?" → 아닙니다. 기각.**

| | |
|---|---|
| 짧은 문제(2,000자 미만) 비율 | 30개 중 11개 = 36.7% |
| 실패 8개 중 짧은 것 | **2개** (무관하다면 2.9개 예상) · P(X≥2) = 0.854 |
| 성공/실패 설명 길이 중앙값 | 2,249.5 / 2,235.0 |

가장 **긴** 문제(6,029자, `0e4fe8cd`)가 실패했고 가장 **짧은** 문제(801자, `4520f882`)는 성공했습니다.

메커니즘도 같은 말을 합니다. 실패 8개 중 5개는 **호출 거절**이고, 거절은 모델이 글자 하나 만들기 전에 옵니다. 설명 길이가 원인일 수가 없습니다. 후보였던 건 내용 필터 3개뿐인데 3개로는 검정이 성립하지 않습니다. 이 예측은 닫습니다.

## 숫자는 요약이 아니라 원본에서 다시 뽑았습니다

실행 로그와 434 MB 산출물을 직접 열어 셌고, 그 덕에 **제 첫 초안의 오류 두 개를 잡았습니다**:

- 재시도된 문제의 회복률은 14개 중 **7개**입니다(13개가 아니라 — 동전 던지기이지 형식적 절차가 아닙니다)
- 가장 짧은 문제는 `4520f882`의 **801자**입니다(앞서 적었던 996자가 아니라)

원장도 **서로 모르는 두 파일로 교차 검증**했습니다. 원장의 호출 59번 = 로그의 첫 시도 30번 + 재시도 29번(`6×1 + 1×2 + 7×3`). 같은 것을 두 군데서 따로 세어 일치했습니다.

## 바뀌는 설정은 하나, 그리고 하마터면 낭비할 뻔했습니다

`execution.relay_max_runs: 6 → 10`. 이어달리기 구간 수일 뿐이라 시도를 늘리지도, 결과를 바꾸지도 못합니다 — 다음 주자가 앞 주자가 멈춘 자리에서 이어받습니다.

**처음엔 14로 적었습니다.** 워크플로는 **0~10만 받고, 범위 밖이면 문제를 한 개도 풀기 전에 설정 읽는 단계에서 거부**합니다. 워크플로의 검사 코드를 그대로 떼어와 로컬에서 돌려보고 10으로 고쳤습니다. 안 잡았으면 디스패치가 즉사했을 겁니다.

| | |
|---|---|
| 예상 소요 | 문제당 6.22분(30문제 실측) × 220 = **22.8시간** |
| 확보한 시간 | 11구간 × 290분 = **53.2시간** (2.3배) |
| 최악의 경우 | 465.7시간 — **어떤 설정으로도 도달 불가**. 숨기지 않고 파일에 적었습니다 |

## 파일에 함정 두 개를 적어뒀습니다

**`dry_run: true`는 "안 돌린다"는 뜻이 아닙니다.** exp034가 이 설정으로 **3시간 6분 동안 진짜 유료 호출**을 했습니다. 실제로 꺼지는 건 마지막 3단계(스키마 검증 · 결과 PR · HuggingFace 업로드)뿐이고, 그나마 **마지막 구간에서만** 해당됩니다. 추론·정리·parquet·보고서·산출물 업로드는 전부 돌아갑니다.

**이어달리기에 무진척 감지가 없습니다.** 한 구간이 0문제를 끝내도 다음 구간이 그대로 출발합니다. 고치려면 공유 워크플로 파일(`batch-run.yml`, 현재 동결)을 건드려야 해서, **고치는 대신 사람이 지켜봅니다** — 한 구간이 아무것도 못 끝내면 손으로 멈춥니다. 이건 파일에 명시했습니다.

## 내용 필터 3개는 실패로 남깁니다

문제를 바꿔 쓰지도, 목록에서 빼지도 않습니다. 220개 목록에 그대로 들어 있습니다. **점수를 올리면 그 숫자가 다른 뜻이 됩니다.**

`resume`를 끄는 진짜 이유도 여기 있습니다. `_get_failed_task_ids`가 **"왜 실패했는지"를 안 보고 상태(`error`/`qa_failed`/`pending`)만 보고** 다시 돌립니다. 켜두면 필터에 걸린 문제를 조용히 다시 풀어 점수를 올립니다. `core/experiment_config.py` 기본값이 3이라 **이 키를 그냥 빼면 그 일이 저절로 일어납니다.** 그래서 `0`을 명시적으로 적었습니다.

## 테스트

`test_the_silent_ones_are_still_silent`의 고정 숫자를 20 → 21로 올립니다. 이 pin은 "`experiments/` 아래 자가검증 주석 없는 파일 수"를 세기 때문에, **파일을 하나 추가하면 반드시 움직입니다.** 파일 추가와 같은 커밋에서 올리는 것이 이 pin이 요구하는 "눈에 보이는 결정"입니다.

전체 스위트를 돌려 **이 파일 추가로 움직이는 카운터가 이것 하나뿐임을 실증**했습니다: `1 failed, 10685 passed, 18 skipped` — 유일한 실패가 이 assert였습니다. 고친 뒤 관련 파일 4개 타겟 재실행 `272 passed`.

## 돈

이번에도 **달러 금액은 안 나옵니다.** 이 배포가 `model_price_table.json`에 없어서 원장이 `status: "partial"` / `estimated_cost_usd: null`로 남습니다. 대신 측정된 건 남습니다 — exp034 기준 호출 59번, 입력 9,308,069 토큰(캐시 7,537,280), 출력 397,131, 추론 141,341.

**없는 숫자는 없는 채로 둡니다. 0이 아니고, 측정한 척하는 추정치도 아닙니다.**

## 병합 후

`gh workflow run batch-run.yml --ref main -f experiment_yaml=exp035_codex_foundry_full220 -f codex_foundry_confirmed=true`. `wall_timeout`은 **넘기지 않습니다**(기본 290 유지 — 0을 넘기면 릴레이 가드에 걸립니다). 실행 ID는 Project #5 카드에 기록합니다.
