### PR TITLE
feat(agentic): give stage one an entry point, two amounts, and a guard

### DIFF
--- a/.github/workflows/agentic-v2-stage-a-probe.yml
+++ b/.github/workflows/agentic-v2-stage-a-probe.yml
@@ -19,11 +19,14 @@ name: Agentic Sandbox V2 — Stage A Probe
 #
 # What it does NOT do, deliberately:
 #   * It does not grade. `finalize` is not among the offered tools, so nothing
-#     here can reach the grader. Marking is about $2,504 of stage one's $2,543,
-#     and a probe that could reach it would be the stage-one run wearing a
-#     smaller name.
+#     here can reach the grader. Marking the five stage-one answers is about
+#     $2,504 against its own approved $2,600, and a probe that could reach it
+#     would be the stage-one run wearing a smaller name.
 #   * It does not run stage one. One task, not five. Stage one is a separate
-#     purchase held to its own amount, and that amount is still `null`.
+#     purchase held to its own two amounts — $50 for running and $2,600 for
+#     marking, approved on 2026-09-11 — and it goes out through
+#     `agentic-v2-stage-run.yml`, not through here. Stage A's own amount is $1
+#     and passing here grants nothing to that.
 #   * It does not open anything. `exec_run` stays shut, the V2 activation flags
 #     stay as they are, and this workflow changes no file in the repository.
 #   * It does not publish. The record leaves as an artifact, not a commit. It

--- a/.github/workflows/agentic-v2-stage-run.yml
+++ b/.github/workflows/agentic-v2-stage-run.yml
@@ -1,0 +1,290 @@
+name: Agentic Sandbox V2 — Stage Run
+
+# The only place a pre-registered V2 stage can actually be run.
+#
+# `scripts/run_agentic_v2_stage.py` puts the parts in a line and turns the
+# handle: the free check, the cohort binding, the per-task ceilings, the
+# conversation loop against a real deployment, the collected deliverables and a
+# cost receipt per task. It cannot run anywhere else. `core/azure_ai_clients.py`
+# calls `_reject_static_azure_credential_env` before it builds anything, so the
+# identity has to come from a federated OIDC session and the only place one
+# exists is a job holding `id-token: write`. A checkout has no route
+# environment at all: asked on this repository's own dev box, every one of the
+# thirteen variables the route reads is unset.
+#
+# What this is, before anyone reads a number off it. The backend is
+# `AgenticV2FixtureBackend`. The model is real, the tool choices are real, the
+# files it writes are real, and the deliverables kept at the end are the ones it
+# wrote. The isolation is not real: no guest boots and `exec_run` answers
+# `capability_unavailable` to everything. That is what the pre-registration
+# fixes for stage one, so a run that opened it would be a different experiment
+# from the one registered. `environment_note` in the runner writes the weaker
+# true sentence into the record, so it travels with the results.
+#
+# Three milestones, deliberately not merged. *The environment is ready* is not
+# *the tasks ran* is not *the results are marked*. This workflow can only reach
+# the middle one. It writes no grade, offers no `finalize` to a grader, and the
+# ledger it fills buckets everything as problem-solving cost, so marking cannot
+# be paid for out of it by accident.
+#
+# What it does NOT do:
+#   * It does not decide what a bigger cohort costs. The two approved amounts in
+#     the plan are whole-run figures for the five tasks the plan pins. The
+#     runner refuses any stage the plan has not priced, for free, in the job
+#     below — `trial_30` and `full_220` are refused today and will stay refused
+#     until somebody writes their task ids and their own two amounts down.
+#   * It does not open anything. `exec_run` stays shut and no file in the
+#     repository is changed by a run.
+#   * It does not publish. The record and the deliverables leave as artifacts,
+#     not as a commit. Nothing here reaches data/grades or the dashboard.
+#
+# A note for whoever prices `full_220`: it will not fit here. The plan fixes
+# `per_task_timeout_seconds: 1200`, so 220 tasks is up to 73 hours against a
+# GitHub job ceiling of six. The cohort needs splitting across jobs, and the
+# runner already takes `--run-id` and resumes on it. Worth settling before the
+# spend rather than after four hours of one.
+
+on:
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: >-
+          Which pre-registered cohort to run. Only the one the plan has priced
+          can start; the others are refused for free by the dry run.
+        type: choice
+        options:
+          - advance_check_5
+          - trial_30
+          - full_220
+        default: advance_check_5
+        required: true
+      mode:
+        description: >-
+          dry-run does everything except reach the network. paid runs the
+          cohort, for at most the running amount the plan approves.
+        type: choice
+        options:
+          - dry-run
+          - paid
+        default: dry-run
+        required: true
+      run_id:
+        description: >-
+          Names the journal's run and namespaces every ledger call id. Leave
+          empty for a fresh run; reuse an earlier one to resume it.
+        type: string
+        default: ''
+        required: false
+
+# A push must never be able to spend. There is no push, pull_request or
+# schedule trigger above, and adding one would be the change that let this
+# charge without anybody asking it to.
+
+permissions:
+  contents: read
+
+concurrency:
+  # One at a time, and never cancelled part-way. A run killed mid-conversation
+  # has already been charged for the turns it made and would leave no record of
+  # them, which is worse than an expensive run. Resuming is what `--run-id` is
+  # for; cancelling is not.
+  group: agentic-v2-stage-run
+  cancel-in-progress: false
+
+jobs:
+  # ── Everything except the network ───────────────────────────────────────
+  #
+  # Runs on both modes and gates the paid job. It is the whole path: the free
+  # check, the two approved amounts, the plan, the pinned dataset, the cohort
+  # seal, the pricing guard. If any of it is wrong it is wrong for free here.
+  free:
+    name: Dry run
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: batch-runner/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          pip install -r requirements.txt
+
+      # The tests that hold what a paid run rests on: that the money question
+      # is answered from the plan rather than from a sentence, that the cohort
+      # binds to the seal it was priced under, that a task stops at its own
+      # ceiling, and that the tool list cannot reach the grader. Run before the
+      # dataset is fetched, so a broken runner fails in a minute.
+      - name: Test the runner
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          python -m pytest -q \
+            tests/test_agentic_stage_one_budget.py \
+            tests/test_agentic_v2_manifest_binding.py \
+            tests/test_agentic_v2_conversation_runner.py \
+            tests/test_agentic_v2_run_driver.py \
+            tests/test_free_checks_agree_on_the_loop.py
+
+      # No charge. The revision is the one the catalogue was built from and the
+      # one every figure in the plan rests on; the binding hashes the wording it
+      # reads and refuses a prompt that drifted from what was sealed.
+      - name: Fetch the pinned dataset
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          set -euo pipefail
+          hf download openai/gdpval --repo-type dataset \
+            --revision 11e7900cdcac61bc4daf59e65feb238acda98fbf
+
+      - name: Dry run
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          python scripts/run_agentic_v2_stage.py \
+            --stage '${{ inputs.stage }}' --dry-run
+
+  # ── The run that spends ─────────────────────────────────────────────────
+  paid:
+    name: Run the cohort
+    needs: free
+    if: ${{ inputs.mode == 'paid' }}
+    runs-on: ubuntu-latest
+    # Five tasks at the plan's 1200s ceiling each, plus setup, plus room for
+    # the retry the plan allows. Deliberately not "the maximum a job can have":
+    # a stage that has run past this has hit something the ceilings did not
+    # catch, and stopping to look is the right outcome.
+    timeout-minutes: 150
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: batch-runner/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          pip install -r requirements.txt
+
+      - name: Azure Login (OIDC)
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Verify Azure OIDC session identity
+        env:
+          AZURE_AI_EXPECTED_CLIENT_ID: ${{ vars.AZURE_AI_EXPECTED_CLIENT_ID }}
+          AZURE_AI_EXPECTED_TENANT_ID: ${{ vars.AZURE_AI_EXPECTED_TENANT_ID }}
+          AZURE_AI_EXPECTED_SUBSCRIPTION_ID: ${{ vars.AZURE_AI_EXPECTED_SUBSCRIPTION_ID }}
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          python scripts/azure_oidc_identity_preflight.py --verify-session
+
+      - name: Fetch the pinned dataset
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          set -euo pipefail
+          hf download openai/gdpval --repo-type dataset \
+            --revision 11e7900cdcac61bc4daf59e65feb238acda98fbf
+
+      # Read from the plan rather than written here. The deployment appears in
+      # exactly one place in the repository, so a workflow cannot come to
+      # validate a route for one model while the runner asks another.
+      - name: Read the deployment the plan fixes
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          python - <<'PY' >> "$GITHUB_ENV"
+          import json
+          from core.agentic_v2_stage_one_budget import load_stage_one_plan
+
+          deployment = load_stage_one_plan()["model"]["deployment"]
+          print("AZURE_AI_WORKLOADS_JSON=" + json.dumps([f"inference={deployment}"]))
+          PY
+
+      # The repository's own route check, run before the runner's. A
+      # misconfigured route is caught by the code that owns routes rather than
+      # by the one script that spends money.
+      - name: Validate the Azure AI route
+        env:
+          AZURE_AI_ROUTE_PROFILE: project-ci
+          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.FOUNDRY_PROJECT_ENDPOINT }}
+          AZURE_AI_REQUIRE_EXPECTED_IDENTITIES: '1'
+          AZURE_AI_EXPECTED_DIRECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_DIRECT_ACCOUNT }}
+          AZURE_AI_EXPECTED_PROJECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_PROJECT_ACCOUNT }}
+          AZURE_AI_EXPECTED_PROJECT_NAME: ${{ vars.AZURE_AI_EXPECTED_PROJECT_NAME }}
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          python scripts/azure_ai_route_preflight.py
+
+      # `project-ci` because that is what the plan fixes, along with the account
+      # and the project. The runner checks all three against the route it was
+      # given and refuses after building the client and before asking it
+      # anything, so a misconfigured dispatch costs nothing.
+      - name: Run
+        id: run
+        env:
+          AZURE_AI_ROUTE_PROFILE: project-ci
+          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.FOUNDRY_PROJECT_ENDPOINT }}
+          AZURE_AI_REQUIRE_EXPECTED_IDENTITIES: '1'
+          AZURE_AI_EXPECTED_DIRECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_DIRECT_ACCOUNT }}
+          AZURE_AI_EXPECTED_PROJECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_PROJECT_ACCOUNT }}
+          AZURE_AI_EXPECTED_PROJECT_NAME: ${{ vars.AZURE_AI_EXPECTED_PROJECT_NAME }}
+          STAGE: ${{ inputs.stage }}
+          RUN_ID: ${{ inputs.run_id }}
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          ARGS=(--stage "$STAGE" --into "$GITHUB_WORKSPACE/agentic-v2-run")
+          if [ -n "$RUN_ID" ]; then
+            ARGS+=(--run-id "$RUN_ID")
+          fi
+          # `set +e` on purpose. A cohort where the model failed some tasks, or
+          # stopped at a ceiling, is a finding this run exists to collect --
+          # and money was spent reaching it either way. The record has to be
+          # uploaded before the exit code is allowed to end the job, so it is
+          # captured here and re-raised at the end.
+          set +e
+          python scripts/run_agentic_v2_stage.py "${ARGS[@]}"
+          echo "stage_exit=$?" >> "$GITHUB_OUTPUT"
+
+      # Before the report, and `always()`, because an unrecorded spend is the
+      # one outcome with no way back. Cost missing is partial, never zero.
+      - name: Keep the record, the journal and what was written
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: agentic-v2-${{ inputs.stage }}-run
+          path: agentic-v2-run/
+          if-no-files-found: warn
+
+      - name: Report what happened
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          STAGE_EXIT="${{ steps.run.outputs.stage_exit }}"
+          if [ -z "$STAGE_EXIT" ]; then
+            echo "The run never recorded an exit code, so nothing here can say" \
+                 "what it did. Read the artifact, and treat the run as possibly" \
+                 "charged until it says otherwise."
+            exit 1
+          fi
+          exit "$STAGE_EXIT"

--- a/.github/workflows/agentic-v2-stage-run.yml
+++ b/.github/workflows/agentic-v2-stage-run.yml
@@ -28,29 +28,48 @@ name: Agentic Sandbox V2 — Stage Run
 # be paid for out of it by accident.
 #
 # What it does NOT do:
-#   * It does not decide what a bigger cohort costs. The two approved amounts in
-#     the plan are whole-run figures for the five tasks the plan pins. The
-#     runner refuses any stage the plan has not priced, for free, in the job
-#     below — `trial_30` and `full_220` are refused today and will stay refused
-#     until somebody writes their task ids and their own two amounts down.
+#   * It does not decide what any cohort costs. Every amount lives in the plan,
+#     one per stage, and every one of them is a whole-run figure for the cohort
+#     it names — none is a rate and none prices another stage. The runner
+#     refuses a stage the plan has not priced by name, and refuses a priced
+#     stage whose cohort has grown past its amount, for free, in the job below.
 #   * It does not open anything. `exec_run` stays shut and no file in the
 #     repository is changed by a run.
 #   * It does not publish. The record and the deliverables leave as artifacts,
 #     not as a commit. Nothing here reaches data/grades or the dashboard.
+#   * It does not pay for marking. Running the thirty and the two hundred and
+#     twenty is approved; marking them is not, and the plan says why rather
+#     than leaving a blank. Finishing a cohort is one milestone and marking it
+#     is another, and the second does not follow from the first.
 #
-# A note for whoever prices `full_220`: it will not fit here. The plan fixes
-# `per_task_timeout_seconds: 1200`, so 220 tasks is up to 73 hours against a
-# GitHub job ceiling of six. The cohort needs splitting across jobs, and the
-# runner already takes `--run-id` and resumes on it. Worth settling before the
-# spend rather than after four hours of one.
+# Two sentences that used to be here were wrong by the time anybody read them,
+# and both in the same direction — they described the file as narrower than it
+# had become. One said `trial_30` and `full_220` "are refused today and will
+# stay refused until somebody writes their task ids and their own two amounts
+# down"; the amounts were written down and the sentence stayed. The other said
+# the two hundred and twenty "will not fit here" and left splitting it as a
+# note for somebody else; the split is below. Corrected in place rather than
+# deleted, because a comment that has gone stale twice is worth a reader
+# knowing about.
+#
+# How the bigger stages fit. The plan fixes `per_task_timeout_seconds: 1200`
+# and a GitHub job is killed at six hours, so at worst thirteen tasks fit in
+# one job. `scripts/plan_agentic_v2_shards.py` works out how many jobs a stage
+# needs from those two numbers -- one for the five, three for the thirty,
+# seventeen for the two hundred and twenty -- and the paid job runs them as a
+# matrix. A shard is a piece of the run, never a smaller stage: it is priced
+# against the whole cohort, so seventeen jobs that are each "within budget"
+# cannot spend seventeen times the approval, and the stage has not run until
+# every shard has and their coverage has been checked.
 
 on:
   workflow_dispatch:
     inputs:
       stage:
         description: >-
-          Which pre-registered cohort to run. Only the one the plan has priced
-          can start; the others are refused for free by the dry run.
+          Which pre-registered cohort to run. All three are priced for running.
+          A stage whose cohort costs more than its own approved amount is
+          refused for free by the dry run, before anything is reached.
         type: choice
         options:
           - advance_check_5
@@ -71,7 +90,9 @@ on:
       run_id:
         description: >-
           Names the journal's run and namespaces every ledger call id. Leave
-          empty for a fresh run; reuse an earlier one to resume it.
+          empty for a fresh run; reuse an earlier one to resume it. Each shard
+          appends its own number, so resuming a stage resumes every piece of it
+          without two jobs writing to one journal.
         type: string
         default: ''
         required: false
@@ -101,6 +122,12 @@ jobs:
     name: Dry run
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    outputs:
+      # The matrix the paid job fans out over. Worked out here rather than
+      # written into the matrix by hand, so it cannot disagree with the timeout
+      # the run is actually using: move `per_task_timeout_seconds` in the plan
+      # and the number of jobs moves with it.
+      shards: ${{ steps.shards.outputs.matrix }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
@@ -143,6 +170,20 @@ jobs:
           hf download openai/gdpval --repo-type dataset \
             --revision 11e7900cdcac61bc4daf59e65feb238acda98fbf
 
+      # Printed as well as captured. The one-line JSON is for `fromJSON`; the
+      # object beside it is for whoever has to decide whether a run that has
+      # been going for five hours is late or stuck.
+      - name: Work out how many jobs this stage needs
+        id: shards
+        env:
+          STAGE: ${{ inputs.stage }}
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          python scripts/plan_agentic_v2_shards.py --stage "$STAGE" --explain
+          MATRIX="$(python scripts/plan_agentic_v2_shards.py --stage "$STAGE")"
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
       - name: Dry run
         run: |
           set -euo pipefail
@@ -152,20 +193,50 @@ jobs:
 
   # ── The run that spends ─────────────────────────────────────────────────
   paid:
-    name: Run the cohort
+    name: Run the cohort — shard ${{ matrix.shard }}
     needs: free
     if: ${{ inputs.mode == 'paid' }}
     runs-on: ubuntu-latest
-    # Five tasks at the plan's 1200s ceiling each, plus setup, plus room for
-    # the retry the plan allows. Deliberately not "the maximum a job can have":
-    # a stage that has run past this has hit something the ceilings did not
-    # catch, and stopping to look is the right outcome.
-    timeout-minutes: 150
+    strategy:
+      # One job per piece of the cohort. For `advance_check_5` this is a matrix
+      # of one, and `--shard 1/1` is the unsharded run rather than a new code
+      # path, so the smallest stage runs exactly as it did before the matrix
+      # existed.
+      matrix:
+        shard: ${{ fromJSON(needs.free.outputs.shards) }}
+      # Never. Each of these jobs has already been charged for the turns it
+      # made, and cancelling its siblings would throw away work that was paid
+      # for because one of them hit something. A failed shard is a finding; the
+      # other sixteen are still results.
+      fail-fast: false
+      # Not about how many runners are free. It is about one deployment: the
+      # whole matrix talks to the same endpoint, and a throttled call is a call
+      # that was made. Four at a time leaves the stage finishing in five waves
+      # at worst rather than one long one, without asking the deployment for
+      # four hundred thousand tokens a minute.
+      max-parallel: 4
+    # Above the step timeout below, not equal to it. The step has to be the
+    # thing that stops first: a step that fails leaves the rest of the job to
+    # run, and the rest of the job is where the record gets uploaded. A job
+    # killed at its own limit -- or worse, at GitHub's six hour one -- can lose
+    # the artifact for a run that has already been charged for.
+    timeout-minutes: 330
     permissions:
       contents: read
       id-token: write
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      # `3/17` cannot be an artifact name and `strategy.job-index` counts from
+      # zero, which is the one thing the shard numbering deliberately does not
+      # do. Turned into `3-of-17` here so that every name a person reads --
+      # the job, the artifact, the resumed run id -- uses the same numbers.
+      - name: Name this shard
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: |
+          set -euo pipefail
+          echo "SHARD_SLUG=${SHARD//\//-of-}" >> "$GITHUB_ENV"
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -241,6 +312,13 @@ jobs:
       # anything, so a misconfigured dispatch costs nothing.
       - name: Run
         id: run
+        # Thirteen tasks is the most any shard holds, and the plan stops each
+        # one at 1200s, so the worst case inside this step is about four and a
+        # half hours. Five leaves slack for setup and the retry the plan allows
+        # while still tripping well before GitHub's own six hour kill -- which
+        # is the point, because this failing is a step failing, and the upload
+        # below still runs.
+        timeout-minutes: 300
         env:
           AZURE_AI_ROUTE_PROFILE: project-ci
           FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.FOUNDRY_PROJECT_ENDPOINT }}
@@ -250,12 +328,17 @@ jobs:
           AZURE_AI_EXPECTED_PROJECT_NAME: ${{ vars.AZURE_AI_EXPECTED_PROJECT_NAME }}
           STAGE: ${{ inputs.stage }}
           RUN_ID: ${{ inputs.run_id }}
+          SHARD: ${{ matrix.shard }}
         run: |
           set -euo pipefail
           cd batch-runner
-          ARGS=(--stage "$STAGE" --into "$GITHUB_WORKSPACE/agentic-v2-run")
+          ARGS=(--stage "$STAGE" --shard "$SHARD" \
+                --into "$GITHUB_WORKSPACE/agentic-v2-run")
           if [ -n "$RUN_ID" ]; then
-            ARGS+=(--run-id "$RUN_ID")
+            # Namespaced per shard even when a run id was given. The shards are
+            # separate journals of separate tasks, and two jobs resuming the
+            # same journal name would be two writers on one file.
+            ARGS+=(--run-id "$RUN_ID-shard-$SHARD_SLUG")
           fi
           # `set +e` on purpose. A cohort where the model failed some tasks, or
           # stopped at a ceiling, is a finding this run exists to collect --
@@ -268,23 +351,36 @@ jobs:
 
       # Before the report, and `always()`, because an unrecorded spend is the
       # one outcome with no way back. Cost missing is partial, never zero.
+      #
+      # Named per shard because artifact names have to be unique within a run,
+      # and because a directory of seventeen indistinguishable `-run` archives
+      # is not a record of anything. The name says which piece it is and of
+      # what, so a missing one is visible from the list alone.
       - name: Keep the record, the journal and what was written
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: agentic-v2-${{ inputs.stage }}-run
+          name: agentic-v2-${{ inputs.stage }}-shard-${{ env.SHARD_SLUG }}
           path: agentic-v2-run/
           if-no-files-found: warn
 
+      # This reports on one shard, and says so. A green job here means this
+      # piece finished, not that the stage ran: that sentence is only earned
+      # once every shard has reported and `coverage_problems` has been shown
+      # nothing was run twice and nothing was missed.
       - name: Report what happened
         if: ${{ always() }}
+        env:
+          SHARD: ${{ matrix.shard }}
         run: |
           set -euo pipefail
           STAGE_EXIT="${{ steps.run.outputs.stage_exit }}"
           if [ -z "$STAGE_EXIT" ]; then
-            echo "The run never recorded an exit code, so nothing here can say" \
-                 "what it did. Read the artifact, and treat the run as possibly" \
-                 "charged until it says otherwise."
+            echo "Shard $SHARD never recorded an exit code, so nothing here" \
+                 "can say what it did. Read the artifact, and treat the run as" \
+                 "possibly charged until it says otherwise."
             exit 1
           fi
+          echo "Shard $SHARD finished with $STAGE_EXIT. The stage is not" \
+               "finished until every shard has reported."
           exit "$STAGE_EXIT"

--- a/.gitignore
+++ b/.gitignore
@@ -213,6 +213,23 @@ batch-runner/scripts/*
 # needs no credential.
 !batch-runner/scripts/run_agentic_v2_stage.py
 
+# Works out how many jobs a stage has to be split across, from the plan's
+# per-task timeout and GitHub's six-hour job limit, and prints the matrix the
+# stage-run workflow fans out over. Committed because that number decides
+# whether a paid run finishes or is killed with four hours of charged
+# conversation in it, and because a matrix nobody can re-derive is a matrix
+# nobody can check. Reads two files and makes no network call.
+!batch-runner/scripts/plan_agentic_v2_shards.py
+
+# Measures the one thing standing between a stage that runs and a stage whose
+# results mean something: the reference files a task names are not yet present
+# where the model can open them. Committed because the shape of that gap -- how
+# many tasks, how many bytes, and the one file no staging can deliver under the
+# compute contract's own limits -- is what the fix gets designed against, and
+# because every figure in it has a cheap wrong answer. Reads the pinned
+# snapshot, makes no network call and spends nothing.
+!batch-runner/scripts/measure_agentic_reference_files.py
+
 
 # Experiment report HTML (skews GitHub language stats)
 batch-runner/results/*/report/report.html

--- a/.gitignore
+++ b/.gitignore
@@ -203,6 +203,16 @@ batch-runner/scripts/*
 # artifact months later as it does in CI.
 !batch-runner/scripts/build_run_record.py
 
+# The way a stage of Agentic Sandbox V2 is actually started, and the only
+# route by which stage one may spend money: it reads the plan, binds the
+# cohort, refuses a cohort the plan has not priced, and reports what was
+# running and what was marking against their own two approved amounts.
+# Committed because a run nobody else can reproduce is a run nobody else can
+# check -- the arguments that were used have to be readable from the
+# repository afterwards, not recalled. --dry-run makes no network call and
+# needs no credential.
+!batch-runner/scripts/run_agentic_v2_stage.py
+
 
 # Experiment report HTML (skews GitHub language stats)
 batch-runner/results/*/report/report.html

--- a/batch-runner/core/agentic_v2_conversation_runner.py
+++ b/batch-runner/core/agentic_v2_conversation_runner.py
@@ -124,11 +124,45 @@ class PerTaskCeilings:
         }
 
 
+def ceilings_from(plan: Mapping[str, Any], chosen: Any) -> PerTaskCeilings:
+    """What one task may spend, read off the plan and the chosen settings row.
+
+    Every field comes from something somebody wrote down. :class:`PerTaskCeilings`
+    has no defaults for exactly that reason — a ceiling nobody set is not a
+    ceiling — so a plan missing ``per_task_timeout_seconds`` raises here rather
+    than running under an invented one.
+
+    It lives beside the type rather than in the entry-point script because two
+    things need the same answer and must not be able to give different ones: the
+    runner, which enforces these ceilings, and the pre-registration, which
+    promises them before the run starts. Written twice, a correction to one is a
+    record describing a run that did not happen.
+
+    ``chosen`` is anything carrying ``tool_calls_per_attempt`` and
+    ``max_output_tokens_per_turn`` — the plan's chosen settings row, or the
+    option the free check picked.
+    """
+    fixed = dict(plan.get("fixed_settings") or {})
+    per_turn = int(chosen.max_output_tokens_per_turn)
+    calls = int(chosen.tool_calls_per_attempt)
+    return PerTaskCeilings(
+        # One model call per tool call, plus the turn that finalises.
+        max_model_turns=calls + 1,
+        max_written_tokens_per_turn=per_turn,
+        max_seconds=float(fixed["per_task_timeout_seconds"]),
+        max_model_calls=calls + 1,
+        # The loop re-sends the whole conversation every turn, so the input a
+        # run may read is quadratic in its length. Priced that way in
+        # price_the_options; bounded the same way here.
+        max_input_tokens=per_turn * (calls + 1) * (calls + 2),
+        max_output_tokens=per_turn * (calls + 1),
+        max_repeats_of_one_request=2,
+    )
+
+
 @dataclass(frozen=True)
 class RunWideCeilings:
     """What a whole run may spend, across every task and every attempt.
-
-    Separate from :class:`PerTaskCeilings` because the two answer different
     questions. A per-task ceiling stops one task from running away; this stops
     the run. ``None`` on a field means nobody set that one, and — unlike the
     per-task case — that is allowed here, because a run may legitimately be
@@ -262,9 +296,10 @@ def build_runner_factory(
     *,
     backend_factory: Callable[..., Any],
     profile: Mapping[str, Any],
-    voice: Any,
     conversations: TaskConversations,
     attempt_of: Callable[[str], int],
+    voice: Any = None,
+    voice_for: Optional[Callable[[StageOneBudget], Any]] = None,
     budget_caps: Optional[Mapping[str, Any]] = None,
     required_backend_type: type | None = None,
     cancel_requested: Optional[Callable[[], bool]] = None,
@@ -280,11 +315,30 @@ def build_runner_factory(
     The run-wide ceiling is checked here rather than inside the runner. Refusing
     at the factory means the task is never started and no guest is booted for a
     run that has already spent what it had.
+
+    **Give ``voice_for`` a real model, and ``voice`` only a scripted one.** The
+    two are not interchangeable and the difference is money. A paid voice such
+    as :class:`~core.agentic_v2_model_voice.AzureFoundryVoice` carries a
+    :class:`~core.agentic_v2_stage_one_budget.StageOneBudget` of its own and
+    refuses before the call that would pass it. This factory hands every task a
+    *fresh* budget, so one paid voice built once and reused would hold the first
+    task's budget for all 220: the early tasks would spend the whole run's
+    allowance and every later task would be refused by a ceiling that has
+    nothing to do with it. ``voice_for`` is handed each task's budget and builds
+    a voice against it, so the two limits are one object and the arithmetic is
+    the same one the ledger will settle.
+
+    A scripted voice spends nothing and has no budget to get wrong, which is why
+    ``voice`` still exists. Exactly one of the two is required — defaulting
+    either way would mean guessing, and the wrong guess is the expensive one.
     """
-    if voice is None:
+    if (voice is None) == (voice_for is None):
         raise ConversationRunnerRefused(
-            "a conversation needs a voice; there is no default model and "
-            "choosing one here would be this module deciding what a run costs"
+            "a conversation needs exactly one of voice or voice_for: there is "
+            "no default model, and choosing one here would be this module "
+            "deciding what a run costs. Pass voice_for for a paid voice, so "
+            "each task's voice is built against that task's own budget, and "
+            "voice for a scripted one, which has no budget to share"
         )
 
     def build(task: Any) -> AgenticV2ScriptedRunner:
@@ -294,10 +348,20 @@ def build_runner_factory(
         task_id = str(getattr(task, "task_id", "unknown-task"))
         attempt = int(attempt_of(task_id))
         limits = conversations.limits_for(task_id, attempt)
+        if voice_for is not None:
+            assert limits.budget is not None  # limits_for always builds one
+            speaking = voice_for(limits.budget)
+            if speaking is None:
+                raise ConversationRunnerRefused(
+                    f"voice_for returned nothing for {task_id!r}, so this task "
+                    "would have run with no way to ask a model"
+                )
+        else:
+            speaking = voice
         return AgenticV2ScriptedRunner(
             backend_factory=backend_factory,
             conversation=conversation_seam(
-                voice=voice,
+                voice=speaking,
                 limits=limits,
                 tools_available=tools_available,
                 cancel_requested=cancel_requested,

--- a/batch-runner/core/agentic_v2_preregistration.py
+++ b/batch-runner/core/agentic_v2_preregistration.py
@@ -445,6 +445,185 @@ NOT_STOP_RULES: tuple[str, ...] = (
 )
 
 
+def _what_this_is_not() -> list[str]:
+    """The disclaimers, worked out rather than typed out.
+
+    Both of the first two used to be sentences, and both went stale within a
+    day of being written. One said the blocker was a role assignment in the
+    subscription holding the model: that was the reading of a 401 which later
+    turned out to have come from *past* the authentication gate, and stage A
+    has since reached a real deployment and been charged for it. The other said
+    the amount was the owner's to fill in, and on 2026-09-11 they filled in two.
+
+    A disclaimer that outlives its fact is worse than no disclaimer, because it
+    is read as current. The one about readiness names what is still not real
+    rather than guessing at a cause, and the one about money asks
+    :func:`~core.agentic_v2_stage_one_budget.stage_one_amount_note`, so it
+    changes back by itself if the approval is ever withdrawn.
+
+    Both feed the seal, so a change here is visible as a changed seal rather
+    than as a quietly different record.
+    """
+    # Imported here rather than at module scope. The budget module reaches the
+    # readiness report, which reaches back into this area of the code; the same
+    # reason that module imports its own dependencies lazily.
+    from core.agentic_v2_stage_one_budget import stage_one_amount_note
+
+    unapproved = list(stage_one_amount_note())
+    if unapproved:
+        money = (
+            "not an approval to spend. "
+            + unapproved[0]
+            + ". The amounts live in "
+            "experiments/execution_envelope/agentic_stage_one_plan.yaml"
+        )
+    else:
+        money = (
+            "not an approval to spend more than the five-task cohort. Two "
+            "amounts are approved in "
+            "experiments/execution_envelope/agentic_stage_one_plan.yaml -- one "
+            "for running the five tasks and one for marking their answers -- "
+            "and they are whole-run figures for those five. The thirty and the "
+            "two hundred and twenty are not priced, and "
+            "scripts/run_agentic_v2_stage.py refuses them until they are"
+        )
+
+    return [
+        # Named rather than diagnosed. What is missing is the isolation, which
+        # this pre-registration itself fixes shut for stage one: a run that
+        # opened exec_run would be a different experiment from the registered
+        # one. Whether a guest could be booted at all is stage B's question and
+        # is answered there.
+        "not a statement that the environment is ready. No V2 task has run. "
+        "What stage one registers is a run with exec_run shut and no guest "
+        "booted, so the isolation is not exercised by it and no result from it "
+        "is evidence that the sandbox contains anything",
+        money,
+        "not a prediction of how the run will go",
+    ]
+
+
+def _run_conditions() -> dict[str, Any]:
+    """The conditions the run is held to, recorded before it starts.
+
+    Model, deployment and resource; the prompt's source; the tools on offer;
+    the token, time and retry ceilings. The point of pre-registering them is
+    that a run which later turns out disappointing cannot be re-described as
+    having been configured some other way.
+
+    Almost none of it is written here. It is read out of
+    ``agentic_stage_one_plan.yaml``, and that file is fingerprinted below, so a
+    settings change after this record was sealed shows up as a mismatch rather
+    than as a record quietly describing the wrong run. The one part the plan
+    does not contain is the per-task ceilings, which are arithmetic on it — and
+    those come from :func:`~core.agentic_v2_conversation_runner.ceilings_from`,
+    the same function the runner enforces them with, for the same reason.
+
+    What is deliberately *not* here: how the run is expected to go. That
+    belongs to the results, and a pre-registration that carried a prediction
+    would be an invitation to read the outcome against it.
+    """
+    # Lazily, like the money note above: the budget module reaches the
+    # readiness report, which reaches back into this module.
+    from core.agentic_v2_conversation_runner import ceilings_from
+    from core.agentic_v2_stage_one_budget import (
+        STAGE_ONE_PLAN_PATH,
+        load_stage_one_plan,
+    )
+
+    plan = load_stage_one_plan()
+    fixed = dict(plan.get("fixed_settings") or {})
+    chosen_settings = dict(plan.get("cost", {}).get("chosen_settings") or {})
+
+    class _Chosen:
+        tool_calls_per_attempt = int(chosen_settings["tool_calls_per_attempt"])
+        max_output_tokens_per_turn = int(
+            chosen_settings["max_output_tokens_per_turn"]
+        )
+
+    ceilings = ceilings_from(plan, _Chosen)
+    connection = dict(plan.get("azure_connection") or {})
+
+    return {
+        "read_from": str(STAGE_ONE_PLAN_PATH.relative_to(REPOSITORY_ROOT)),
+        # The whole settings file, fingerprinted. Every field below is a copy
+        # of something inside it, and this is what catches a copy going stale.
+        "read_from_sha256": _digest_of(STAGE_ONE_PLAN_PATH),
+        "model": {
+            "deployment": plan["model"]["deployment"],
+            "resolved_model": plan["model"]["resolved_model"],
+            # A deployment name alone does not name a model. The same name in
+            # another resource is another deployment, so the resource is part
+            # of the condition rather than context for it.
+            "account": connection.get("account"),
+            "project": connection.get("project"),
+            "route_profile": connection.get("route_profile"),
+            "automatic_model_switch_allowed": fixed.get(
+                "automatic_model_switch_allowed"
+            ),
+        },
+        "prompt": {
+            # Not reproduced. The wording is the benchmark's own, it is long,
+            # and a copy here would be a second thing to keep in step. The
+            # manifest above seals the dataset revision and the wording hash.
+            "task_wording_comes_from": "the pinned dataset revision in `manifest`",
+            "standing_instruction_length_assumed_from": (
+                plan.get("cost", {}).get("assumptions_come_from")
+            ),
+            "self_review_enabled": fixed.get("self_review_enabled"),
+        },
+        "tools": {
+            # All eight, which is what the model really sees: nothing in the
+            # stage run narrows `tools_available`, and its default is the whole
+            # contract. Listing seven here would have been a nicer-sounding
+            # description of a run that does not happen.
+            "offered": list(TOOL_NAMES),
+            # Offered and shut are not the same thing, and the difference is
+            # the point. exec_run is in the list above, the model may choose
+            # it, and what comes back is `capability_unavailable`. How a model
+            # reacts to a refused capability is a finding this run can collect;
+            # a model that never saw the tool could produce no such finding.
+            "offered_but_refuses_everything": ["exec_run"],
+            "exec_run_open": fixed.get("exec_run_open"),
+            "comes_from": "core/agentic_v2_contract.py TOOL_NAMES",
+            "narrowed_by_the_run": False,
+        },
+        "per_task_ceilings": ceilings.as_dict(),
+        "how_the_ceilings_were_derived": {
+            "chosen_settings": chosen_settings,
+            "turns": "one model call per tool call, plus the turn that finalises",
+            "input_tokens": (
+                "quadratic in the number of turns, because the loop re-sends "
+                "the whole conversation every turn"
+            ),
+            "seconds": "per_task_timeout_seconds, straight from the plan",
+            "comes_from": "core/agentic_v2_conversation_runner.py ceilings_from",
+        },
+        "retry": {
+            "max_attempts": fixed.get("retry_max_attempts"),
+            "reasons_allowed": list(fixed.get("retry_reasons_allowed") or []),
+            # Three kinds, kept apart in the record. An infrastructure retry is
+            # the environment's fault and a task that needed several says
+            # something about the environment rather than about the model; a
+            # semantic one is the model changing its mind, which is the thing
+            # being measured; an internal one is the client library's own,
+            # below the level either of those is about. Collapsed into one
+            # count, a flaky endpoint reads as an indecisive model.
+            "kinds_recorded_separately": [
+                "infrastructure",
+                "semantic",
+                "internal",
+            ],
+            "max_repeats_of_one_request": ceilings.max_repeats_of_one_request,
+        },
+        "what_stops_a_task": (
+            "any per-task ceiling above, or the per-task budget, whichever "
+            "comes first. A task stopped by a ceiling is recorded as stopped "
+            "by that ceiling and is not a model failure"
+        ),
+    }
+
+
 def record(catalog: TaskCatalog | None = None) -> dict[str, Any]:
     """The whole pre-registration, as it is committed before anything runs."""
     comparisons = compare_with_codex_run()
@@ -457,6 +636,7 @@ def record(catalog: TaskCatalog | None = None) -> dict[str, Any]:
         ),
         "escalation": list(ESCALATION),
         "manifest": manifest(catalog),
+        "run_conditions": _run_conditions(),
         "comparison_with_codex": {
             "source": str(CODEX_TRIAL_PLAN.relative_to(REPOSITORY_ROOT)),
             # The basis of the comparison, fingerprinted. If A's file moves, the
@@ -479,15 +659,7 @@ def record(catalog: TaskCatalog | None = None) -> dict[str, Any]:
         },
         "stop_rules": list(STOP_RULES),
         "not_stop_rules": list(NOT_STOP_RULES),
-        "what_this_is_not": [
-            "not a statement that the environment is ready -- at the time of "
-            "writing no V2 task has run, and the blocker is a role assignment "
-            "in the subscription that holds the model",
-            "not an approval to spend; the amount lives in "
-            "experiments/execution_envelope/agentic_stage_one_plan.yaml and is "
-            "the owner's to fill in",
-            "not a prediction of how the run will go",
-        ],
+        "what_this_is_not": _what_this_is_not(),
     }
     body["seal"] = seal(body)
     return body

--- a/batch-runner/core/agentic_v2_route_check.py
+++ b/batch-runner/core/agentic_v2_route_check.py
@@ -1,0 +1,79 @@
+"""Whether the route a client resolved is the one the plan approved.
+
+Moved out of ``scripts/run_agentic_stage_a_probe.py`` unchanged, because a
+second caller arrived. Stage A asks one task and a stage run asks up to 220, and
+the question they both have to answer first is identical: *did the client that
+was just built reach the account, project and profile the plan fixed?* Two
+copies of that check would be two things to keep right, and the copy that
+drifted would be the one guarding the larger spend.
+
+Nothing here builds a client, reads the environment or spends anything. It is
+handed a resolved route and the plan's own ``azure_connection`` block and
+returns the ways they disagree.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+def check_route_is_the_one_the_plan_fixed(
+    route: Any,
+    connection: Mapping[str, Any],
+    *,
+    settings: Any = None,
+) -> list[str]:
+    """Every way the resolved route could differ from what was approved.
+
+    The plan fixes an account, a project and a route profile. A run that
+    reached a real model over some other route would have proved something
+    about a different environment than the one stage one is being priced for,
+    and it would have cost the same to prove it. Checked after the client is
+    built, because until then the route is a request rather than a fact.
+
+    All three collected rather than the first returned, so a reader fixing a
+    misconfigured dispatch sees the whole of it at once.
+
+    The project needs its own paragraph, because the route selected for
+    inference under ``project-ci`` does not carry one. That profile derives an
+    account-scoped ``direct-v1`` URL from the configured project endpoint and
+    sends inference over it, so the selected endpoint has an account and a
+    ``project`` of ``None`` — while the project it was derived from is still
+    the fact being checked. Where it is, the project endpoint says so, and that
+    is read here rather than assumed away. If neither the selection nor the
+    settings names a project, the run is refused: an unconfirmable project is
+    the case a silent skip would hide.
+    """
+    problems: list[str] = []
+    account = str(connection.get("account") or "")
+    project = connection.get("project")
+    profile = connection.get("route_profile")
+
+    if account and route.endpoint.account != account:
+        problems.append(
+            f"the route resolves to account {route.endpoint.account!r}, but "
+            f"the plan fixes {account!r}"
+        )
+    if project:
+        configured = getattr(getattr(settings, "project", None), "project", None)
+        found = route.endpoint.project or configured
+        if found is None:
+            problems.append(
+                f"the plan fixes project {project!r}, but neither the route "
+                "that was selected nor the endpoints it was built from names "
+                "a project, so there is nothing to check it against"
+            )
+        elif found != project:
+            problems.append(
+                f"the route resolves to project {found!r}, but the plan "
+                f"fixes {project!r}"
+            )
+    if profile and str(route.profile.value) != str(profile):
+        problems.append(
+            f"the route profile is {route.profile.value!r}, but the plan "
+            f"fixes {profile!r}"
+        )
+    return problems
+
+
+__all__ = ["check_route_is_the_one_the_plan_fixed"]

--- a/batch-runner/core/agentic_v2_sharding.py
+++ b/batch-runner/core/agentic_v2_sharding.py
@@ -1,0 +1,228 @@
+"""Splitting one stage across several runs, without losing what the stage was.
+
+A stage is a fixed cohort: five tasks, thirty, or two hundred and twenty. The
+cohort is sealed before the run, and the seal is what lets a result be quoted as
+*this* experiment rather than some tasks that happened to be handy. Nothing here
+touches that. What it does is let the cohort be *run* in pieces, because one
+piece is all that fits in the place the paid run has to happen.
+
+**Why pieces are necessary.** The plan fixes ``per_task_timeout_seconds: 1200``,
+so a task may take twenty minutes. A GitHub Actions job is killed at six hours.
+That is eighteen tasks in the very worst case, and the worst case is the only one
+a limit may be designed against — thirty tasks is already ten hours and the full
+two hundred and twenty is over seventy-three. So the choice is not between one
+job and several; it is between several jobs and a stage that cannot be run at
+all beyond the first five.
+
+**Why the split is by stride and not by block.** ``task_ids[i::n]`` deals the
+cohort out like cards. A block split — first eleven, next eleven — would hand one
+shard a run of neighbouring tasks, and the cohort is ordered by a selection rule
+that groups related work together. If a block shard is lost, what is missing from
+the partial result is *all of one kind of work*; if a stride shard is lost, what
+is missing is a thin slice of every kind. Both lose the same number of tasks. Only
+one of them lets the remainder still be described.
+
+**What a shard is not.** It is not a smaller stage. A run of one shard has not run
+the stage, and :meth:`Shard.as_dict` says so in the record rather than leaving the
+reader to work it out from a count. :func:`coverage_problems` is how a set of
+finished shards earns the sentence "the stage ran" — by showing that every task
+was covered exactly once, not by adding up how many each shard reported.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Sequence
+
+
+class ShardRefused(ValueError):
+    """Raised for a split that would not mean what it says."""
+
+
+@dataclass(frozen=True)
+class Shard:
+    """One piece of a cohort, and the whole it is a piece of.
+
+    Carries ``cohort_size`` rather than only its own tasks, because a record
+    holding twelve task ids and no denominator is indistinguishable from a
+    twelve-task experiment.
+    """
+
+    index: int
+    """Which piece, counted from one.
+
+    From one rather than from zero because this number is written by a person
+    into a workflow input and read by a person out of a run record, and "shard 0
+    of 20" is read as *none of them* about as often as it is read correctly.
+    """
+
+    of: int
+    task_ids: tuple[str, ...]
+    cohort_size: int
+
+    @property
+    def covers_whole_stage(self) -> bool:
+        return self.of == 1
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "index": self.index,
+            "of": self.of,
+            "task_count": len(self.task_ids),
+            "cohort_size": self.cohort_size,
+            "task_ids": list(self.task_ids),
+            "covers_whole_stage": self.covers_whole_stage,
+            "what_this_run_is": (
+                "the whole stage, in one run"
+                if self.covers_whole_stage
+                else (
+                    f"{len(self.task_ids)} of the {self.cohort_size} tasks in "
+                    f"this stage. The stage has not run until all {self.of} "
+                    "shards have, and their coverage has been checked"
+                )
+            ),
+        }
+
+
+def split(task_ids: Sequence[str], of: int) -> tuple[tuple[str, ...], ...]:
+    """Deal the cohort into ``of`` piles, one card at a time.
+
+    Every task lands in exactly one pile and the order inside a pile follows the
+    cohort's own order, so a shard is reproducible from the cohort and its two
+    numbers alone — nothing about the split is stored anywhere or has to be.
+    """
+    if of < 1:
+        raise ShardRefused("a cohort cannot be split into fewer than one piece")
+    if of > len(task_ids):
+        raise ShardRefused(
+            f"{len(task_ids)} tasks cannot be split into {of} pieces without "
+            "leaving some piece empty, and an empty run that reports success "
+            "is worse than one that refuses to start"
+        )
+    return tuple(tuple(task_ids[start::of]) for start in range(of))
+
+
+def shard_of(task_ids: Sequence[str], index: int, of: int) -> Shard:
+    """The one piece this run is responsible for."""
+    if index < 1 or index > of:
+        raise ShardRefused(
+            f"shard {index} of {of} does not exist; shards are numbered 1 to {of}"
+        )
+    return Shard(
+        index=index,
+        of=of,
+        task_ids=split(task_ids, of)[index - 1],
+        cohort_size=len(task_ids),
+    )
+
+
+def parse(text: str | None, task_ids: Sequence[str]) -> Shard | None:
+    """``"3/20"`` as a shard of this cohort, or ``None`` for the whole of it.
+
+    ``None`` rather than a one-of-one shard for the unsharded case, so a caller
+    that forgot to handle sharding at all behaves exactly as it did before this
+    module existed instead of picking up a new code path by default.
+    """
+    if text is None or text.strip() in {"", "all", "1/1"}:
+        return None
+    try:
+        left, right = text.split("/", 1)
+        index, of = int(left.strip()), int(right.strip())
+    except ValueError as error:
+        raise ShardRefused(
+            f"{text!r} is not a shard. Write it as index/total, like 3/20"
+        ) from error
+    if of == 1:
+        return None
+    return shard_of(task_ids, index, of)
+
+
+def how_many_shards_fit(
+    *,
+    cohort_size: int,
+    per_task_timeout_seconds: float,
+    job_limit_seconds: float,
+    margin: float = 0.75,
+) -> int:
+    """The fewest pieces that fit the worst case inside the job limit.
+
+    ``margin`` is not timidity. A job spends time before the first task —
+    checkout, a Python install, the dataset download — and a run that is killed
+    at the limit loses the task it was in the middle of, which is the one thing a
+    resume cannot recover cheaply. Three quarters leaves room for both.
+
+    Worst case throughout: every task is assumed to run to its timeout. Most will
+    not, and sizing against what most tasks do is how a run gets killed at hour
+    six with nothing collected.
+    """
+    if cohort_size < 1:
+        raise ShardRefused("a cohort with no tasks needs no shards")
+    usable = job_limit_seconds * margin
+    if usable < per_task_timeout_seconds:
+        raise ShardRefused(
+            f"one task may take {per_task_timeout_seconds:.0f}s and a job has "
+            f"{usable:.0f}s of usable time, so no split makes this fit"
+        )
+    per_shard = int(usable // per_task_timeout_seconds)
+    return -(-cohort_size // per_shard)
+
+
+def coverage_problems(
+    shards: Iterable[Shard], *, task_ids: Sequence[str]
+) -> list[str]:
+    """Every reason a set of finished shards is not the whole stage.
+
+    The question this answers is the one that decides whether the results may be
+    described as the stage's results. Counting is not enough: twenty shards that
+    each ran twelve tasks could still have run one task twice and missed another,
+    and the total would look right.
+    """
+    shards = list(shards)
+    problems: list[str] = []
+    if not shards:
+        return ["no shard ran, so the stage did not run"]
+
+    totals = {shard.of for shard in shards}
+    if len(totals) > 1:
+        problems.append(
+            f"the shards disagree about how many there are ({sorted(totals)}), "
+            "so they are pieces of different splits and cannot be added up"
+        )
+        return problems
+
+    of = totals.pop()
+    missing_indices = sorted(set(range(1, of + 1)) - {shard.index for shard in shards})
+    if missing_indices:
+        problems.append(
+            f"{len(missing_indices)} of {of} shards did not run: "
+            + ", ".join(str(index) for index in missing_indices)
+        )
+
+    seen: dict[str, int] = {}
+    for shard in shards:
+        for task_id in shard.task_ids:
+            seen[task_id] = seen.get(task_id, 0) + 1
+
+    twice = sorted(task_id for task_id, count in seen.items() if count > 1)
+    if twice:
+        problems.append(
+            f"{len(twice)} tasks were covered by more than one shard, so they "
+            f"were paid for twice: {', '.join(twice[:3])}"
+            + (" and others" if len(twice) > 3 else "")
+        )
+
+    never = sorted(set(task_ids) - set(seen))
+    if never:
+        problems.append(
+            f"{len(never)} of the {len(task_ids)} tasks in this stage were "
+            f"covered by no shard: {', '.join(never[:3])}"
+            + (" and others" if len(never) > 3 else "")
+        )
+
+    stranger = sorted(set(seen) - set(task_ids))
+    if stranger:
+        problems.append(
+            f"{len(stranger)} tasks were run that are not in this stage: "
+            + ", ".join(stranger[:3])
+        )
+    return problems

--- a/batch-runner/core/agentic_v2_stage_one_budget.py
+++ b/batch-runner/core/agentic_v2_stage_one_budget.py
@@ -481,6 +481,45 @@ def _money(value: Decimal) -> str:
     return str(value.quantize(Decimal("0.01"), rounding=ROUND_CEILING))
 
 
+def _approved_amount(
+    raw: Any,
+    problems: list[str],
+    *,
+    what: str,
+    key: str,
+) -> Decimal | None:
+    """One written-down amount, or every reason it is not one.
+
+    Returns ``None`` both when nobody wrote a figure and when what they wrote
+    is not usable. That is deliberate: a caller that compared a ceiling against
+    an unusable amount would either wave the run through or refuse it for the
+    wrong reason, and the reason is already in ``problems`` either way.
+    """
+    if raw is None:
+        problems.append(
+            f"nobody has written down the largest amount that may be spent on "
+            f"{what}. The 32.23 United States dollars approved for the "
+            "three-place comparison was for that comparison and does not "
+            f"extend here. Write it in {key}"
+        )
+        return None
+    try:
+        amount = Decimal(str(raw))
+    except Exception:
+        problems.append(
+            f"the largest amount that may be spent on {what}, {raw!r}, is not "
+            "a number"
+        )
+        return None
+    if amount <= 0:
+        problems.append(
+            f"the largest amount that may be spent on {what} must be greater "
+            "than zero"
+        )
+        return None
+    return amount
+
+
 def price_the_options(
     *,
     base: StageOneConditions,
@@ -569,7 +608,32 @@ class StageOnePreflight:
     that would actually stop a run, rather than only the amount.
     """
 
-    approved_maximum_usd: Decimal | None = None
+    running_approved_maximum_usd: Decimal | None = None
+    """The largest amount that may be spent *running* the five tasks.
+
+    Separate from the marking figure below, and the separation is not
+    bookkeeping tidiness. At the committed assumptions, marking is a flat
+    2,504.67 United States dollars whatever the settings are, while running
+    ranges from 3.37 to 493.70 across the candidate rows. Held as one number,
+    the decision an approver is actually making — which settings buy an answer
+    worth having — is under one per cent of the figure they sign, and a
+    hundredfold change in it moves the total by a rounding error. Two numbers,
+    each compared against its own ceiling, put the figure that moves in front
+    of the person deciding.
+
+    It is also what step four of the run instructions requires: marking cost is
+    kept apart from problem-solving cost, and an approval that silently covered
+    both would be the place that stopped being true first.
+    """
+
+    grading_approved_maximum_usd: Decimal | None = None
+    """The largest amount that may be spent *marking* the five answers.
+
+    Written down here rather than left to the marking run, because the plan is
+    where the whole of stage one is priced, and a stage whose marking cost
+    nobody approved is a stage that is half-approved.
+    """
+
     dispatcher_limits: DispatcherLimits | None = None
     probe: "StageAProbePreflight | None" = None
     """Stage A's separate verdict, on the one paid question that comes first.
@@ -590,9 +654,14 @@ class StageOnePreflight:
                 task_id: budget.as_dict()
                 for task_id, budget in self.chosen_budget.items()
             },
-            "approved_maximum_usd": (
-                _money(self.approved_maximum_usd)
-                if self.approved_maximum_usd is not None
+            "running_approved_maximum_usd": (
+                _money(self.running_approved_maximum_usd)
+                if self.running_approved_maximum_usd is not None
+                else None
+            ),
+            "grading_approved_maximum_usd": (
+                _money(self.grading_approved_maximum_usd)
+                if self.grading_approved_maximum_usd is not None
                 else None
             ),
             "dispatcher_limits": (
@@ -684,8 +753,9 @@ def load_stage_one_plan(path: Any = None) -> dict:
     return raw
 
 
-#: What a clean safety check reports when nobody has approved anything for the
-#: five-task run: not a finding, a standing fact about where stage one stands.
+#: What the safety check reports while nobody has approved anything for the
+#: five-task run. Whether that is the case today is read from the plan by
+#: :func:`stage_one_amount_note`; this is only the wording.
 STAGE_ONE_HAS_NO_APPROVED_AMOUNT = (
     "stage one cannot start because no amount has been approved for it. A "
     "real model can now be reached — core.agentic_v2_model_voice."
@@ -725,13 +795,15 @@ def check_stage_one_cannot_reach_a_model(
 
     A comment could claim either refusal and be wrong, so both are exercised.
 
-    ``include_amount_note`` decides whether a clean result is reported as a
-    problem. It is one by default, because a caller asking this on its own is
-    asking "may stage one go", and the answer is no while no amount is on
-    record. A caller that decides about amounts itself — the preflight, which
-    reaches a separate verdict for stage A on a separate amount — asks for the
-    safety findings alone, so that stage one's missing amount is not made into
-    a reason stage A cannot proceed.
+    ``include_amount_note`` decides whether the amount question is answered at
+    all. It is by default, because a caller asking this on its own is asking
+    "may stage one go", and until an amount is on record the answer is no
+    whatever the code does. Whether one *is* on record is read from the plan by
+    :func:`stage_one_amount_note` rather than assumed, so this stopped saying
+    no the day the amounts were written down. A caller that decides about
+    amounts itself — the preflight, which reaches a separate verdict for stage
+    A on a separate amount — asks for the safety findings alone, so that stage
+    one's money question is not made into a reason stage A cannot proceed.
     """
     import inspect
 
@@ -859,7 +931,51 @@ def check_stage_one_cannot_reach_a_model(
 
     if problems:
         return problems
-    return [STAGE_ONE_HAS_NO_APPROVED_AMOUNT] if include_amount_note else []
+    if not include_amount_note:
+        return []
+    return stage_one_amount_note()
+
+
+#: The two figures that together approve stage one. Both, or neither: an
+#: approval for the running half is not an approval to mark the answers, and
+#: marking is where nearly all of the money is.
+STAGE_ONE_APPROVAL_KEYS = (
+    "running_approved_maximum_usd",
+    "grading_approved_maximum_usd",
+)
+
+
+def stage_one_amount_note(plan_path: Any = None) -> list[str]:
+    """Whether an amount is on record for the five-task run.
+
+    Read from the plan rather than stated, which is the whole of the change
+    made here on 2026-09-11. This used to return a constant sentence saying no
+    amount had been approved — true when it was written, and it would have gone
+    on being printed as a blocker by
+    :mod:`core.execution_environment_readiness` for as long as nobody noticed,
+    including after the amounts were written down.
+
+    Deliberately narrow. This answers *is a figure on record*, not *does it
+    cover the settings chosen*. The second question is
+    :func:`run_stage_one_preflight`, which cannot be asked from here without
+    circling back into this function, and which is the thing a caller should
+    ask if it wants a verdict rather than a blocker.
+    """
+    try:
+        cost = load_stage_one_plan(plan_path).get("cost") or {}
+    except Exception as error:
+        return [
+            "whether an amount has been approved for stage one could not be "
+            "read from the plan, so it has to be treated as unapproved: "
+            f"{type(error).__name__}: {error}"
+        ]
+    missing = [key for key in STAGE_ONE_APPROVAL_KEYS if cost.get(key) is None]
+    if not missing:
+        return []
+    return [
+        f"{STAGE_ONE_HAS_NO_APPROVED_AMOUNT}. Missing: "
+        + ", ".join(f"cost.{key}" for key in missing)
+    ]
 
 
 def check_stage_a_probe(
@@ -1209,35 +1325,52 @@ def run_stage_one_preflight(
                 for task_id in task_ids
             }
 
-    approved_raw = cost.get("approved_maximum_usd")
-    approved: Decimal | None = None
-    if approved_raw is None:
+    # Running and marking are approved separately, and a plan naming one figure
+    # for both is refused rather than reinterpreted. The old key meant "the
+    # total", so silently reading it as either half would take an approval
+    # somebody gave for 2,543 dollars and apply it to a number that is not the
+    # one they were shown.
+    if "approved_maximum_usd" in cost:
         problems.append(
-            "nobody has written down the largest amount that may be spent on "
-            "stage one. The 32.23 United States dollars approved for the "
-            "three-place comparison was for that comparison and does not "
-            "extend here"
+            "cost.approved_maximum_usd is one figure covering both running "
+            "and marking. Stage one now approves them separately, because "
+            "marking is a flat amount the settings do not change and running "
+            "is the part the decision is about. Replace it with "
+            "cost.running_approved_maximum_usd and "
+            "cost.grading_approved_maximum_usd"
         )
-    else:
-        try:
-            approved = Decimal(str(approved_raw))
-        except Exception:
-            problems.append(
-                f"the largest amount that may be spent, {approved_raw!r}, is "
-                "not a number"
-            )
-        else:
-            if approved <= 0:
+
+    running_approved = _approved_amount(
+        cost.get("running_approved_maximum_usd"),
+        problems,
+        what="running stage one's five tasks",
+        key="cost.running_approved_maximum_usd",
+    )
+    grading_approved = _approved_amount(
+        cost.get("grading_approved_maximum_usd"),
+        problems,
+        what="marking stage one's five answers",
+        key="cost.grading_approved_maximum_usd",
+    )
+
+    if chosen is not None:
+        for amount, ceiling, what in (
+            (
+                running_approved,
+                chosen.most_running_could_cost_usd,
+                "running the five tasks",
+            ),
+            (
+                grading_approved,
+                chosen.most_grading_could_cost_usd,
+                "marking the five answers",
+            ),
+        ):
+            if amount is not None and ceiling > amount:
                 problems.append(
-                    "the largest amount that may be spent must be greater "
-                    "than zero"
-                )
-            elif chosen is not None and chosen.most_it_could_cost_usd > approved:
-                problems.append(
-                    "the most the chosen settings could cost, "
-                    f"{_money(chosen.most_it_could_cost_usd)} United States "
-                    f"dollars, is above the {_money(approved)} that was "
-                    "approved"
+                    f"the most {what} could cost, {_money(ceiling)} United "
+                    f"States dollars, is above the {_money(amount)} that was "
+                    "approved for it"
                 )
 
     probe = check_stage_a_probe(
@@ -1255,7 +1388,8 @@ def run_stage_one_preflight(
         options=options,
         chosen=chosen,
         chosen_budget=chosen_budget,
-        approved_maximum_usd=approved,
+        running_approved_maximum_usd=running_approved,
+        grading_approved_maximum_usd=grading_approved,
         dispatcher_limits=dispatcher_limits,
         probe=probe,
     )
@@ -1301,8 +1435,29 @@ def describe_stage_one_preflight(result: StageOnePreflight) -> list[str]:
         lines.append(
             f"Chosen: {result.chosen.tool_calls_per_attempt} tool calls, "
             f"{result.chosen.max_output_tokens_per_turn} tokens per turn, at "
-            f"most ${written['most_it_could_cost_usd']} in total"
+            f"most ${written['most_running_could_cost_usd']} to run and "
+            f"${written['most_grading_could_cost_usd']} to mark"
         )
+        for label, amount, ceiling in (
+            (
+                "running",
+                result.running_approved_maximum_usd,
+                result.chosen.most_running_could_cost_usd,
+            ),
+            (
+                "marking",
+                result.grading_approved_maximum_usd,
+                result.chosen.most_grading_could_cost_usd,
+            ),
+        ):
+            lines.append(
+                f"  {label}: at most ${_money(ceiling)} against "
+                + (
+                    f"${_money(amount)} approved"
+                    if amount is not None
+                    else "nothing approved"
+                )
+            )
         if result.chosen_budget:
             lines.append("")
             lines.append(

--- a/batch-runner/core/agentic_v2_stage_one_budget.py
+++ b/batch-runner/core/agentic_v2_stage_one_budget.py
@@ -1536,3 +1536,221 @@ def describe_stage_a_probe(probe: StageAProbePreflight) -> list[str]:
             "one, which is a separate purchase held to its own amount."
         )
     return lines
+
+
+# ── Pricing a stage other than the five ────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class StagePricing:
+    """Whether one named stage may run, and against what amount.
+
+    Separate from :class:`StageOnePreflight` because it asks a different
+    question. The preflight asks whether stage one is *safe* to start — the
+    blocks, the model, the settings, the figures for the five tasks the plan
+    pins. This asks only whether the cohort actually about to run has an
+    approved amount that covers it. A stage can pass every safety check and
+    still be unpriced, which is exactly the state the thirty- and
+    two-hundred-and-twenty-task stages were in until they were priced by name.
+    """
+
+    stage: str
+    task_count: int
+    approved_running_usd: Decimal | None
+    approved_grading_usd: Decimal | None
+    grading_not_approved_because: str | None
+    most_running_could_cost_usd: Decimal | None
+    problems: tuple[str, ...]
+
+    @property
+    def may_run(self) -> bool:
+        return not self.problems
+
+    @property
+    def headroom_usd(self) -> Decimal | None:
+        if self.approved_running_usd is None or self.most_running_could_cost_usd is None:
+            return None
+        return self.approved_running_usd - self.most_running_could_cost_usd
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "stage": self.stage,
+            "task_count": self.task_count,
+            "approved_running_usd": (
+                _money(self.approved_running_usd)
+                if self.approved_running_usd is not None
+                else None
+            ),
+            "approved_grading_usd": (
+                _money(self.approved_grading_usd)
+                if self.approved_grading_usd is not None
+                else None
+            ),
+            "grading_not_approved_because": self.grading_not_approved_because,
+            "most_running_could_cost_usd": (
+                _money(self.most_running_could_cost_usd)
+                if self.most_running_could_cost_usd is not None
+                else None
+            ),
+            "may_run": self.may_run,
+            "problems": list(self.problems),
+        }
+
+
+def price_one_stage(
+    plan: Mapping[str, Any],
+    *,
+    stage: str,
+    task_ids: Sequence[str],
+    tasks_by_id: Mapping[str, CatalogTask],
+    assumptions: CostAssumptions,
+    limits: DispatcherLimits | None = None,
+    prices: Mapping[str, ModelPrice] | None = None,
+) -> StagePricing:
+    """What this cohort could cost, against what this stage may spend.
+
+    ``task_ids`` comes from the caller rather than from the plan, and that is
+    the point. The plan holds amounts; the sealed catalogue holds tasks. Pricing
+    the amounts against the cohort that is really about to run is what catches
+    the mistake this function exists for — an approval worked out for five tasks
+    being spent on two hundred and twenty, with the printed line saying it was
+    within budget because the arithmetic behind that line never saw the larger
+    cohort.
+
+    The figure compared is the same one ``scripts/check_agentic_stage_one_ceiling``
+    prints, safety multiplier included, worked out through
+    :func:`price_the_options` rather than beside it. A second route to the same
+    number is a second number waiting to disagree.
+    """
+    problems: list[str] = []
+    table = dict(plan.get("stages") or {})
+    if not table:
+        return StagePricing(
+            stage=stage,
+            task_count=len(task_ids),
+            approved_running_usd=None,
+            approved_grading_usd=None,
+            grading_not_approved_because=None,
+            most_running_could_cost_usd=None,
+            problems=(
+                "the plan has no `stages` block, so no stage is priced by name "
+                "and there is nothing to check this run against",
+            ),
+        )
+
+    block = table.get(stage)
+    if block is None:
+        return StagePricing(
+            stage=stage,
+            task_count=len(task_ids),
+            approved_running_usd=None,
+            approved_grading_usd=None,
+            grading_not_approved_because=None,
+            most_running_could_cost_usd=None,
+            problems=(
+                f"the plan prices {sorted(table)} and says nothing about "
+                f"{stage!r}. An amount approved for one cohort is not an "
+                "amount approved for another, whatever their relative sizes: "
+                "every figure in this plan is a whole-run figure, not a rate. "
+                f"Add a `stages.{stage}` entry before running it",
+            ),
+        )
+
+    approved_running = _approved_amount(
+        block.get("running_approved_maximum_usd"),
+        problems,
+        what=f"running the {stage} stage",
+        key=f"stages.{stage}.running_approved_maximum_usd",
+    )
+
+    # Absent and null are different answers, and only one of them is a mistake.
+    # A stage that has thought about marking and decided against it says so with
+    # a reason; a stage that never considered it has neither key.
+    raw_grading = block.get("grading_approved_maximum_usd")
+    refusal = block.get("grading_not_approved_because")
+    approved_grading: Decimal | None = None
+    if raw_grading is not None:
+        approved_grading = _approved_amount(
+            raw_grading,
+            problems,
+            what=f"marking the {stage} answers",
+            key=f"stages.{stage}.grading_approved_maximum_usd",
+        )
+    elif "grading_approved_maximum_usd" not in block:
+        problems.append(
+            f"stages.{stage} says nothing about marking, one way or the other. "
+            "Marking costs many times what running does, so silence about it "
+            "is the one thing this block may not contain: write an amount, or "
+            "write null with grading_not_approved_because"
+        )
+    elif not str(refusal or "").strip():
+        problems.append(
+            f"stages.{stage} declines to approve marking and gives no reason. "
+            "A refusal without a reason is indistinguishable from a figure "
+            "somebody forgot to fill in, and the two want opposite responses"
+        )
+
+    chosen = dict(plan.get("cost", {}).get("chosen_settings") or {})
+    fixed = dict(plan.get("fixed_settings") or {})
+    most_running: Decimal | None = None
+    if not task_ids:
+        problems.append(f"stage {stage!r} binds no task, so there is nothing to price")
+    elif chosen.get("tool_calls_per_attempt") and chosen.get(
+        "max_output_tokens_per_turn"
+    ):
+        conditions = StageOneConditions(
+            resource=str((plan.get("azure_connection") or {}).get("account") or ""),
+            deployment=str((plan.get("model") or {}).get("deployment") or ""),
+            resolved_model=str((plan.get("model") or {}).get("resolved_model") or ""),
+            task_ids=tuple(str(one) for one in task_ids),
+            tool_calls_per_attempt=int(chosen["tool_calls_per_attempt"]),
+            max_output_tokens_per_turn=int(chosen["max_output_tokens_per_turn"]),
+            retry_max_attempts=int(fixed.get("retry_max_attempts") or 0),
+            per_task_timeout_seconds=int(fixed.get("per_task_timeout_seconds") or 0),
+        )
+        missing = [one for one in conditions.task_ids if one not in tasks_by_id]
+        if missing:
+            problems.append(
+                f"{len(missing)} of the {len(task_ids)} tasks this stage binds "
+                f"are not in the catalogue, so their cost cannot be worked out: "
+                + ", ".join(missing[:3])
+            )
+        else:
+            options = price_the_options(
+                base=conditions,
+                tasks_by_id=tasks_by_id,
+                assumptions=assumptions,
+                tool_call_choices=(conditions.tool_calls_per_attempt,),
+                output_token_choices=(conditions.max_output_tokens_per_turn,),
+                limits=limits,
+                prices=prices,
+            )
+            if options:
+                most_running = options[0].most_running_could_cost_usd
+    else:
+        problems.append(
+            "the plan names no chosen settings, so what this stage would cost "
+            "cannot be worked out"
+        )
+
+    if approved_running is not None and most_running is not None:
+        if most_running > approved_running:
+            problems.append(
+                f"running {stage} over its {len(task_ids)} tasks could cost "
+                f"${_money(most_running)}, and ${_money(approved_running)} is "
+                f"approved for it — short by ${_money(most_running - approved_running)}. "
+                "Approve the larger figure or run a smaller stage; nothing here "
+                "may scale an approved amount on its own"
+            )
+
+    return StagePricing(
+        stage=stage,
+        task_count=len(task_ids),
+        approved_running_usd=approved_running,
+        approved_grading_usd=approved_grading,
+        grading_not_approved_because=(
+            str(refusal).strip() if approved_grading is None and refusal else None
+        ),
+        most_running_could_cost_usd=most_running,
+        problems=tuple(problems),
+    )

--- a/batch-runner/core/execution_environment_readiness.py
+++ b/batch-runner/core/execution_environment_readiness.py
@@ -931,10 +931,47 @@ def _agentic_sandbox_v2_blockers() -> list[str]:
 
     blockers.extend(_why_a_real_model_is_out_of_reach())
 
-    blockers.append(
-        "no approval exists to use this environment in a real experiment"
-    )
+    blockers.append(_what_this_environment_is_not_approved_for())
     return blockers
+
+
+def _what_this_environment_is_not_approved_for() -> str:
+    """The approval blocker, narrowed on 2026-09-11 to what is still true.
+
+    This used to read "no approval exists to use this environment in a real
+    experiment". That was right until stage one was approved, and then it was a
+    sentence outliving its fact — the exact failure this module's tests were
+    written about, in the same list, two lines below the blocker that had
+    already been fixed for it.
+
+    Two different approvals were hiding behind the one sentence. Stage one's
+    five-task run is approved, on its own two figures, in the stage-one plan.
+    What is not approved — and what the two blocks in the paid pipeline enforce
+    — is reaching this environment the ordinary way, through an experiment
+    YAML. So the blocker now names the second and points at the first, and it
+    is read from the plan rather than stated, so it goes back to the blunter
+    wording by itself if the approval is ever withdrawn.
+    """
+    try:
+        establish = _import_attribute(
+            "core.agentic_v2_stage_one_budget", "stage_one_amount_note"
+        )
+        unapproved = list(establish())
+    except Exception:  # pragma: no cover - defensive
+        # Unreadable is treated as unapproved, which is the safe direction: the
+        # blunter sentence overstates what is blocked, and this one understates.
+        unapproved = ["the stage-one plan could not be read"]
+
+    if unapproved:
+        return "no approval exists to use this environment in a real experiment"
+    return (
+        "this environment is not approved for the ordinary experiment "
+        "pipeline: step2_run_inference refuses the mode and core.executor "
+        "refuses to build a runner for a paid run. Stage one's five-task run "
+        "is approved separately, on its own two amounts in "
+        "agentic_stage_one_plan.yaml, and goes through "
+        "scripts/run_agentic_v2_stage.py rather than through here"
+    )
 
 
 def inspect_environment_support(

--- a/batch-runner/experiments/execution_envelope/agentic_stage_one_plan.yaml
+++ b/batch-runner/experiments/execution_envelope/agentic_stage_one_plan.yaml
@@ -7,20 +7,30 @@
 # exec_run still shut. It answers one question — does asking the model again
 # after each tool result help at all? — and nothing else.
 #
-# TWO AMOUNTS ARE APPROVED HERE, FOR THE FIVE TASKS BELOW AND NOTHING ELSE.
+# RUNNING IS APPROVED FOR ALL THREE STAGES. MARKING, FOR THE FIVE ONLY.
 #
-# This header used to read "NOTHING HERE IS APPROVED AND NOTHING HERE RUNS",
-# and it went on reading that way after the amounts were filled in on
-# 2026-09-11 — four lines above the block that holds them. Corrected rather
-# than quietly deleted, because the first sentence of a file is the one a
-# reader trusts, and a file that contradicts itself is believed at the top.
+# This header has now been wrong twice, and both times in the same direction —
+# it went on describing a narrower approval than the file below it carried. It
+# first read "NOTHING HERE IS APPROVED AND NOTHING HERE RUNS", and kept reading
+# that after two amounts were filled in four lines further down. It was then
+# corrected to say two amounts covered the five tasks and nothing else, and kept
+# reading that after the `stages` block priced all three. Corrected again rather
+# than quietly deleted, because the first sentence of a file is the one a reader
+# trusts, and a file that contradicts itself is believed at the top.
 #
-# What is approved: running the five task_ids below (50.00) and marking their
-# answers (2600.00), under the standing approval for Foundry model calls and
-# experiments within the already authorised scope. Both are whole-run figures
-# for those five tasks. Neither is a per-task rate, so neither prices a larger
-# cohort: scripts/run_agentic_v2_stage.py refuses any stage this file has not
-# priced and says by what multiple it would have overrun.
+# What is approved, in the `stages` block below:
+#
+#   - running all three cohorts — five tasks, thirty, and all two hundred and
+#     twenty — under the standing approval for Foundry model calls and
+#     experiments within the already authorised scope.
+#   - marking the five answers, and only those five. Marking thirty or two
+#     hundred and twenty is a five- and six-figure decision that nobody has
+#     made; each is written as a refusal carrying its reason, not left blank.
+#
+# Every amount is a whole-run figure for the cohort it names. None of them is a
+# per-task rate, so none of them prices any other cohort, and
+# scripts/run_agentic_v2_stage.py refuses a stage this file has not priced by
+# name and says by what multiple it would have overrun.
 #
 # Read this file with:
 #     cd batch-runner
@@ -49,7 +59,8 @@
 # the amounts are the thing that mattered, and because a run that finds itself
 # refused for want of a budget is being refused by those two mechanisms.
 #
-# Written: 2026-08-26. Amounts approved and this header corrected: 2026-09-11.
+# Written: 2026-08-26. Five-task amounts approved: 2026-09-11. All three stages
+# priced for running, and this header corrected a second time: 2026-09-11.
 
 plan_version: "agentic-stage-one-v1"
 
@@ -173,14 +184,14 @@ cost:
   # correct plan into a refused one without anybody having changed their mind.
   # Nothing spends up to it: the per-task budgets under chosen_settings are
   # what actually stop a run, and they are worked out from the same arithmetic.
-  running_approved_maximum_usd: 50.00
+  running_approved_maximum_usd: &five_task_running 50.00
 
   # Marking the five answers. Approved here because the plan is where the whole
   # of stage one is priced and a half-approved stage is not an approved one.
   # Nothing in scripts/run_agentic_v2_stage.py can spend it — that script binds
   # every call to the problem-solving bucket, and core.agentic_v2_cost_binding
   # raises on a grading stage. Marking is a separate run against this figure.
-  grading_approved_maximum_usd: 2600.00
+  grading_approved_maximum_usd: &five_task_grading 2600.00
 
   # ── The settings ─────────────────────────────────────────────────────────
   #
@@ -270,6 +281,77 @@ cost:
   # enforce it when something runs. A number written down here could disagree
   # with the code; a number read from the code cannot.
   tool_result_size_comes_from: "core/agentic_v2_tools.py AgenticV2ToolDispatcher"
+
+# ── What each of the three stages may spend ───────────────────────────────
+#
+# The escalation is five tasks, then thirty, then two hundred and twenty, fixed
+# in core/agentic_v2_preregistration.py. The block above prices the first of
+# those and nothing else: its figures are whole-run figures, so running thirty
+# tasks under them would go out against an approval worked out for a run six
+# times smaller, and the printed line would say it was within budget because
+# the arithmetic behind it never saw the larger cohort.
+#
+# So each stage is priced by name here. The task ids are NOT repeated — they
+# come from the sealed catalogue through cohorts(), and a second copy in this
+# file would be a second thing to keep correct. What is written here is only
+# the part a person has to decide: the amount.
+#
+# No estimated figure is written down either, for the reason the note about
+# assumptions_come_from gives at length. The estimate has moved three times
+# already, and each move changed the answer. Run
+#     python scripts/check_agentic_stage_one_ceiling.py
+# to see what each stage costs against what it may spend, worked out live.
+#
+# Running is approved for all three, under the standing approval for Foundry
+# model calls and experiments within the already authorised scope. The whole
+# point of the work is that the two hundred and twenty tasks are actually run.
+#
+# Marking is NOT approved beyond the five, and that is a real difference rather
+# than an oversight, so it is written as a refusal with its reason rather than
+# left blank. Marking is not a share of the running cost — it is roughly fifty
+# times it, because the grader asks about five hundred questions per task
+# against the model's answer. A figure for marking two hundred and twenty tasks
+# is a six-figure decision and belongs to whoever is paying, not to the file
+# that happens to need it. Nothing here can spend it by accident in the
+# meantime: scripts/run_agentic_v2_stage.py binds every call it makes to the
+# problem-solving bucket and core.agentic_v2_cost_binding raises on a grading
+# stage.
+#
+# Written 2026-09-11, when the escalation stopped being hypothetical.
+stages:
+  advance_check_5:
+    # The same two figures as the block above, by reference rather than by
+    # copy. An alias cannot drift from what it points at; a second literal can,
+    # and would be found only by whoever next compared them.
+    running_approved_maximum_usd: *five_task_running
+    grading_approved_maximum_usd: *five_task_grading
+
+  trial_30:
+    # Roughly six times the five-task run, and the margin over the computed
+    # ceiling is deliberately narrower than the five-task one. Margin is
+    # insurance against the shared assumptions moving, and that movement is
+    # proportional — the three corrections to the standing-instruction length
+    # moved the cheapest row by about four per cent each time. At eighteen
+    # dollars a wide margin costs nothing, so the five-task figure is generous.
+    # Here it would be real money, so it is not.
+    running_approved_maximum_usd: 200.00
+    grading_approved_maximum_usd: null
+    grading_not_approved_because: >-
+      Marking thirty answers is a five-figure amount, and nothing in the goal
+      this stage serves needs it. Running thirty tasks answers whether the loop
+      holds up past five; how well the answers scored is a separate question
+      with a separate bill, asked after there are answers to ask it about.
+
+  full_220:
+    # Every task in the benchmark, run once.
+    running_approved_maximum_usd: 1400.00
+    grading_approved_maximum_usd: null
+    grading_not_approved_because: >-
+      Marking all two hundred and twenty answers is a six-figure amount — far
+      more than running them, and more than every other cost in this project
+      put together. It is approved separately or not at all. Finishing the two
+      hundred and twenty runs is one milestone; marking them is another, and
+      the second does not follow from the first having been paid for.
 
 # ── What happens after stage one ──────────────────────────────────────────
 #

--- a/batch-runner/experiments/execution_envelope/agentic_stage_one_plan.yaml
+++ b/batch-runner/experiments/execution_envelope/agentic_stage_one_plan.yaml
@@ -7,40 +7,49 @@
 # exec_run still shut. It answers one question — does asking the model again
 # after each tool result help at all? — and nothing else.
 #
-# NOTHING HERE IS APPROVED AND NOTHING HERE RUNS.
+# TWO AMOUNTS ARE APPROVED HERE, FOR THE FIVE TASKS BELOW AND NOTHING ELSE.
 #
-# The amount that may be spent is deliberately left empty below. The free check
-# at batch-runner/scripts/check_agentic_stage_one_ceiling.py reads this file,
-# works out what each candidate setting could cost, and refuses to let anything
-# start while that amount is empty. Filling it in is a decision for the owner
-# of the repository, and this file exists to put the numbers in front of that
-# decision rather than to make it.
+# This header used to read "NOTHING HERE IS APPROVED AND NOTHING HERE RUNS",
+# and it went on reading that way after the amounts were filled in on
+# 2026-09-11 — four lines above the block that holds them. Corrected rather
+# than quietly deleted, because the first sentence of a file is the one a
+# reader trusts, and a file that contradicts itself is believed at the top.
 #
-# Beyond the money, two things still block stage one even if the money is
-# approved, and neither is removed here:
-#
-#   - the guards that keep the mode out of the paid pipeline. Two of them: the
-#     check in step2_run_inference._require_runnable_execution_mode, and the
-#     refusal in core/executor.py to build a runner unless the caller states
-#     the run makes no paid model calls. Both stay exactly as they are.
-#   - exec_run is still shut, so nothing stage one does runs a command.
-#
-# One thing that used to be on this list has moved, and is written down here so
-# the change is not silent. Until 2026-09-10 nothing in the repository could
-# reach a real model at all. Now it can:
-# core/agentic_v2_model_voice.AzureFoundryVoice asks a Foundry deployment
-# through the Responses API. What replaced that blocker is narrower and is the
-# amount below — real_model_voice refuses when it is handed no budget, and the
-# loop refuses a paid voice on a run that carries none. Both refusals are run,
-# not read, by the free check. So filling in the amount below is now what lets
-# stage one start, which is exactly why it is the owner's decision and not this
-# file's.
+# What is approved: running the five task_ids below (50.00) and marking their
+# answers (2600.00), under the standing approval for Foundry model calls and
+# experiments within the already authorised scope. Both are whole-run figures
+# for those five tasks. Neither is a per-task rate, so neither prices a larger
+# cohort: scripts/run_agentic_v2_stage.py refuses any stage this file has not
+# priced and says by what multiple it would have overrun.
 #
 # Read this file with:
 #     cd batch-runner
 #     python scripts/check_agentic_stage_one_ceiling.py
 #
-# Written: 2026-08-26.
+# Beyond the money, two things still block stage one, and approving an amount
+# did not move either of them:
+#
+#   - the guards that keep the mode out of the paid pipeline. Two of them: the
+#     check in step2_run_inference._require_runnable_execution_mode, and the
+#     refusal in core/executor.py to build a runner unless the caller states
+#     the run makes no paid model calls. Both stay exactly as they are.
+#   - exec_run is still shut, so nothing stage one does runs a command. No
+#     guest boots either, so stage one exercises the loop and not the
+#     isolation, and no result from it is evidence about the isolation.
+#
+# One thing that used to be on this list has moved, and is written down here so
+# the change is not silent. Until 2026-09-10 nothing in the repository could
+# reach a real model at all. Now it can:
+# core/agentic_v2_model_voice.AzureFoundryVoice asks a Foundry deployment
+# through the Responses API. What replaced that blocker was narrower — the
+# amount below, since real_model_voice refuses when it is handed no budget and
+# the loop refuses a paid voice on a run that carries none, both of which the
+# free check runs rather than reads. That blocker was cleared on 2026-09-11
+# when the two amounts were approved. It is kept here because it explains why
+# the amounts are the thing that mattered, and because a run that finds itself
+# refused for want of a budget is being refused by those two mechanisms.
+#
+# Written: 2026-08-26. Amounts approved and this header corrected: 2026-09-11.
 
 plan_version: "agentic-stage-one-v1"
 
@@ -143,22 +152,57 @@ safety_blocks_must_stay_closed: true
 
 # ── What may be spent ─────────────────────────────────────────────────────
 cost:
-  # Empty on purpose. Nothing has been approved for stage one.
+  # ── Two amounts, because they are two decisions ─────────────────────────
   #
-  # The 32.23 United States dollars approved on 2026-08-25 was for the
-  # three-place comparison of five tasks and nothing else. It does not extend
-  # here, and stage one must not be started under it.
+  # There used to be one key here, approved_maximum_usd, holding the total. The
+  # free check now refuses a plan that still carries it, rather than reading it
+  # as either half — an approval given for a total is not an approval of a part
+  # of it.
   #
-  # To approve stage one, choose one row from the table the free check prints,
-  # write the two settings into chosen_settings below, and write the amount
-  # from that row here.
-  approved_maximum_usd: null
+  # The reason for the split is in the table the free check prints. Marking is
+  # a flat 2504.67 whatever the settings are; running moves from 3.37 to 493.70
+  # across the candidate rows. Held as one figure, the decision actually being
+  # made — which settings buy an answer worth having — is under one per cent of
+  # the number being signed, and could change a hundredfold without moving it.
+  #
+  # Approved 2026-09-11 under the standing approval for Foundry model calls and
+  # experiments in the existing authorised scope.
 
-  # Empty until a row is chosen. The free check refuses while either is empty,
-  # and refuses if the pair is not one of the candidates above.
+  # Running the five tasks. The chosen row below prices at 18.47 at most; 50 is
+  # written here so a modest move in the shared assumptions does not turn a
+  # correct plan into a refused one without anybody having changed their mind.
+  # Nothing spends up to it: the per-task budgets under chosen_settings are
+  # what actually stop a run, and they are worked out from the same arithmetic.
+  running_approved_maximum_usd: 50.00
+
+  # Marking the five answers. Approved here because the plan is where the whole
+  # of stage one is priced and a half-approved stage is not an approved one.
+  # Nothing in scripts/run_agentic_v2_stage.py can spend it — that script binds
+  # every call to the problem-solving bucket, and core.agentic_v2_cost_binding
+  # raises on a grading stage. Marking is a separate run against this figure.
+  grading_approved_maximum_usd: 2600.00
+
+  # ── The settings ─────────────────────────────────────────────────────────
+  #
+  # Eight tool calls and 8192 tokens a turn, from the table the free check
+  # prints. Chosen 2026-09-11, and the reasoning is worth keeping because the
+  # cheapest row is not obviously wrong:
+  #
+  #   4 / 2048   3.37   what stage A asked one question with. Four tool calls
+  #                     is enough to read, write and finalise, and little else;
+  #                     a task needing to look at two inputs first has spent
+  #                     them before it starts.
+  #   8 / 8192  18.46   chosen. Double the calls, quadruple the write cap, at
+  #                     an amount that is still small.
+  #  16 / 32768 137.62  the write cap is past what these deliverables need, and
+  #                     the loop re-sends the whole conversation every turn, so
+  #                     the input cost grows with the square of the length.
+  #
+  # This is a choice about what the model is given room to do, and it will show
+  # up in the results either way. Recorded before the run, not after it.
   chosen_settings:
-    tool_calls_per_attempt: null
-    max_output_tokens_per_turn: null
+    tool_calls_per_attempt: 8
+    max_output_tokens_per_turn: 8192
 
   # ── Stage A: the one paid question that comes before the run above ──────
   #

--- a/batch-runner/scripts/check_agentic_stage_one_ceiling.py
+++ b/batch-runner/scripts/check_agentic_stage_one_ceiling.py
@@ -14,10 +14,16 @@ Usage:
     python scripts/check_agentic_stage_one_ceiling.py --probe
     python scripts/check_agentic_stage_one_ceiling.py --plan other.yaml
 
-The exit code follows the five-task run's verdict, which today is never zero:
-no amount has been approved for stage one, and no settings have been chosen.
-A real model *can* now be reached, so the amount is the thing standing in the
-way rather than missing code.
+The exit code follows the five-task run's verdict. As of 2026-09-11 that is
+zero: two amounts have been approved — one for running the five tasks, one for
+marking the five answers — and a settings row has been chosen, so the gate
+passes. It passed by the arithmetic below rather than by anybody deciding it
+should, and removing either amount from the plan makes it refuse again.
+
+A zero here is not a start signal. It says the money question and the safety
+questions have both been answered; what actually runs the five tasks is
+``scripts/run_agentic_v2_stage.py``, and the three blocks that keep this mode
+out of the paid pipeline are still shut.
 
 ``--probe`` follows stage A's verdict instead — one task, no marking, its own
 amount, and a narrower tool list read from the probe's own code. It is a second

--- a/batch-runner/scripts/measure_agentic_reference_files.py
+++ b/batch-runner/scripts/measure_agentic_reference_files.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""What it would actually take to stage every task's reference files.
+
+The gap is known and has been stated in every V2 record so far: a bound task is
+a task whose reference files are *named* and not *present*, so a task that needs
+one opened fails on its merits and the result is a mixture of model failure and
+environment defect. What has not been stated is the shape of the gap, and the
+shape is what decides whether closing it is an afternoon or a redesign.
+
+Measured rather than estimated, against the pinned snapshot, because every
+figure here has a cheap wrong answer. "A hundred and twenty-five tasks need
+files" suggests a hundred and twenty-five similar problems; the sizes say
+otherwise, and so does the one file that no amount of staging can deliver under
+the limits the compute contract already sets.
+
+Reads the parquet and stats files on disk. Calls nothing, spends nothing, and
+writes nothing except its own report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.agentic_compute import (  # noqa: E402
+    MAX_INPUT_FILES,
+    MAX_INPUT_SINGLE,
+    MAX_INPUT_TOTAL,
+)
+
+DATASET_REPO_ID = "openai/gdpval"
+DATASET_REVISION = "11e7900cdcac61bc4daf59e65feb238acda98fbf"
+SNAPSHOT = (
+    Path.home()
+    / ".cache"
+    / "huggingface"
+    / "hub"
+    / f"datasets--{DATASET_REPO_ID.replace('/', '--')}"
+    / "snapshots"
+    / DATASET_REVISION
+)
+
+#: The reference-file paths in the parquet are relative to the snapshot root and
+#: already correct -- `reference_files/<folder>/<name>`. The folder name is a
+#: 32-hex string that looks like a digest and is not reliably one, so it is
+#: treated as an opaque identifier here and never recomputed or verified as a
+#: hash. Calling it a hash in a record would be a provenance claim the data does
+#: not support.
+PARQUET = SNAPSHOT / "data" / "train-00000-of-00001.parquet"
+
+
+def measure() -> dict:
+    import pyarrow.parquet as pq
+
+    if not PARQUET.is_file():
+        raise SystemExit(
+            f"the pinned dataset is not at {PARQUET}.\n"
+            f"  hf download {DATASET_REPO_ID} --repo-type dataset "
+            f"--revision {DATASET_REVISION}"
+        )
+
+    table = pq.read_table(PARQUET, columns=["task_id", "reference_files"])
+    task_ids = table.column("task_id").to_pylist()
+    references = table.column("reference_files").to_pylist()
+
+    per_task: list[dict] = []
+    extensions: Counter = Counter()
+    absent: list[str] = []
+    over_single_limit: list[dict] = []
+
+    for task_id, paths in zip(task_ids, references):
+        paths = [str(one) for one in (paths or [])]
+        if not paths:
+            continue
+        total = 0
+        for relative in paths:
+            path = SNAPSHOT / relative
+            extensions[path.suffix.lower()] += 1
+            if not path.is_file():
+                absent.append(relative)
+                continue
+            size = path.stat().st_size
+            total += size
+            if size > MAX_INPUT_SINGLE:
+                over_single_limit.append(
+                    {"task_id": task_id, "file": path.name, "bytes": size}
+                )
+        per_task.append(
+            {"task_id": task_id, "file_count": len(paths), "bytes": total}
+        )
+
+    sizes = sorted(entry["bytes"] for entry in per_task)
+    biggest = sorted(per_task, key=lambda entry: -entry["bytes"])[:5]
+
+    return {
+        "dataset": {"repo_id": DATASET_REPO_ID, "revision": DATASET_REVISION},
+        "tasks_total": len(task_ids),
+        "tasks_needing_reference_files": len(per_task),
+        "files_named_but_absent_from_the_snapshot": absent,
+        "bytes_all_together": sum(sizes),
+        # The whole total is the wrong number to plan against, because three
+        # tasks hold most of it. This is what the other hundred and twenty-two
+        # actually weigh.
+        "bytes_without_the_three_heaviest_tasks": sum(sizes[:-3]),
+        "bytes_per_task": {
+            "median": sizes[len(sizes) // 2],
+            "p90": sizes[int(len(sizes) * 0.9)],
+            "max": sizes[-1],
+        },
+        "files_per_task_max": max(entry["file_count"] for entry in per_task),
+        "extensions": dict(extensions.most_common()),
+        "biggest_tasks": biggest,
+        "limits_from_the_compute_contract": {
+            "max_input_files": MAX_INPUT_FILES,
+            "max_input_single_bytes": MAX_INPUT_SINGLE,
+            "max_input_total_bytes": MAX_INPUT_TOTAL,
+        },
+        "files_over_the_single_file_limit": over_single_limit,
+    }
+
+
+def size(count: int) -> str:
+    """Kilobytes stay kilobytes.
+
+    The median task's files are about fifty kilobytes. Rounded to megabytes
+    that reads as "0.1 MB", which looks like a rounding artefact rather than a
+    measurement and invites the reader to skip it -- when it is in fact the most
+    load-bearing number here, because it is what says most of this gap is a
+    copy.
+    """
+    if count < 1_000_000:
+        return f"{count / 1_000:,.1f} KB"
+    return f"{count / 1_000_000:,.1f} MB"
+
+
+def report(found: dict) -> str:
+    lines = [
+        f"{found['tasks_needing_reference_files']} of {found['tasks_total']} "
+        "tasks name reference files.",
+        f"All of them are present in the pinned snapshot: "
+        f"{len(found['files_named_but_absent_from_the_snapshot'])} named files "
+        "are missing.",
+        f"Together they are {size(found['bytes_all_together'])}.",
+        "",
+        "Per task: "
+        f"median {size(found['bytes_per_task']['median'])}, "
+        f"p90 {size(found['bytes_per_task']['p90'])}, "
+        f"max {size(found['bytes_per_task']['max'])}. "
+        f"At most {found['files_per_task_max']} files.",
+        "",
+        "So this is not one problem repeated 125 times. For most tasks it is a "
+        "handful of documents -- spreadsheets, PDFs and Word files are "
+        f"{found['extensions'].get('.xlsx', 0)} + {found['extensions'].get('.pdf', 0)}"
+        f" + {found['extensions'].get('.docx', 0)} of the "
+        f"{sum(found['extensions'].values())} files -- and copying them is a "
+        "copy. The weight is in a short tail of media: take out the three "
+        "heaviest tasks and the remaining 122 come to "
+        f"{size(found['bytes_without_the_three_heaviest_tasks'])} between them.",
+        "",
+    ]
+    if found["files_over_the_single_file_limit"]:
+        lines.append(
+            "Files larger than the compute contract's own single-file limit of "
+            f"{size(found['limits_from_the_compute_contract']['max_input_single_bytes'])}:"
+        )
+        for entry in found["files_over_the_single_file_limit"]:
+            lines.append(
+                f"  {size(entry['bytes'])}  {entry['file']}  ({entry['task_id']})"
+            )
+        lines += [
+            "",
+            "That limit is not a staging bug to be raised out of the way. A file "
+            "that size is not something a model reads; delivering it would mean "
+            "deciding what a model gets instead -- a transcript, frames, a "
+            "summary -- and that decision changes what the task measures. It is "
+            "recorded per task as an unmet need, not quietly dropped.",
+        ]
+    else:
+        lines.append("No file exceeds the contract's single-file limit.")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json", action="store_true", help="print the measurement, not the prose"
+    )
+    args = parser.parse_args(argv)
+
+    found = measure()
+    print(json.dumps(found, indent=2) if args.json else report(found))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/batch-runner/scripts/plan_agentic_v2_shards.py
+++ b/batch-runner/scripts/plan_agentic_v2_shards.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""How many jobs one stage has to be run across, and what to pass to each.
+
+Printed as a JSON array of ``"index/total"`` strings, because that is what a
+GitHub Actions matrix can be built from with ``fromJSON`` and what
+``run_agentic_v2_stage.py --shard`` takes. One value, read by both.
+
+The reason this is a script and not four lines of Python in a heredoc inside the
+workflow is that the heredoc version cannot be run anywhere except a dispatch.
+The number it produces decides whether a paid run finishes or is killed at the
+six hour mark with the tasks it was in the middle of lost, and that is not a
+number to find out about from a workflow log.
+
+Both inputs are read rather than written here:
+
+* the per-task ceiling comes from the plan, so the split cannot be sized against
+  a timeout the run is not actually using;
+* the cohort size comes from the committed catalogue by way of the
+  pre-registration, so it cannot be sized against a stage that is a different
+  size from the one that will run.
+
+The job limit is the one thing written down here, because it belongs to GitHub
+rather than to this project. It is six hours: the documented maximum for a job
+on a GitHub-hosted runner. A job that asks for more is not refused at dispatch;
+it is killed when it gets there.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.agentic_v2_preregistration import ESCALATION, STAGE_SIZES  # noqa: E402
+from core.agentic_v2_sharding import how_many_shards_fit  # noqa: E402
+from core.agentic_v2_stage_one_budget import load_stage_one_plan  # noqa: E402
+
+#: The documented ceiling on one job on a GitHub-hosted runner. Not configurable
+#: and not negotiable: a job that runs past it is killed where it stands, and the
+#: task it was in the middle of is the one a resume has to pay for twice.
+GITHUB_JOB_LIMIT_SECONDS = 6 * 60 * 60
+
+
+def shard_plan(stage: str) -> dict[str, object]:
+    if stage not in STAGE_SIZES:
+        raise SystemExit(
+            f"{stage!r} is not a registered stage. The three are: "
+            + ", ".join(ESCALATION)
+        )
+
+    per_task = float(load_stage_one_plan()["fixed_settings"]["per_task_timeout_seconds"])
+    size = STAGE_SIZES[stage]
+    pieces = how_many_shards_fit(
+        cohort_size=size,
+        per_task_timeout_seconds=per_task,
+        job_limit_seconds=GITHUB_JOB_LIMIT_SECONDS,
+    )
+    biggest = -(-size // pieces)
+    return {
+        "stage": stage,
+        "cohort_size": size,
+        "shards": [f"{index}/{pieces}" for index in range(1, pieces + 1)],
+        "per_task_timeout_seconds": per_task,
+        "worst_case_hours_per_shard": round(biggest * per_task / 3600, 1),
+        "worst_case_hours_if_run_as_one": round(size * per_task / 3600, 1),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stage", required=True, choices=list(ESCALATION))
+    parser.add_argument(
+        "--explain",
+        action="store_true",
+        help="print the whole plan as an object instead of just the matrix list",
+    )
+    args = parser.parse_args(argv)
+
+    plan = shard_plan(args.stage)
+    if args.explain:
+        print(json.dumps(plan, indent=2))
+    else:
+        # Compact and on one line: this is read by `$(...)` into a workflow
+        # output, and an output with a newline in it is a parse error there.
+        print(json.dumps(plan["shards"], separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/batch-runner/scripts/run_agentic_stage_a_probe.py
+++ b/batch-runner/scripts/run_agentic_stage_a_probe.py
@@ -45,6 +45,9 @@ BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
 if str(BATCH_RUNNER_ROOT) not in sys.path:
     sys.path.insert(0, str(BATCH_RUNNER_ROOT))
 
+from core.agentic_v2_route_check import (  # noqa: E402
+    check_route_is_the_one_the_plan_fixed as _check_route,
+)
 from core.agentic_v2_stage_a_probe import (  # noqa: E402
     PROBE_TOOLS,
     run_stage_a_probe,
@@ -152,55 +155,11 @@ def _verdict(plan_path: Path):
 def check_route_is_the_one_the_plan_fixed(route, connection, *, settings=None):
     """Every way the resolved route could differ from what was approved.
 
-    The plan fixes an account, a project and a route profile. A run that
-    reached a real model over some other route would have proved something
-    about a different environment than the one stage one is being priced for,
-    and it would have cost the same to prove it. Checked after the client is
-    built, because until then the route is a request rather than a fact.
-
-    All three collected rather than the first returned, so a reader fixing a
-    misconfigured dispatch sees the whole of it at once.
-
-    The project needs its own paragraph, because the route selected for
-    inference under ``project-ci`` does not carry one. That profile derives an
-    account-scoped ``direct-v1`` URL from the configured project endpoint and
-    sends inference over it, so the selected endpoint has an account and a
-    ``project`` of ``None`` — while the project it was derived from is still
-    the fact being checked. Where it is, the project endpoint says so, and that
-    is read here rather than assumed away. If neither the selection nor the
-    settings names a project, the run is refused: an unconfirmable project is
-    the case a silent skip would hide.
+    The body moved to :mod:`core.agentic_v2_route_check` when the stage runner
+    needed the same check; this stays as the name, because the tests that pin
+    stage A's behaviour call it here and what they are pinning has not changed.
     """
-    problems: list[str] = []
-    account = str(connection.get("account") or "")
-    project = connection.get("project")
-    profile = connection.get("route_profile")
-
-    if account and route.endpoint.account != account:
-        problems.append(
-            f"the route resolves to account {route.endpoint.account!r}, but "
-            f"the plan fixes {account!r}"
-        )
-    if project:
-        configured = getattr(getattr(settings, "project", None), "project", None)
-        found = route.endpoint.project or configured
-        if found is None:
-            problems.append(
-                f"the plan fixes project {project!r}, but neither the route "
-                "that was selected nor the endpoints it was built from names "
-                "a project, so there is nothing to check it against"
-            )
-        elif found != project:
-            problems.append(
-                f"the route resolves to project {found!r}, but the plan "
-                f"fixes {project!r}"
-            )
-    if profile and str(route.profile.value) != str(profile):
-        problems.append(
-            f"the route profile is {route.profile.value!r}, but the plan "
-            f"fixes {profile!r}"
-        )
-    return problems
+    return _check_route(route, connection, settings=settings)
 
 
 def exit_condition_met(outcome) -> bool:

--- a/batch-runner/scripts/run_agentic_v2_stage.py
+++ b/batch-runner/scripts/run_agentic_v2_stage.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""Run one pre-registered Agentic Sandbox V2 stage against a real deployment.
+
+Everything this needs has existed separately for a while. The conversation loop
+asks a model and runs what it asks for; the runner admits a backend and writes a
+verified record; the driver walks a fixed manifest, resumes, collects files and
+stops when it should; the binding turns a sealed cohort into tasks and refuses a
+prompt that drifted; the budget module decides whether anything may be spent at
+all. This is the one place that puts them in a line and turns the handle.
+
+    cd batch-runner
+    python scripts/run_agentic_v2_stage.py --stage advance_check_5 --dry-run
+    python scripts/run_agentic_v2_stage.py --stage advance_check_5
+
+``--dry-run`` does everything except reach the network: the free check, the
+binding, the ceilings, the workspace, the journal path. The only difference
+between a free run and a paid one is the calls themselves, which is what makes
+the free run worth anything.
+
+**What this is, stated before anyone reads a number off it.** The backend is
+:class:`~core.agentic_v2_fixture_backend.AgenticV2FixtureBackend`. The model is
+real, the tool choices are real, the files it writes are real files on this
+disk, and the deliverables collected at the end are the ones it wrote. What is
+*not* real is the isolation: no guest boots, and ``exec_run`` answers
+``capability_unavailable`` to everything. That is not a shortcut taken here —
+the pre-registration fixes ``exec_run_open: false`` for stage one, so a run that
+opened it would be a different experiment from the one that was registered. It
+does mean a sentence like "Agentic Sandbox V2 completed the stage" would be
+wrong, and :func:`environment_note` is written into the record so that the
+weaker true sentence travels with the results instead of having to be
+remembered.
+
+**Three milestones, deliberately not merged.** *The environment is ready* is not
+*the tasks ran* is not *the results are marked*. This script can only report the
+middle one. It writes no grade, and the ledger it writes to buckets everything
+as problem-solving cost, so marking cannot be paid for out of this even by
+accident.
+
+**What is written down.** The driver's own journal, one row per task, the
+collected deliverables, and a cost receipt per task. Never a prompt, never a
+reply, never a credential — same rule as the stage A probe, for the same reason.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.agentic_v2_conversation_runner import (  # noqa: E402
+    PerTaskCeilings,
+    RunWideCeilings,
+    TaskConversations,
+    build_runner_factory,
+    # Imported rather than worked out here. The pre-registration promises these
+    # same ceilings before the run starts, so a second copy of the arithmetic
+    # would let the promise and the enforcement drift apart silently.
+    ceilings_from,
+    model_turns_of,
+)
+from core.agentic_v2_cost_binding import bind_run_to_ledger  # noqa: E402
+from core.agentic_v2_fixture_backend import AgenticV2FixtureBackend  # noqa: E402
+from core.agentic_v2_manifest_binding import (  # noqa: E402
+    ManifestRefused,
+    bind_stage,
+    binding_record,
+)
+from core.agentic_v2_preregistration import STAGE_SIZES  # noqa: E402
+from core.agentic_v2_route_check import (  # noqa: E402
+    check_route_is_the_one_the_plan_fixed,
+)
+from core.agentic_v2_run_driver import DriverRefused, run_manifest  # noqa: E402
+from core.agentic_v2_stage_one_budget import (  # noqa: E402
+    STAGE_ONE_PLAN_PATH,
+    load_stage_one_plan,
+    run_stage_one_preflight,
+)
+from core.execution_envelope_cost import (  # noqa: E402
+    CostAssumptions,
+    load_price_table,
+)
+from core.execution_envelope_preflight import load_plan  # noqa: E402
+from core.execution_envelope_tasks import (  # noqa: E402
+    DATASET_REPO_ID,
+    DATASET_REVISION,
+    catalog_sha256,
+    load_task_catalog,
+)
+
+
+class StageRefused(RuntimeError):
+    """Raised for every reason the stage must not start."""
+
+
+#: Where the pinned dataset lands once it has been downloaded.
+#:
+#: The same revision the catalogue was built from, read the same way the stage A
+#: probe reads it. ``dataset_tasks_from_snapshot`` would read whatever revision
+#: happens to be bootstrapped into ``data/gdpval-local``, and the whole point of
+#: the binding is that the prompts are the ones the seal was computed over — so
+#: the revision is pinned here rather than taken on trust and checked afterwards.
+PINNED_DATASET_PARQUET = (
+    Path.home()
+    / ".cache"
+    / "huggingface"
+    / "hub"
+    / f"datasets--{DATASET_REPO_ID.replace('/', '--')}"
+    / "snapshots"
+    / DATASET_REVISION
+    / "data"
+    / "train-00000-of-00001.parquet"
+)
+
+
+@dataclass(frozen=True)
+class DatasetRow:
+    """One row, carrying only what the binding is allowed to see.
+
+    Built by hand rather than by handing the parquet frame over, because the
+    frame also holds ``deliverable_text`` and ``deliverable_files`` — the
+    expert's own answer. :data:`ANSWER_FIELDS_THAT_MUST_NOT_TRAVEL` keeps those
+    out of ``TaskToRun``, and this keeps them out of what the binding is given
+    in the first place.
+    """
+
+    task_id: str
+    prompt: str
+    sector: str
+    occupation: str
+    reference_files: tuple[str, ...]
+
+
+def read_pinned_dataset(parquet: Path) -> list[DatasetRow]:
+    """The pinned revision's rows, with the answer columns never read."""
+    if not parquet.is_file():
+        raise StageRefused(
+            f"the pinned dataset is not at {parquet}. Download revision "
+            f"{DATASET_REVISION} of {DATASET_REPO_ID} first, or pass --parquet"
+        )
+    import pandas
+
+    frame = pandas.read_parquet(
+        parquet,
+        columns=["task_id", "prompt", "sector", "occupation", "reference_files"],
+    )
+    return [
+        DatasetRow(
+            task_id=str(row.task_id),
+            prompt=str(row.prompt),
+            sector=str(row.sector),
+            occupation=str(row.occupation),
+            # ``or ()`` would be wrong here: the column holds a numpy array, and
+            # an array with more than one element raises rather than being
+            # truthy. Asked whether it is None instead.
+            reference_files=tuple(
+                str(name)
+                for name in (
+                    () if row.reference_files is None else row.reference_files
+                )
+            ),
+        )
+        for row in frame.itertuples()
+    ]
+
+
+#: What the fixture backend is, in words that survive being quoted.
+#:
+#: Written into the run record rather than only into this file's docstring,
+#: because the record is what a reader three months from now will have. A run
+#: whose isolation was a fixture and whose record does not say so is a result
+#: that will eventually be described as something it was not.
+def environment_note(profile: dict) -> dict:
+    return {
+        "backend": "AgenticV2FixtureBackend",
+        "guest_booted": False,
+        "exec_run_open": False,
+        "policy_profile_id": profile.get("policy_profile_id"),
+        "what_was_real": [
+            "the model, the deployment and the charge for every call",
+            "the tool choices the model made, turn by turn",
+            "the files workspace_apply wrote, and the deliverables collected",
+            "the per-task ceilings, which stopped tasks that reached them",
+        ],
+        "what_was_not_real": [
+            "the isolation: no guest booted and nothing ran in one",
+            "exec_run, which answered capability_unavailable to everything",
+        ],
+        "so_the_honest_sentence_is": (
+            "a real model drove a real tool loop and wrote real files, with "
+            "the V2 tool contract enforced and its isolation not exercised. "
+            "This is not evidence that the sandbox contains anything."
+        ),
+    }
+
+
+def verdict_for(plan_path: Path):
+    """The same free check the gate runs, run again where the money is."""
+    plan = load_stage_one_plan(plan_path)
+    shared_plan_path = BATCH_RUNNER_ROOT / str(
+        plan.get("cost", {}).get("assumptions_come_from")
+        or "experiments/execution_envelope/advance_check_plan.yaml"
+    )
+    assumptions = CostAssumptions.from_mapping(
+        load_plan(shared_plan_path)["cost"]["assumptions"]
+    )
+    catalog = load_task_catalog()
+    result = run_stage_one_preflight(
+        plan, tasks_by_id=catalog.by_task_id(), assumptions=assumptions
+    )
+    if not result.may_start:
+        raise StageRefused(
+            "the free check refuses this stage:\n  - "
+            + "\n  - ".join(result.problems)
+        )
+    if result.chosen is None:
+        raise StageRefused(
+            "the free check passed but the plan names no chosen settings, so "
+            "there is no ceiling to hold a task to. Fill cost.chosen_settings "
+            "in the plan before running anything"
+        )
+    return plan, result, catalog
+
+
+def check_the_plan_priced_this_stage(plan: dict, bound) -> list[str]:
+    """Whether the amounts approved describe the run about to happen.
+
+    The free check prices the tasks the plan pins, which is the five-task
+    cohort. Its figures are per-run, not per-task, so a thirty-task or
+    two-hundred-and-twenty-task stage run under them would go out against an
+    approval worked out for a run forty-four times smaller — and the printed
+    line would say it was within budget, because the arithmetic it came from
+    never saw the larger cohort.
+
+    Caught here rather than by scaling the figure, because scaling would be
+    this script deciding what a bigger run costs. Prices come from the plan.
+    When stage thirty and stage two-twenty are to be run, the plan gains their
+    task ids and their two approved amounts, and this stops refusing them.
+    """
+    priced = {str(task_id) for task_id in (plan.get("task_ids") or ())}
+    binding = set(bound.task_ids)
+    if priced == binding:
+        return []
+    return [
+        f"the plan prices {len(priced)} tasks and this stage binds "
+        f"{len(binding)}, so the approved amounts do not describe this run. "
+        "They are whole-run figures, not per-task ones, and running "
+        f"{len(binding)} tasks under them would spend roughly "
+        f"{len(binding) / max(len(priced), 1):.0f} times what was approved. "
+        "Price this cohort in the plan first."
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run one pre-registered Agentic Sandbox V2 stage."
+    )
+    parser.add_argument(
+        "--stage",
+        required=True,
+        choices=sorted(STAGE_SIZES),
+        help="Which pre-registered cohort to run.",
+    )
+    parser.add_argument("--plan", type=Path, default=STAGE_ONE_PLAN_PATH)
+    parser.add_argument("--parquet", type=Path, default=PINNED_DATASET_PARQUET)
+    parser.add_argument(
+        "--run-id",
+        default=None,
+        help=(
+            "Names the journal's run and namespaces every ledger call id. "
+            "Reuse it to resume; a fresh one starts over."
+        ),
+    )
+    parser.add_argument(
+        "--into",
+        type=Path,
+        default=None,
+        help=(
+            "Where deliverables, the journal and the record are written. A "
+            "fresh temporary directory is made if this is left out."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Do everything except reach the network. Exits 0 when the paid "
+            "run would be allowed to go ahead."
+        ),
+    )
+    args = parser.parse_args()
+
+    try:
+        plan, verdict, catalog = verdict_for(args.plan)
+        bound = bind_stage(
+            args.stage,
+            dataset_tasks=read_pinned_dataset(args.parquet),
+            catalog=catalog,
+            catalog_digest=catalog_sha256(),
+        )
+        unpriced = check_the_plan_priced_this_stage(plan, bound)
+        if unpriced:
+            raise StageRefused("\n  - ".join(["this stage is not priced:", *unpriced]))
+    except (StageRefused, ManifestRefused) as refusal:
+        print(f"Refused before spending anything.\n\n{refusal}")
+        return 1
+
+    chosen = verdict.chosen
+    ceilings = ceilings_from(plan, chosen)
+    connection = plan.get("azure_connection") or {}
+    deployment = str((plan.get("model") or {}).get("deployment") or "")
+    resource = str(connection.get("account") or "")
+    profile = {
+        "tool_contract_version": "2.0",
+        "policy_profile_id": str(
+            plan.get("policy_profile_id") or "offline-full-v1"
+        ),
+        "foundation_only": True,
+    }
+    needs = binding_record(bound)["unmet_needs"]
+
+    print(f"Agentic Sandbox V2 — stage {args.stage}")
+    print("=" * 74)
+    print(f"  tasks          {len(bound.tasks)}, sealed as {bound.binding_seal()[:16]}")
+    print(f"  dataset        revision {DATASET_REVISION[:12]}")
+    print(f"  deployment     {deployment} at {resource}")
+    print(
+        f"  settings       {chosen.tool_calls_per_attempt} tool calls, "
+        f"{chosen.max_output_tokens_per_turn} tokens per turn"
+    )
+    priced = chosen.as_dict()
+    print(
+        f"  running        at most ${priced['most_running_could_cost_usd']} "
+        f"against ${verdict.as_dict()['running_approved_maximum_usd']} approved"
+    )
+    print(
+        f"  marking        at most ${priced['most_grading_could_cost_usd']} "
+        f"against ${verdict.as_dict()['grading_approved_maximum_usd']} "
+        "approved, and not spent by this script"
+    )
+    print(f"  isolation      none — fixture backend, exec_run shut")
+    print(
+        f"  handicap       {needs['tasks_needing_reference_files_count']} of "
+        f"{len(bound.tasks)} tasks name reference files that are not in the "
+        "workspace"
+    )
+    print()
+
+    if args.dry_run:
+        print(
+            "Dry run. Nothing was asked and nothing was spent. Every condition "
+            "for the paid run is met."
+        )
+        return 0
+
+    into = (
+        args.into
+        if args.into is not None
+        else Path(tempfile.mkdtemp(prefix=f"agentic-v2-{args.stage}-"))
+    )
+    into.mkdir(parents=True, exist_ok=True)
+    run_id = args.run_id or f"agentic-v2-{args.stage}-{int(time.time())}"
+    print(f"  run id         {run_id}")
+    print(f"  writing to     {into}")
+    print()
+
+    from core.agentic_v2_model_voice import AzureFoundryVoice
+    from core.azure_ai_clients import AzureAIRouteSettings, AzureAIWorkload
+    from core.llm_client import create_typed_azure_client
+
+    settings = AzureAIRouteSettings.from_env()
+    managed = create_typed_azure_client(
+        AzureAIWorkload.INFERENCE,
+        deployment,
+        settings=settings,
+        timeout=float(plan["fixed_settings"]["per_task_timeout_seconds"]),
+    )
+    prices = load_price_table()
+
+    try:
+        wrong_route = check_route_is_the_one_the_plan_fixed(
+            managed.route, connection, settings=settings
+        )
+        if wrong_route:
+            print(
+                "Refused after building a client and before asking it "
+                "anything.\n\n  - " + "\n  - ".join(wrong_route)
+            )
+            return 1
+
+        held = TaskConversations(ceilings, RunWideCeilings())
+        attempts: dict[str, int] = {}
+
+        def attempt_of(task_id: str) -> int:
+            attempts[task_id] = attempts.get(task_id, 0) + 1
+            return attempts[task_id]
+
+        # One voice per task, built on that task's own budget. A single voice
+        # reused across the stage would hold task one's ceiling for all of
+        # them, and the later tasks would be refused by an ceiling that had
+        # nothing to do with them. See build_runner_factory's docstring.
+        def voice_for(budget):
+            return AzureFoundryVoice(
+                client=managed.client,
+                deployment=deployment,
+                resource=resource,
+                budget=budget,
+                instructions=str(plan.get("instructions") or ""),
+                max_output_tokens_per_turn=ceilings.max_written_tokens_per_turn,
+                request_timeout_seconds=ceilings.max_seconds,
+                prices=prices,
+            )
+
+        workspaces = into / "workspaces"
+
+        def backend_factory(**kwargs):
+            task_root = workspaces / f"task-{len(list(workspaces.glob('task-*')))}"
+            task_root.mkdir(parents=True, exist_ok=True)
+            return AgenticV2FixtureBackend(root=task_root, **kwargs)
+
+        workspaces.mkdir(parents=True, exist_ok=True)
+        factory = build_runner_factory(
+            backend_factory=backend_factory,
+            profile=profile,
+            conversations=held,
+            attempt_of=attempt_of,
+            voice_for=voice_for,
+        )
+
+        from core.cost_receipts import CostReceiptLedger
+
+        ledger = CostReceiptLedger(str(into / "cost_receipts.sqlite3"))
+
+        def receipt_for(task, attempt: int):
+            outcome = held.outcome_of(task.task_id, attempt)
+            if outcome is None:
+                return None
+            turns = model_turns_of(
+                outcome,
+                run_id=run_id,
+                task_id=task.task_id,
+                attempt=attempt,
+                provider="azure",
+                requested_model=deployment,
+                deployment=deployment,
+                resolved_model=None,
+            )
+            return bind_run_to_ledger(
+                ledger, task_id=task.task_id, model_turns=turns
+            )
+
+        outcome = run_manifest(
+            bound.tasks,
+            run_id=run_id,
+            runner_factory=factory,
+            journal_path=into / "journal.jsonl",
+            collect_into=into / "deliverables",
+            receipt_for=receipt_for,
+            on_task=lambda task_id, row: print(
+                f"  {task_id}  {'ok' if row.get('success') else 'failed'}"
+            ),
+        )
+    except DriverRefused as refusal:
+        print(f"\nThe run was refused.\n\n{refusal}")
+        return 1
+    finally:
+        managed.close()
+
+    record = {
+        "stage": args.stage,
+        "run_id": run_id,
+        "dataset_revision": DATASET_REVISION,
+        "binding": binding_record(bound),
+        "environment": environment_note(profile),
+        "route_fingerprint": managed.runtime_fingerprint,
+        "chosen_settings": chosen.as_dict(),
+        "conversations": held.as_dict(),
+        "run": outcome.as_dict(),
+    }
+    written = json.dumps(record, indent=2, sort_keys=True, default=str)
+    (into / "run_record.json").write_text(written + "\n", encoding="utf-8")
+
+    summary = outcome.summary
+    print()
+    print(f"  record         {into / 'run_record.json'}")
+    print(f"  finished       {summary.get('succeeded', 0)} of {len(bound.tasks)}")
+    print(f"  spent          {held.spent}")
+    if outcome.stopped is not None:
+        print(f"\nStopped early: {outcome.stopped.detail}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/batch-runner/scripts/run_agentic_v2_stage.py
+++ b/batch-runner/scripts/run_agentic_v2_stage.py
@@ -78,9 +78,12 @@ from core.agentic_v2_route_check import (  # noqa: E402
     check_route_is_the_one_the_plan_fixed,
 )
 from core.agentic_v2_run_driver import DriverRefused, run_manifest  # noqa: E402
+from core.agentic_v2_sharding import ShardRefused  # noqa: E402
+from core.agentic_v2_sharding import parse as parse_shard  # noqa: E402
 from core.agentic_v2_stage_one_budget import (  # noqa: E402
     STAGE_ONE_PLAN_PATH,
     load_stage_one_plan,
+    price_one_stage,
     run_stage_one_preflight,
 )
 from core.execution_envelope_cost import (  # noqa: E402
@@ -229,33 +232,37 @@ def verdict_for(plan_path: Path):
     return plan, result, catalog
 
 
-def check_the_plan_priced_this_stage(plan: dict, bound) -> list[str]:
+def check_the_plan_priced_this_stage(plan: dict, stage: str, bound, catalog) -> list[str]:
     """Whether the amounts approved describe the run about to happen.
 
-    The free check prices the tasks the plan pins, which is the five-task
-    cohort. Its figures are per-run, not per-task, so a thirty-task or
-    two-hundred-and-twenty-task stage run under them would go out against an
-    approval worked out for a run forty-four times smaller — and the printed
-    line would say it was within budget, because the arithmetic it came from
-    never saw the larger cohort.
+    The plan prices each stage by name, and the figures are per-run rather than
+    per-task. So a thirty-task or two-hundred-and-twenty-task stage run under
+    the five-task stage's approval would go out against a figure worked out for
+    a run forty-four times smaller — and the printed line would say it was
+    within budget, because the arithmetic it came from never saw the larger
+    cohort.
 
-    Caught here rather than by scaling the figure, because scaling would be
-    this script deciding what a bigger run costs. Prices come from the plan.
-    When stage thirty and stage two-twenty are to be run, the plan gains their
-    task ids and their two approved amounts, and this stops refusing them.
+    Caught by pricing the cohort that is actually bound, rather than by
+    comparing counts. Counting was the earlier version of this check and it was
+    weaker in both directions: it refused a correctly priced larger stage, and
+    it would have waved through a same-sized cohort whose tasks had grown more
+    expensive. Prices come from the plan; nothing here scales an approved
+    amount on its own.
     """
-    priced = {str(task_id) for task_id in (plan.get("task_ids") or ())}
-    binding = set(bound.task_ids)
-    if priced == binding:
-        return []
-    return [
-        f"the plan prices {len(priced)} tasks and this stage binds "
-        f"{len(binding)}, so the approved amounts do not describe this run. "
-        "They are whole-run figures, not per-task ones, and running "
-        f"{len(binding)} tasks under them would spend roughly "
-        f"{len(binding) / max(len(priced), 1):.0f} times what was approved. "
-        "Price this cohort in the plan first."
-    ]
+    shared_plan_path = BATCH_RUNNER_ROOT / str(
+        plan.get("cost", {}).get("assumptions_come_from")
+        or "experiments/execution_envelope/advance_check_plan.yaml"
+    )
+    pricing = price_one_stage(
+        plan,
+        stage=stage,
+        task_ids=bound.task_ids,
+        tasks_by_id=catalog.by_task_id(),
+        assumptions=CostAssumptions.from_mapping(
+            load_plan(shared_plan_path)["cost"]["assumptions"]
+        ),
+    )
+    return pricing, list(pricing.problems)
 
 
 def main() -> int:
@@ -288,6 +295,16 @@ def main() -> int:
         ),
     )
     parser.add_argument(
+        "--shard",
+        default=None,
+        help=(
+            "Run one piece of the stage, written index/total like 3/17. The "
+            "cohort is dealt out one task at a time, so every shard holds a "
+            "slice of the whole rather than a run of neighbours. Left out, or "
+            "given as 1/1, the whole stage runs in this one process."
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help=(
@@ -305,12 +322,26 @@ def main() -> int:
             catalog=catalog,
             catalog_digest=catalog_sha256(),
         )
-        unpriced = check_the_plan_priced_this_stage(plan, bound)
+        # Priced over the whole stage, never over the shard. A shard is a way of
+        # fitting the run into the place it has to happen, not a smaller
+        # purchase — pricing each piece separately would let seventeen runs that
+        # are each "within budget" spend seventeen times the approval.
+        pricing, unpriced = check_the_plan_priced_this_stage(
+            plan, args.stage, bound, catalog
+        )
         if unpriced:
             raise StageRefused("\n  - ".join(["this stage is not priced:", *unpriced]))
-    except (StageRefused, ManifestRefused) as refusal:
+        shard = parse_shard(args.shard, bound.task_ids)
+    except (StageRefused, ManifestRefused, ShardRefused) as refusal:
         print(f"Refused before spending anything.\n\n{refusal}")
         return 1
+
+    tasks_to_run = bound.tasks
+    if shard is not None:
+        wanted = set(shard.task_ids)
+        tasks_to_run = tuple(
+            task for task in bound.tasks if task.task_id in wanted
+        )
 
     chosen = verdict.chosen
     ceilings = ceilings_from(plan, chosen)
@@ -329,22 +360,34 @@ def main() -> int:
     print(f"Agentic Sandbox V2 — stage {args.stage}")
     print("=" * 74)
     print(f"  tasks          {len(bound.tasks)}, sealed as {bound.binding_seal()[:16]}")
+    if shard is not None:
+        print(
+            f"  shard          {shard.index} of {shard.of} — this run does "
+            f"{len(tasks_to_run)} of them, and the stage has not run until "
+            "every shard has"
+        )
     print(f"  dataset        revision {DATASET_REVISION[:12]}")
     print(f"  deployment     {deployment} at {resource}")
     print(
         f"  settings       {chosen.tool_calls_per_attempt} tool calls, "
         f"{chosen.max_output_tokens_per_turn} tokens per turn"
     )
-    priced = chosen.as_dict()
+    # The stage's own figures, not the five-task plan's. Those two are the same
+    # number only for advance_check_5, and printing the wrong one beside a
+    # two-hundred-task run is how a stage gets described as affordable.
+    money = pricing.as_dict()
     print(
-        f"  running        at most ${priced['most_running_could_cost_usd']} "
-        f"against ${verdict.as_dict()['running_approved_maximum_usd']} approved"
+        f"  running        at most ${money['most_running_could_cost_usd']} "
+        f"against ${money['approved_running_usd']} approved for the whole stage"
     )
-    print(
-        f"  marking        at most ${priced['most_grading_could_cost_usd']} "
-        f"against ${verdict.as_dict()['grading_approved_maximum_usd']} "
-        "approved, and not spent by this script"
-    )
+    if money["approved_grading_usd"] is not None:
+        print(
+            f"  marking        at most ${money['approved_grading_usd']} "
+            "approved, and not spent by this script"
+        )
+    else:
+        print("  marking        not approved for this stage, and not spent here")
+        print(f"                 {money['grading_not_approved_because']}")
     print(f"  isolation      none — fixture backend, exec_run shut")
     print(
         f"  handicap       {needs['tasks_needing_reference_files_count']} of "
@@ -457,7 +500,7 @@ def main() -> int:
             )
 
         outcome = run_manifest(
-            bound.tasks,
+            tasks_to_run,
             run_id=run_id,
             runner_factory=factory,
             journal_path=into / "journal.jsonl",
@@ -478,6 +521,22 @@ def main() -> int:
         "run_id": run_id,
         "dataset_revision": DATASET_REVISION,
         "binding": binding_record(bound),
+        # Present even when the run is not sharded, so that a reader never has
+        # to infer from silence whether a record covers the whole stage.
+        "shard": (
+            shard.as_dict()
+            if shard is not None
+            else {
+                "index": 1,
+                "of": 1,
+                "task_count": len(tasks_to_run),
+                "cohort_size": len(bound.tasks),
+                "task_ids": list(bound.task_ids),
+                "covers_whole_stage": True,
+                "what_this_run_is": "the whole stage, in one run",
+            }
+        ),
+        "approved_amounts": pricing.as_dict(),
         "environment": environment_note(profile),
         "route_fingerprint": managed.runtime_fingerprint,
         "chosen_settings": chosen.as_dict(),
@@ -490,8 +549,13 @@ def main() -> int:
     summary = outcome.summary
     print()
     print(f"  record         {into / 'run_record.json'}")
-    print(f"  finished       {summary.get('succeeded', 0)} of {len(bound.tasks)}")
+    print(f"  finished       {summary.get('succeeded', 0)} of {len(tasks_to_run)}")
     print(f"  spent          {held.spent}")
+    if shard is not None:
+        print(
+            f"\nThis was shard {shard.index} of {shard.of}. The stage has not "
+            "run until the others have and their coverage has been checked."
+        )
     if outcome.stopped is not None:
         print(f"\nStopped early: {outcome.stopped.detail}")
         return 1

--- a/batch-runner/tests/test_agentic_stage_one_budget.py
+++ b/batch-runner/tests/test_agentic_stage_one_budget.py
@@ -42,6 +42,7 @@ from core.agentic_v2_stage_one_budget import (  # noqa: E402
     price_the_options,
     read_dispatcher_limits,
     run_stage_one_preflight,
+    stage_one_amount_note,
     stage_one_ceiling,
     tool_result_tokens_ceiling,
 )
@@ -600,36 +601,102 @@ def _preflight(plan, catalog, assumptions):
     )
 
 
-def test_stage_one_is_refused_today_and_says_the_amount_is_what_is_missing(
+def test_the_committed_stage_one_plan_may_start(
     stage_one_plan, catalog, assumptions
 ):
-    """The honest first answer names which of the two things is missing.
+    """Stage one is approved, and the shipped file is what says so.
 
-    A real model can now be reached: ``AzureFoundryVoice`` asks a Foundry
-    deployment. What has not happened is anybody writing down an amount for
-    stage one, and the refusal says so rather than letting a stale "no model
-    exists" stand in for it.
+    This test used to assert the opposite, and the change is worth naming
+    rather than quietly rewriting. Until 2026-09-11 nobody had written down an
+    amount, so the honest answer was a refusal that said which figure was
+    missing. Two amounts have since been written into the plan under the
+    standing approval, and the gate now passes.
 
-    Said in the preflight's own words rather than the safety check's standing
-    line. Since stage A reaches a separate verdict on a separate amount, that
-    line is no longer a fact about every purchase, so the sentence a reader
-    gets here is the one about stage one's own missing amount.
+    What did not change is where the answer comes from. This reads the
+    committed plan, not a copy with something helpful added, so if either
+    amount is removed or a ceiling grows past it, this fails.
     """
     result = _preflight(stage_one_plan, catalog, assumptions)
 
+    assert result.problems == []
+    assert result.may_start is True
+
+
+@pytest.mark.parametrize(
+    "key, names",
+    [
+        ("running_approved_maximum_usd", "running stage one's five tasks"),
+        ("grading_approved_maximum_usd", "marking stage one's five answers"),
+    ],
+)
+def test_removing_either_approved_amount_refuses_and_names_that_one(
+    stage_one_plan, catalog, assumptions, key, names
+):
+    """Half an approval is not an approval, and the refusal says which half.
+
+    The machinery that refuses a missing amount can no longer be seen through
+    the shipped plan, because the shipped plan now has both. So it is
+    established by taking one away at a time. A reader who gets this refusal
+    must be able to tell which of the two decisions has not been made, since
+    they are made by different reasoning and one is a hundred times the other.
+    """
+    plan = copy.deepcopy(stage_one_plan)
+    plan["cost"].pop(key)
+
+    result = _preflight(plan, catalog, assumptions)
+
     assert result.may_start is False
     assert any(
-        "largest amount that may be spent on stage one" in note
+        f"largest amount that may be spent on {names}" in note
+        and f"cost.{key}" in note
         for note in result.problems
     )
+    # And the other half is not dragged down with it.
+    assert not any("largest amount" in note and names not in note
+                   for note in result.problems)
 
 
-def test_the_missing_amount_is_established_by_running_the_code():
-    """Established by calling the refusing seam, not by reading a comment."""
-    problems = check_stage_one_cannot_reach_a_model()
+def test_the_amount_note_follows_the_plan_rather_than_a_constant(tmp_path):
+    """The sentence that used to be unconditional, now read from the file.
+
+    It said "no amount has been approved" for as long as it existed, and would
+    have gone on saying it after the amounts were written down — printed as a
+    blocker by the readiness report, where somebody deciding what to do next
+    would read it. Both directions are checked here: silence on the committed
+    plan, and the full sentence on a plan with the figures taken out.
+    """
+    assert check_stage_one_cannot_reach_a_model() == []
+    assert stage_one_amount_note() == []
+
+    raw = yaml.safe_load(STAGE_ONE_PLAN_PATH.read_text(encoding="utf-8"))
+    raw["cost"].pop("running_approved_maximum_usd")
+    stripped = tmp_path / "one_amount_missing.yaml"
+    stripped.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+
+    problems = stage_one_amount_note(stripped)
+
     assert len(problems) == 1
     assert "no amount has been approved" in problems[0]
     assert "core.agentic_v2_model_voice.AzureFoundryVoice" in problems[0]
+    # And it names the half that is missing rather than both.
+    assert "cost.running_approved_maximum_usd" in problems[0]
+    assert "cost.grading_approved_maximum_usd" not in problems[0]
+
+
+def test_an_unreadable_plan_counts_as_unapproved(tmp_path):
+    """The safe direction when the question cannot be answered.
+
+    Treating a plan nobody can read as approved would turn a corrupted file
+    into permission. It reports the failure instead, which is a blocker either
+    way, and names what went wrong so it can be fixed rather than puzzled over.
+    """
+    broken = tmp_path / "not_a_plan.yaml"
+    broken.write_text("plan_version: something-else\n", encoding="utf-8")
+
+    problems = stage_one_amount_note(broken)
+
+    assert len(problems) == 1
+    assert "has to be treated as unapproved" in problems[0]
 
 
 def test_the_check_reports_it_if_the_seam_stops_asking_for_an_amount(
@@ -738,19 +805,47 @@ def test_the_check_reports_it_if_the_runner_gains_a_model_client(monkeypatch):
     assert any("now accepts a model client" in note for note in problems)
 
 
-def test_the_committed_stage_one_plan_approves_nothing(stage_one_plan):
-    """Nothing has been approved for stage one, and the file must say so."""
+def test_the_committed_stage_one_plan_approves_two_amounts_and_settings(
+    stage_one_plan,
+):
+    """The exact figures in the file, read back, and the old key gone.
+
+    Pinned rather than left to the gate because these four numbers are the
+    decision. A change to any of them is somebody deciding something different
+    about what stage one may cost or what the model is given room to do, and
+    that should have to edit this test and say why.
+
+    The absence of ``approved_maximum_usd`` is asserted too. A plan carrying
+    both the old total and the two parts would be read one way by the gate and
+    another way by a person, and the person would be reading a number that
+    nothing enforces.
+    """
     cost = stage_one_plan["cost"]
-    assert cost["approved_maximum_usd"] is None
-    assert cost["chosen_settings"]["tool_calls_per_attempt"] is None
-    assert cost["chosen_settings"]["max_output_tokens_per_turn"] is None
+
+    assert "approved_maximum_usd" not in cost
+    assert Decimal(str(cost["running_approved_maximum_usd"])) == Decimal("50.00")
+    assert Decimal(str(cost["grading_approved_maximum_usd"])) == Decimal("2600.00")
+    assert cost["chosen_settings"]["tool_calls_per_attempt"] == 8
+    assert cost["chosen_settings"]["max_output_tokens_per_turn"] == 8_192
 
 
 def test_the_three_place_approval_does_not_extend_to_stage_one(
     stage_one_plan, catalog, assumptions
 ):
-    """The 32.23 approved on 2026-08-25 was for that comparison and no other."""
-    result = _preflight(stage_one_plan, catalog, assumptions)
+    """The 32.23 approved on 2026-08-25 was for that comparison and no other.
+
+    Seen by removing stage one's own amounts, which is the only state in which
+    the question arises. Stage one was approved separately and on its own
+    figures; the point being kept alive here is that it had to be, and that a
+    plan with nothing written down is not quietly covered by the older, smaller
+    approval sitting next to it in the same repository.
+    """
+    plan = copy.deepcopy(stage_one_plan)
+    plan["cost"].pop("running_approved_maximum_usd")
+    plan["cost"].pop("grading_approved_maximum_usd")
+
+    result = _preflight(plan, catalog, assumptions)
+
     assert any("does not extend here" in note for note in result.problems)
 
 
@@ -772,11 +867,16 @@ def test_choosing_a_row_reports_the_limit_each_task_would_be_stopped_by(
     refusing it. Nothing about stage one had changed; a number written down by
     hand had simply stopped describing the thing it was chosen to clear.
 
-    So it is derived instead: price the row, approve exactly that, and the
-    money question is settled by construction however the assumptions move
-    next. Exactly the price is enough because the refusal is written ``>``,
-    not ``>=`` — an approver who signs off the quoted figure has signed off
-    the run.
+    So they are derived instead: price the row, approve exactly what it prices
+    at, and the money question is settled by construction however the
+    assumptions move next. Exactly the price is enough because the refusal is
+    written ``>``, not ``>=`` — an approver who signs off the quoted figure has
+    signed off the run.
+
+    Two amounts are derived, not one, because the two halves move for
+    unrelated reasons. Running follows the row; marking is the same flat figure
+    on every row. Approving the total would let a change in one be absorbed by
+    headroom in the other.
     """
     plan = copy.deepcopy(stage_one_plan)
     plan["cost"]["chosen_settings"] = {
@@ -786,7 +886,12 @@ def test_choosing_a_row_reports_the_limit_each_task_would_be_stopped_by(
 
     priced = _preflight(plan, catalog, assumptions)
     assert priced.chosen is not None
-    plan["cost"]["approved_maximum_usd"] = priced.chosen.most_it_could_cost_usd
+    plan["cost"]["running_approved_maximum_usd"] = (
+        priced.chosen.most_running_could_cost_usd
+    )
+    plan["cost"]["grading_approved_maximum_usd"] = (
+        priced.chosen.most_grading_could_cost_usd
+    )
 
     result = _preflight(plan, catalog, assumptions)
 
@@ -798,23 +903,56 @@ def test_choosing_a_row_reports_the_limit_each_task_would_be_stopped_by(
         assert budget.max_input_tokens > 0
         assert budget.refusal_before_next_call() is None
 
-    # And with the row chosen and exactly its price approved, nothing is left
-    # standing. That is the whole shape of this gate: the amount is the last
-    # thing, so supplying it here empties the list rather than shortening it.
+    # And with the row chosen and exactly its price approved for each half,
+    # nothing is left standing. That is the whole shape of this gate: the
+    # amounts are the last thing, so supplying them here empties the list
+    # rather than shortening it.
     #
     # Nothing starts because of this. The check is a verdict, not a switch —
-    # the safety blocks it just confirmed are separate code and are still shut,
-    # and this ran against a copy of the plan. The shipped file still carries
-    # no amount and is still refused, which the tool test below runs to see.
+    # the safety blocks it just confirmed are separate code and are still shut.
+    # The shipped plan clears the same gate on different figures, which the
+    # test above runs to see; this one shows the gate would still be passable
+    # at a row nobody chose, so what passed up there was the arithmetic and not
+    # a number picked to be comfortable.
     assert result.problems == []
     assert result.may_start is True
 
 
-def test_nothing_is_chosen_so_no_limit_is_reported(
+def test_nothing_chosen_means_no_limit_is_reported(
     stage_one_plan, catalog, assumptions
 ):
-    result = _preflight(stage_one_plan, catalog, assumptions)
+    """No settings, no per-task limit — and nothing invented to stand in.
+
+    The plan now names a chosen row, so this is seen by taking it away. What
+    matters is the empty dictionary rather than a refusal: a gate that helpfully
+    supplied a default limit here would be choosing the settings itself, and
+    the settings are the thing stage one exists to decide.
+    """
+    plan = copy.deepcopy(stage_one_plan)
+    plan["cost"]["chosen_settings"] = {
+        "tool_calls_per_attempt": None,
+        "max_output_tokens_per_turn": None,
+    }
+
+    result = _preflight(plan, catalog, assumptions)
+
+    assert result.chosen is None
     assert result.chosen_budget == {}
+    assert result.may_start is False
+
+
+def test_the_committed_plan_reports_a_limit_for_every_task(
+    stage_one_plan, catalog, assumptions
+):
+    """The other side of the same coin, on the figures that will really run."""
+    result = _preflight(stage_one_plan, catalog, assumptions)
+
+    assert set(result.chosen_budget) == set(stage_one_plan["task_ids"])
+    for budget in result.chosen_budget.values():
+        # Nine turns — eight tool calls and the turn that finishes — across a
+        # first attempt and one retry.
+        assert budget.max_model_calls == 8 * 2
+        assert budget.max_output_tokens == 8_192 * 8 * 2
 
 
 def test_the_reported_limit_stops_a_run_that_reaches_it(
@@ -826,7 +964,8 @@ def test_the_reported_limit_stops_a_run_that_reaches_it(
         "tool_calls_per_attempt": 4,
         "max_output_tokens_per_turn": 2_048,
     }
-    plan["cost"]["approved_maximum_usd"] = 1_000
+    plan["cost"]["running_approved_maximum_usd"] = 1_000
+    plan["cost"]["grading_approved_maximum_usd"] = 10_000
 
     result = _preflight(plan, catalog, assumptions)
     budget = result.chosen_budget[plan["task_ids"][0]]
@@ -846,7 +985,6 @@ def test_choosing_settings_nobody_priced_is_refused(
         "tool_calls_per_attempt": 5,
         "max_output_tokens_per_turn": 3_000,
     }
-    plan["cost"]["approved_maximum_usd"] = 1_000
 
     result = _preflight(plan, catalog, assumptions)
 
@@ -854,20 +992,60 @@ def test_choosing_settings_nobody_priced_is_refused(
     assert any("not one of the candidates" in note for note in result.problems)
 
 
-def test_an_approved_amount_below_the_chosen_setting_is_refused(
+def test_a_plan_still_carrying_the_old_single_amount_is_refused(
     stage_one_plan, catalog, assumptions
 ):
+    """The retired key is refused out loud, not read as either half.
+
+    An approval given for a total is not an approval of a part of it. The
+    danger being closed is the quiet reading: a gate that saw 2,600 under the
+    old name and took it as the running ceiling would wave through a run
+    seventy times larger than the one the approver had in mind, and would print
+    a line saying it was within budget.
+    """
+    plan = copy.deepcopy(stage_one_plan)
+    plan["cost"]["approved_maximum_usd"] = 2_600
+
+    result = _preflight(plan, catalog, assumptions)
+
+    assert result.may_start is False
+    assert any(
+        "one figure covering both running and marking" in note
+        for note in result.problems
+    )
+
+
+@pytest.mark.parametrize(
+    "key, half",
+    [
+        ("running_approved_maximum_usd", "running the five tasks"),
+        ("grading_approved_maximum_usd", "marking the five answers"),
+    ],
+)
+def test_an_approved_amount_below_the_chosen_setting_is_refused(
+    stage_one_plan, catalog, assumptions, key, half
+):
+    """Either half being too small refuses the whole, and says which half.
+
+    Run against both because they fail differently. Running is what the chosen
+    row moves, so it is the half an ambitious setting breaks. Marking is flat,
+    so it is the half that breaks when the marking assumptions are corrected
+    and nobody revisits the amount — which has already happened once.
+    """
     plan = copy.deepcopy(stage_one_plan)
     plan["cost"]["chosen_settings"] = {
         "tool_calls_per_attempt": 32,
         "max_output_tokens_per_turn": 32_768,
     }
-    plan["cost"]["approved_maximum_usd"] = "1.00"
+    plan["cost"][key] = "1.00"
 
     result = _preflight(plan, catalog, assumptions)
 
     assert result.may_start is False
-    assert any("is above the" in note for note in result.problems)
+    assert any(
+        f"the most {half} could cost" in note and "is above the" in note
+        for note in result.problems
+    )
     assert result.chosen is not None
 
 
@@ -1003,21 +1181,49 @@ def test_the_stage_one_plan_uses_the_same_five_tasks(stage_one_plan):
 # amount must never be the reason stage A cannot go.
 
 
-def test_the_probe_may_go_today_while_stage_one_still_may_not(
+def test_both_verdicts_pass_on_the_shipped_plan(
     stage_one_plan, catalog, assumptions
 ):
-    """The two verdicts as the shipped plan leaves them, and why they differ.
+    """The two verdicts as the shipped plan now leaves them: both green.
 
-    Stage A has an amount and settings written down; stage one has neither.
-    Nothing else separates them, which is the point — the same safety checks
-    were run for both, and only the money question came out differently.
+    They used to disagree, and that disagreement was doing the work of showing
+    they were reached separately. It no longer can, so the separation is shown
+    by the test below instead, which takes stage one's amounts away and watches
+    stage A carry on unaffected.
     """
     result = _preflight(stage_one_plan, catalog, assumptions)
 
-    assert result.may_start is False
+    assert result.may_start is True
     assert result.probe is not None
     assert result.probe.may_start is True
     assert result.probe.problems == []
+
+
+def test_stage_ones_money_question_does_not_reach_the_probe(
+    stage_one_plan, catalog, assumptions
+):
+    """Stage one losing its approval must not stop stage A, or vice versa.
+
+    Each is held to its own amount. Stage A's is one dollar for a single
+    unmarked task; stage one's is two figures covering five tasks and their
+    marking. A gate that let one answer the other would either block the cheap
+    question over the expensive one's paperwork, or — far worse in the other
+    direction — let the expensive one ride on the cheap one's approval.
+    """
+    without_stage_one = copy.deepcopy(stage_one_plan)
+    without_stage_one["cost"].pop("running_approved_maximum_usd")
+    without_stage_one["cost"].pop("grading_approved_maximum_usd")
+
+    result = _preflight(without_stage_one, catalog, assumptions)
+    assert result.may_start is False
+    assert result.probe is not None and result.probe.may_start is True
+
+    without_the_probe = copy.deepcopy(stage_one_plan)
+    without_the_probe["cost"]["stage_a_probe"]["approved_maximum_usd"] = None
+
+    other = _preflight(without_the_probe, catalog, assumptions)
+    assert other.probe is not None and other.probe.may_start is False
+    assert other.may_start is True
 
 
 def test_a_safety_block_opening_refuses_the_probe_as_well(
@@ -1101,7 +1307,8 @@ def test_no_amount_for_the_probe_is_refused_rather_than_borrowed(
     """Approval for one purchase is not approval for the other, either way."""
     plan = copy.deepcopy(stage_one_plan)
     plan["cost"]["stage_a_probe"]["approved_maximum_usd"] = None
-    plan["cost"]["approved_maximum_usd"] = Decimal("10000")
+    plan["cost"]["running_approved_maximum_usd"] = Decimal("10000")
+    plan["cost"]["grading_approved_maximum_usd"] = Decimal("10000")
 
     result = _preflight(plan, catalog, assumptions)
 
@@ -1213,8 +1420,14 @@ def test_the_probe_verdict_survives_being_written_down(
     assert Decimal(probe["most_it_could_cost_usd"]) <= Decimal(
         probe["approved_maximum_usd"]
     )
-    # The two verdicts are reported side by side and disagree.
-    assert written["may_start"] is False
+
+    # Stage one's own verdict is written alongside, against two amounts rather
+    # than one. The probe keeps a single figure on purpose: it marks nothing,
+    # so a second amount there would be an approval for work it does not do.
+    assert written["may_start"] is True
+    assert written["running_approved_maximum_usd"] == "50.00"
+    assert written["grading_approved_maximum_usd"] == "2600.00"
+    assert "approved_maximum_usd" not in written
 
 
 # ── The tool a person actually runs ────────────────────────────────────────
@@ -1251,8 +1464,29 @@ def test_the_new_files_are_in_the_repository(relative):
     )
 
 
-def test_running_the_tool_refuses_and_prints_the_table():
-    """Run it exactly as a person would, and require a refusal with the numbers."""
+def _plan_without_stage_ones_amounts(tmp_path: Path) -> Path:
+    """The committed plan with only the two approved figures taken out.
+
+    Written for the command-line tests, which need a plan the tool refuses now
+    that the shipped one passes. Everything else is copied through untouched,
+    so what the tool is reacting to is the missing money and nothing else.
+    """
+    raw = yaml.safe_load(STAGE_ONE_PLAN_PATH.read_text(encoding="utf-8"))
+    raw["cost"].pop("running_approved_maximum_usd")
+    raw["cost"].pop("grading_approved_maximum_usd")
+    written = tmp_path / "plan_without_amounts.yaml"
+    written.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+    return written
+
+
+def test_running_the_tool_passes_and_prints_the_table():
+    """Run it exactly as a person would, and require the numbers with the verdict.
+
+    The table matters more now than when this refused. A zero exit is the point
+    at which somebody could stop reading, so the figures the approval rests on
+    have to be in the same output rather than only in the refusal that used to
+    carry them.
+    """
     finished = subprocess.run(
         [sys.executable, str(STAGE_ONE_SCRIPT)],
         cwd=BATCH_RUNNER_ROOT,
@@ -1261,39 +1495,79 @@ def test_running_the_tool_refuses_and_prints_the_table():
         timeout=300,
     )
 
-    assert finished.returncode == 1, finished.stdout + finished.stderr
+    assert finished.returncode == 0, finished.stdout + finished.stderr
     assert "What each candidate setting could cost at most" in finished.stdout
-    assert (
-        "nobody has written down the largest amount that may be spent on "
-        "stage one" in finished.stdout
-    )
+    # Both halves of the approval, each against its own ceiling.
+    assert "50.00" in finished.stdout
+    assert "2600.00" in finished.stdout
     # The dispatcher's real ceiling, read from code, must reach the report.
     assert str(read_dispatcher_limits().max_total_calls) in finished.stdout
 
 
-def test_the_probe_flag_follows_the_probe_s_verdict_and_says_so():
-    """A green light for stage A, printed in the same report that refuses stage one.
+def test_the_tool_still_refuses_a_plan_with_no_amounts(tmp_path):
+    """The refusal path, kept alive on a plan that has had its figures removed.
 
-    Two verdicts in one place is the risk this covers: a reader who sees a zero
-    exit could take it for permission to run the five tasks. The report says
-    plainly that it is not, and the default form of the same command still
-    refuses.
+    This is the state the repository was in until stage one was approved, and
+    it is the state any future stage starts in. Losing the test with the
+    approval would mean the next stage's gate was never seen to refuse.
     """
     finished = subprocess.run(
-        [sys.executable, str(STAGE_ONE_SCRIPT), "--probe"],
+        [
+            sys.executable,
+            str(STAGE_ONE_SCRIPT),
+            "--plan",
+            str(_plan_without_stage_ones_amounts(tmp_path)),
+        ],
         cwd=BATCH_RUNNER_ROOT,
         capture_output=True,
         text=True,
         timeout=300,
     )
 
-    assert finished.returncode == 0, finished.stdout + finished.stderr
-    assert "Every stage A condition is met" in finished.stdout
-    assert "separate purchase" in finished.stdout
+    assert finished.returncode == 1, finished.stdout + finished.stderr
+    assert (
+        "nobody has written down the largest amount that may be spent on "
+        "running stage one's five tasks" in finished.stdout
+    )
+    assert (
+        "nobody has written down the largest amount that may be spent on "
+        "marking stage one's five answers" in finished.stdout
+    )
+
+
+def test_the_probe_flag_follows_the_probe_and_not_stage_one(tmp_path):
+    """``--probe`` answers about stage A even when stage one is refused.
+
+    Two verdicts in one place is the risk this covers, and the direction of the
+    risk has flipped. It used to be that a zero exit from ``--probe`` might be
+    read as permission to run the five tasks. Now that the default form also
+    exits zero, the thing worth holding is that ``--probe`` is still *not*
+    reading stage one's verdict — shown on a plan where the two disagree.
+    """
+    without_amounts = str(_plan_without_stage_ones_amounts(tmp_path))
+    probed = subprocess.run(
+        [sys.executable, str(STAGE_ONE_SCRIPT), "--probe", "--plan", without_amounts],
+        cwd=BATCH_RUNNER_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    default = subprocess.run(
+        [sys.executable, str(STAGE_ONE_SCRIPT), "--plan", without_amounts],
+        cwd=BATCH_RUNNER_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+    assert probed.returncode == 0, probed.stdout + probed.stderr
+    assert default.returncode == 1
+    assert "Every stage A condition is met" in probed.stdout
+    assert "separate purchase" in probed.stdout
     # The refusal of the larger purchase is printed by the same run.
     assert (
         "nobody has written down the largest amount that may be spent on "
-        "stage one" in finished.stdout
+        "running stage one's five tasks" in probed.stdout
     )
 
 
@@ -1314,7 +1588,10 @@ def test_the_probe_is_reported_whichever_form_of_the_command_is_run():
         timeout=300,
     )
 
-    assert default.returncode == 1
+    # Both pass on the shipped plan, so this no longer shows the exit codes
+    # coming from different places. That is the test above. What it does show
+    # is that the report itself does not change with the flag.
+    assert default.returncode == 0
     assert probed.returncode == 0
     assert default.stdout == probed.stdout
 
@@ -1336,11 +1613,12 @@ def test_the_tool_can_report_itself_as_json():
         timeout=300,
     )
 
-    assert finished.returncode == 1
+    assert finished.returncode == 0
     import json
 
     written = json.loads(finished.stdout)
-    assert written["may_start"] is False
-    assert written["approved_maximum_usd"] is None
-    assert written["chosen"] is None
+    assert written["may_start"] is True
+    assert written["running_approved_maximum_usd"] == "50.00"
+    assert written["grading_approved_maximum_usd"] == "2600.00"
+    assert written["chosen"] is not None
     assert len(written["options"]) > 0

--- a/batch-runner/tests/test_agentic_stage_one_budget.py
+++ b/batch-runner/tests/test_agentic_stage_one_budget.py
@@ -39,6 +39,7 @@ from core.agentic_v2_stage_one_budget import (  # noqa: E402
     budget_for_one_task,
     check_stage_one_cannot_reach_a_model,
     load_stage_one_plan,
+    price_one_stage,
     price_the_options,
     read_dispatcher_limits,
     run_stage_one_preflight,
@@ -1622,3 +1623,196 @@ def test_the_tool_can_report_itself_as_json():
     assert written["grading_approved_maximum_usd"] == "2600.00"
     assert written["chosen"] is not None
     assert len(written["options"]) > 0
+
+
+# ── Pricing a stage by name ────────────────────────────────────────────────
+#
+# The guard these cover replaced one that compared two task counts. The
+# counting version had the failure mode that matters here backwards: it refused
+# a larger stage even when that stage had been priced, and it would have passed
+# a cohort of the approved *size* whose tasks had grown more expensive. These
+# ask the only question worth asking — does the amount approved for this stage
+# cover the cohort that is about to run.
+
+
+def _priced_plan(**stage_overrides) -> dict:
+    """The committed plan, with its `stages` block swapped for a given one."""
+    plan = dict(load_stage_one_plan(STAGE_ONE_PLAN_PATH))
+    plan["stages"] = dict(stage_overrides)
+    return plan
+
+
+def test_every_registered_stage_in_the_committed_plan_is_priced_for_running(
+    catalog, assumptions, stage_one_plan
+):
+    """All three rungs, priced. An escalation with a gap cannot be climbed.
+
+    Read from the committed plan rather than a fixture, because the thing being
+    checked is that the real file carries the approvals — a fixture would pass
+    happily while the file that actually gates the run did not.
+    """
+    from core.agentic_v2_preregistration import ESCALATION, cohorts
+
+    groups = cohorts(catalog)
+    for stage in ESCALATION:
+        pricing = price_one_stage(
+            stage_one_plan,
+            stage=stage,
+            task_ids=groups[stage],
+            tasks_by_id=catalog.by_task_id(),
+            assumptions=assumptions,
+        )
+        assert pricing.may_run, (stage, pricing.problems)
+        assert pricing.approved_running_usd is not None
+        assert pricing.most_running_could_cost_usd <= pricing.approved_running_usd
+        assert pricing.headroom_usd >= 0
+
+
+def test_marking_is_approved_for_the_five_and_refused_with_a_reason_beyond_them(
+    catalog, assumptions, stage_one_plan
+):
+    """The asymmetry is the finding, so it is asserted rather than assumed.
+
+    Running two hundred and twenty tasks costs a few hundred dollars. Marking
+    them costs six figures, because the grader asks hundreds of questions per
+    answer. Those are two decisions and only one of them has been made.
+    """
+    from core.agentic_v2_preregistration import cohorts
+
+    groups = cohorts(catalog)
+
+    five = price_one_stage(
+        stage_one_plan, stage="advance_check_5", task_ids=groups["advance_check_5"],
+        tasks_by_id=catalog.by_task_id(), assumptions=assumptions,
+    )
+    assert five.approved_grading_usd is not None
+    assert five.grading_not_approved_because is None
+
+    for stage in ("trial_30", "full_220"):
+        bigger = price_one_stage(
+            stage_one_plan, stage=stage, task_ids=groups[stage],
+            tasks_by_id=catalog.by_task_id(), assumptions=assumptions,
+        )
+        assert bigger.approved_grading_usd is None, stage
+        # Refused *and* explained. A null with no reason is indistinguishable
+        # from a figure somebody forgot to write, and the two want opposite
+        # responses from whoever reads it next.
+        assert bigger.grading_not_approved_because, stage
+        assert bigger.may_run, (stage, bigger.problems)
+
+
+def test_the_five_task_amounts_are_one_figure_and_not_two_copies(stage_one_plan):
+    """``cost`` and ``stages.advance_check_5`` must not be able to disagree.
+
+    They are written as a YAML anchor and an alias, so they cannot. This holds
+    that property against somebody later replacing the alias with a literal
+    that looks identical on the day it is written.
+    """
+    cost = stage_one_plan["cost"]
+    entry = stage_one_plan["stages"]["advance_check_5"]
+
+    assert entry["running_approved_maximum_usd"] == cost["running_approved_maximum_usd"]
+    assert entry["grading_approved_maximum_usd"] == cost["grading_approved_maximum_usd"]
+
+
+def test_a_cohort_larger_than_its_approval_is_refused_with_the_shortfall(
+    catalog, assumptions
+):
+    """The number is the point. "Not priced" invites someone to wave it through."""
+    from core.agentic_v2_preregistration import cohorts
+
+    plan = _priced_plan(
+        full_220={
+            "running_approved_maximum_usd": 50.00,
+            "grading_approved_maximum_usd": None,
+            "grading_not_approved_because": "not asked for",
+        }
+    )
+
+    pricing = price_one_stage(
+        plan, stage="full_220", task_ids=cohorts(catalog)["full_220"],
+        tasks_by_id=catalog.by_task_id(), assumptions=assumptions,
+    )
+
+    assert not pricing.may_run
+    trouble = " ".join(pricing.problems)
+    assert "short by $" in trouble
+    assert "nothing here may scale an approved amount on its own" in trouble
+
+
+def test_a_stage_the_plan_never_mentions_is_refused_by_name(catalog, assumptions):
+    plan = _priced_plan(advance_check_5={"running_approved_maximum_usd": 50.00,
+                                         "grading_approved_maximum_usd": 2600.00})
+
+    pricing = price_one_stage(
+        plan, stage="trial_30", task_ids=("a", "b"),
+        tasks_by_id=catalog.by_task_id(), assumptions=assumptions,
+    )
+
+    assert not pricing.may_run
+    trouble = " ".join(pricing.problems)
+    assert "'trial_30'" in trouble
+    assert "whatever their relative sizes" in trouble
+
+
+def test_silence_about_marking_is_refused_but_a_reasoned_refusal_is_not(
+    catalog, assumptions
+):
+    """Absent and null are different answers, and only one is a mistake.
+
+    Marking costs many times what running does, so a stage block that simply
+    never mentions it is the one shape this may not take: it reads as approved
+    to anybody who does not already know the number.
+    """
+    from core.agentic_v2_preregistration import cohorts
+
+    ids = cohorts(catalog)["advance_check_5"]
+    silent = price_one_stage(
+        _priced_plan(advance_check_5={"running_approved_maximum_usd": 50.00}),
+        stage="advance_check_5", task_ids=ids,
+        tasks_by_id=catalog.by_task_id(), assumptions=assumptions,
+    )
+    assert not silent.may_run
+    assert "says nothing about marking" in " ".join(silent.problems)
+
+    unexplained = price_one_stage(
+        _priced_plan(advance_check_5={
+            "running_approved_maximum_usd": 50.00,
+            "grading_approved_maximum_usd": None,
+        }),
+        stage="advance_check_5", task_ids=ids,
+        tasks_by_id=catalog.by_task_id(), assumptions=assumptions,
+    )
+    assert not unexplained.may_run
+    assert "gives no reason" in " ".join(unexplained.problems)
+
+    explained = price_one_stage(
+        _priced_plan(advance_check_5={
+            "running_approved_maximum_usd": 50.00,
+            "grading_approved_maximum_usd": None,
+            "grading_not_approved_because": "nobody has asked for the answers "
+                                            "to be marked yet",
+        }),
+        stage="advance_check_5", task_ids=ids,
+        tasks_by_id=catalog.by_task_id(), assumptions=assumptions,
+    )
+    assert explained.may_run, explained.problems
+
+
+def test_a_plan_with_no_stages_block_refuses_rather_than_passing_by_default(
+    catalog, assumptions
+):
+    """The state the file was in before any stage was priced by name.
+
+    A guard whose absent configuration means "allow" is not a guard.
+    """
+    plan = dict(load_stage_one_plan(STAGE_ONE_PLAN_PATH))
+    plan.pop("stages", None)
+
+    pricing = price_one_stage(
+        plan, stage="advance_check_5", task_ids=("a",),
+        tasks_by_id=catalog.by_task_id(), assumptions=assumptions,
+    )
+
+    assert not pricing.may_run
+    assert "no `stages` block" in " ".join(pricing.problems)

--- a/batch-runner/tests/test_agentic_v2_conversation_runner.py
+++ b/batch-runner/tests/test_agentic_v2_conversation_runner.py
@@ -38,6 +38,7 @@ from core.agentic_v2_cost_binding import bind_run_to_ledger
 from core.agentic_v2_fixture_backend import AgenticV2FixtureBackend
 from core.agentic_v2_provenance import verify_agentic_v2_result
 from core.agentic_v2_runner import AgenticV2ScriptedRunner
+from core.agentic_v2_stage_one_budget import StageOneBudget
 from core.cost_receipts import (
     BUCKET_PROBLEM_SOLVING,
     CostReceiptLedger,
@@ -440,15 +441,81 @@ class TestTheRunnerFactory:
         assert held.outcome_of("task-1", 1).stop_reason is StopReason.FINISHED_NORMALLY
         assert held.attempts_of("task-1") == (1,)
 
-    def test_a_factory_without_a_voice_is_refused(self, tmp_path):
-        with pytest.raises(ConversationRunnerRefused, match="needs a voice"):
+    def test_a_factory_with_neither_voice_is_refused(self, tmp_path):
+        with pytest.raises(ConversationRunnerRefused, match="exactly one"):
             build_runner_factory(
                 backend_factory=_backend_factory(tmp_path),
                 profile=PROFILE,
-                voice=None,
                 conversations=TaskConversations(CEILINGS),
                 attempt_of=lambda task_id: 1,
             )
+
+    def test_a_factory_with_both_voices_is_refused(self, tmp_path):
+        """Not a style objection. The two disagree about which budget is real.
+
+        ``voice`` carries whatever budget it was built with and ``voice_for``
+        is handed the task's own; a factory holding both would use one and
+        quietly drop the other, and which one it dropped would only show up in
+        the bill.
+        """
+        with pytest.raises(ConversationRunnerRefused, match="exactly one"):
+            build_runner_factory(
+                backend_factory=_backend_factory(tmp_path),
+                profile=PROFILE,
+                voice=ScriptedVoice(replies=[_finalize()]),
+                voice_for=lambda budget: ScriptedVoice(replies=[_finalize()]),
+                conversations=TaskConversations(CEILINGS),
+                attempt_of=lambda task_id: 1,
+            )
+
+    def test_each_task_gets_a_voice_built_on_its_own_budget(self, tmp_path):
+        """The reason ``voice_for`` exists, stated as an assertion.
+
+        A paid voice holds a budget and refuses before the call that would pass
+        it. If the run built one voice and reused it, task 220 would be refused
+        by task 1's spending. Here each task's voice must receive *that task's*
+        budget object — the same one the loop charges — so the two ceilings are
+        one number rather than two that drift.
+        """
+        held = TaskConversations(CEILINGS)
+        handed: list[StageOneBudget] = []
+
+        def voice_for(budget):
+            handed.append(budget)
+            return ScriptedVoice(replies=[_write(), _finalize()])
+
+        factory = build_runner_factory(
+            backend_factory=_backend_factory(tmp_path),
+            profile=PROFILE,
+            voice_for=voice_for,
+            conversations=held,
+            attempt_of=lambda task_id: 1,
+        )
+        for task_id in ("task-1", "task-2", "task-3"):
+            factory(self._task(task_id)).run("Write the report", task_id=task_id)
+
+        assert len(handed) == 3
+        assert len({id(budget) for budget in handed}) == 3, (
+            "three tasks were handed the same budget object, which is the "
+            "sharing this argument exists to prevent"
+        )
+        for task_id, budget in zip(("task-1", "task-2", "task-3"), handed):
+            assert held.budgets[(task_id, 1)] is budget, (
+                "the voice was built on a budget the loop does not charge, so "
+                "the voice's ceiling and the run's accounting are two "
+                "different numbers"
+            )
+
+    def test_a_voice_for_that_returns_nothing_is_refused(self, tmp_path):
+        factory = build_runner_factory(
+            backend_factory=_backend_factory(tmp_path),
+            profile=PROFILE,
+            voice_for=lambda budget: None,
+            conversations=TaskConversations(CEILINGS),
+            attempt_of=lambda task_id: 1,
+        )
+        with pytest.raises(ConversationRunnerRefused, match="no way to ask a model"):
+            factory(self._task())
 
     def test_a_spent_run_refuses_before_a_guest_is_booted(self, tmp_path):
         held = TaskConversations(CEILINGS, RunWideCeilings(max_model_calls=1))

--- a/batch-runner/tests/test_agentic_v2_preregistration.py
+++ b/batch-runner/tests/test_agentic_v2_preregistration.py
@@ -11,13 +11,18 @@ Nothing here runs a task, calls a model, boots a guest or spends.
 from __future__ import annotations
 
 import hashlib
+import inspect
 import json
 from pathlib import Path
+from unittest import mock
 
 import pytest
 import yaml
 
 from core.agentic_v2_contract import TOOL_NAMES
+from core.agentic_v2_conversation import run_model_conversation
+from core.agentic_v2_conversation_runner import build_runner_factory, ceilings_from
+from core.agentic_v2_stage_one_budget import load_stage_one_plan
 from core.agentic_v2_preregistration import (
     CODEX_TRIAL_PLAN,
     Comparison,
@@ -26,6 +31,7 @@ from core.agentic_v2_preregistration import (
     MATCHES,
     NOT_STOP_RULES,
     PREREGISTRATION_ARTEFACT as ARTEFACT,
+    REPOSITORY_ROOT,
     STAGE_FIVE,
     STAGE_THIRTY,
     STAGE_TWO_TWENTY,
@@ -246,15 +252,188 @@ class TestThereIsNoSuccessQuota:
         assert all(isinstance(rule, str) and rule for rule in STOP_RULES)
 
 
+class TestTheConditionsAreRecordedBeforeTheRun:
+    """Model, prompt, tools, ceilings, retries — written down ahead of time.
+
+    A pre-registration whose conditions are written by hand is a description of
+    a run somebody intended. Each test below asks the thing that would actually
+    execute, and fails if the record and the executable disagree — which is the
+    only way the record stays worth reading a month after it was sealed.
+    """
+
+    def test_the_conditions_are_read_from_the_plan_and_the_plan_is_sealed(self):
+        conditions = record()["run_conditions"]
+
+        plan_path = REPOSITORY_ROOT / conditions["read_from"]
+        assert plan_path.is_file()
+        assert (
+            conditions["read_from_sha256"]
+            == hashlib.sha256(plan_path.read_bytes()).hexdigest()
+        )
+
+    def test_the_model_and_the_resource_both_appear(self):
+        """A deployment name alone does not identify a model.
+
+        The same name in another Foundry resource is another deployment, so a
+        record naming only ``gpt-5.4`` would not distinguish this run from one
+        against a different account's deployment of the same name.
+        """
+        model = record()["run_conditions"]["model"]
+        plan = load_stage_one_plan()
+
+        assert model["deployment"] == plan["model"]["deployment"]
+        assert model["resolved_model"] == plan["model"]["resolved_model"]
+        assert model["account"] == plan["azure_connection"]["account"]
+        assert model["project"] == plan["azure_connection"]["project"]
+        assert model["route_profile"] == plan["azure_connection"]["route_profile"]
+        assert model["automatic_model_switch_allowed"] is False
+
+    def test_the_recorded_tool_list_is_the_one_the_model_will_be_offered(self):
+        """The record said seven tools before this test was written.
+
+        It excluded ``exec_run`` on the reasoning that a shut tool is not
+        offered. Nothing in the run narrows the list: ``tools_available``
+        defaults to the whole contract and no caller overrides it, so the model
+        is offered all eight and ``exec_run`` answers ``capability_unavailable``
+        when it is chosen. Which is the more interesting run — how a model
+        reacts to a refused capability is a finding — but either way the record
+        has to say what happens rather than what sounds tidier.
+        """
+        tools = record()["run_conditions"]["tools"]
+
+        # Both ends of the path the stage run takes: the factory it builds
+        # its runner with, and the loop that loop actually runs.
+        for built in (build_runner_factory, run_model_conversation):
+            offered = inspect.signature(built).parameters["tools_available"].default
+            assert tuple(tools["offered"]) == tuple(offered), built.__name__
+
+        assert tools["offered"] == list(TOOL_NAMES)
+        assert tools["offered_but_refuses_everything"] == ["exec_run"]
+        assert tools["exec_run_open"] is False
+        assert tools["narrowed_by_the_run"] is False
+
+    def test_the_recorded_ceilings_are_the_ones_that_will_be_enforced(self):
+        """Derived by the runner's own function, not by a second copy of it.
+
+        The ceilings are the one part of the conditions the plan does not
+        contain — they are arithmetic on it. Worked out twice, a correction to
+        the enforcing copy would leave the promised copy describing a run that
+        did not happen, and nothing would say so.
+        """
+        conditions = record()["run_conditions"]
+        plan = load_stage_one_plan()
+        chosen = plan["cost"]["chosen_settings"]
+
+        class _Chosen:
+            tool_calls_per_attempt = chosen["tool_calls_per_attempt"]
+            max_output_tokens_per_turn = chosen["max_output_tokens_per_turn"]
+
+        assert conditions["per_task_ceilings"] == ceilings_from(plan, _Chosen).as_dict()
+        assert conditions["how_the_ceilings_were_derived"]["chosen_settings"] == chosen
+
+    def test_no_ceiling_is_left_unset(self):
+        """A ceiling nobody set is not a ceiling, and nulls read as "no limit"."""
+        ceilings = record()["run_conditions"]["per_task_ceilings"]
+
+        assert ceilings
+        assert all(value is not None for value in ceilings.values())
+        assert all(
+            value > 0 for value in ceilings.values() if isinstance(value, (int, float))
+        )
+
+    def test_the_three_kinds_of_retry_stay_apart(self):
+        """Collapsed into one count, a flaky endpoint reads as an unsure model.
+
+        The distinction is the fourth ordered step's, and it has to be fixed
+        before the run rather than reconstructed from logs afterwards.
+        """
+        retry = record()["run_conditions"]["retry"]
+
+        assert retry["kinds_recorded_separately"] == [
+            "infrastructure",
+            "semantic",
+            "internal",
+        ]
+        assert retry["reasons_allowed"] == ["infrastructure_error"]
+        assert retry["max_attempts"] == 1
+
+    def test_the_conditions_carry_no_prediction_of_the_outcome(self):
+        """Pre-registering an expectation invites reading the result against it.
+
+        What a good result would be is in ``after_stage_one.success_criteria``
+        in the plan, which is a criterion. A guess at the outcome is not, and
+        the words below are the ones such a guess arrives wearing.
+        """
+        written = json.dumps(record()["run_conditions"]).lower()
+
+        for guess in ("we expect", "should succeed", "likely", "probably"):
+            assert guess not in written
+
+    def test_a_changed_setting_changes_the_seal(self):
+        """The record is only a commitment if editing the plan invalidates it."""
+        before = record()["seal"]
+        plan = load_stage_one_plan()
+        moved = json.loads(json.dumps(plan))
+        moved["cost"]["chosen_settings"]["tool_calls_per_attempt"] = 4
+
+        with mock.patch(
+            "core.agentic_v2_stage_one_budget.load_stage_one_plan",
+            return_value=moved,
+        ):
+            after = record()["seal"]
+
+        assert after != before
+
+
 class TestTheRecordSaysWhatItIsNot:
     def test_it_does_not_claim_the_environment_is_ready(self):
+        """Named, not diagnosed — and the diagnosis it used to carry is barred.
+
+        This assertion used to be ``"role assignment" in disclaimed``, which
+        pinned a *cause*: that the run was blocked by a missing role in the
+        subscription holding the model. That reading came from a 401 which was
+        later shown to have arrived from past the authentication gate, and
+        stage A has since reached a real deployment and been charged for it. A
+        disclaimer naming a cause that has been disproved is worse than none,
+        because it sends the next reader to ask for permission nobody needs.
+
+        So the assertion is inverted. What is still missing is named — the
+        isolation, which the pre-registration itself fixes shut — and the
+        retired cause is held out, so bringing the sentence back fails here.
+        """
         disclaimed = " ".join(record()["what_this_is_not"])
+
         assert "not a statement that the environment is ready" in disclaimed
-        assert "role assignment" in disclaimed
+        assert "No V2 task has run" in disclaimed
+        assert "exec_run shut and no guest booted" in disclaimed
+        assert "no result from it is evidence that the sandbox contains anything" in disclaimed
+        assert "role assignment" not in disclaimed
 
     def test_it_does_not_approve_any_spending(self):
         disclaimed = " ".join(record()["what_this_is_not"])
         assert "not an approval to spend" in disclaimed
+
+    def test_the_money_disclaimer_is_read_from_the_plan_rather_than_stated(self):
+        """The other sentence that went stale, and why it cannot again.
+
+        It used to say the amount was the owner's to fill in. On 2026-09-11
+        they filled in two, and the sentence carried on saying otherwise. It
+        now asks :func:`stage_one_amount_note`, so the record follows the plan
+        in both directions: an approval that is withdrawn turns the disclaimer
+        back by itself.
+
+        The assertions are about *scope*, not about the figures. The two
+        amounts are whole-run ones for the five tasks the plan pins, so a
+        record that read as a general approval would be read as pricing 220.
+        """
+        disclaimed = " ".join(record()["what_this_is_not"])
+
+        assert "five-task cohort" in disclaimed
+        assert "whole-run figures for those five" in disclaimed
+        assert "thirty and the two hundred and twenty are not priced" in disclaimed
+        assert "scripts/run_agentic_v2_stage.py refuses them until they are" in disclaimed
+        # The stale shape: an amount nobody has approved yet.
+        assert "the owner's to fill in" not in disclaimed
 
     def test_the_committed_comparison_is_carried_in_the_record(self):
         carried = record()["comparison_with_codex"]

--- a/batch-runner/tests/test_agentic_v2_shard_plan.py
+++ b/batch-runner/tests/test_agentic_v2_shard_plan.py
@@ -1,0 +1,209 @@
+"""The matrix a paid stage fans out over, checked before it is dispatched.
+
+`.github/workflows/agentic-v2-stage-run.yml` builds its matrix by running
+`scripts/plan_agentic_v2_shards.py` and handing the result to ``fromJSON``. That
+is one string, produced in a job, consumed by a job, and every way it can be
+wrong is a way that costs money:
+
+* a list that does not cover the cohort runs a stage that is missing tasks, and
+  the run still finishes and still reports;
+* a list that covers a task twice pays for it twice;
+* a list sized against the wrong timeout produces jobs that are killed at six
+  hours, losing the task each was in the middle of;
+* a string ``fromJSON`` cannot read fails the dispatch, which is the *good*
+  case and still wastes the setup.
+
+So the properties are checked here, where finding out is free, rather than in
+the first dispatch that uses them.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+REPOSITORY_ROOT = BATCH_RUNNER_ROOT.parent
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.agentic_v2_preregistration import ESCALATION, STAGE_SIZES  # noqa: E402
+from core.agentic_v2_sharding import coverage_problems  # noqa: E402
+from core.agentic_v2_sharding import parse as parse_shard  # noqa: E402
+
+SCRIPT = BATCH_RUNNER_ROOT / "scripts" / "plan_agentic_v2_shards.py"
+WORKFLOW = REPOSITORY_ROOT / ".github" / "workflows" / "agentic-v2-stage-run.yml"
+
+
+def _plan(stage: str, *extra: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--stage", stage, *extra],
+        cwd=BATCH_RUNNER_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+# ── The string the workflow actually captures ─────────────────────────────
+
+
+@pytest.mark.parametrize("stage", ESCALATION)
+def test_the_matrix_is_one_line_of_json_that_fromjson_can_read(stage):
+    """One line because a workflow output with a newline in it is a parse error.
+
+    Not a hypothetical: ``echo "matrix=$(...)" >> $GITHUB_OUTPUT`` with a
+    multi-line value writes a broken output file, and the failure surfaces two
+    steps later as an empty matrix rather than as a bad value.
+    """
+    finished = _plan(stage)
+
+    assert finished.returncode == 0, finished.stderr
+    assert finished.stdout.count("\n") == 1
+
+    shards = json.loads(finished.stdout)
+    assert isinstance(shards, list)
+    assert all(isinstance(one, str) for one in shards)
+    assert shards, "a stage with no shards would dispatch a matrix of no jobs"
+
+
+@pytest.mark.parametrize("stage", ESCALATION)
+def test_every_value_in_the_matrix_is_something_the_runner_accepts(stage):
+    """The producer and the consumer agree, checked rather than assumed.
+
+    These two are joined only by a string passed through a workflow input, which
+    is the kind of seam where a format changes on one side and is noticed on the
+    other by a paid job failing at its first argument parse.
+    """
+    ids = tuple(f"task-{n}" for n in range(STAGE_SIZES[stage]))
+
+    for value in json.loads(_plan(stage).stdout):
+        shard = parse_shard(value, ids)
+        assert shard is None or shard.task_ids
+
+
+@pytest.mark.parametrize("stage", ESCALATION)
+def test_the_matrix_covers_the_cohort_exactly_once(stage):
+    """The property the whole split exists to have, checked end to end.
+
+    Run against the real stage sizes, through the real parser, using the same
+    coverage check a finished set of shards is judged by. A matrix that passes
+    here cannot leave a task unrun or run one twice.
+    """
+    ids = tuple(f"task-{n}" for n in range(STAGE_SIZES[stage]))
+    values = json.loads(_plan(stage).stdout)
+
+    pieces = [parse_shard(value, ids) for value in values]
+    if pieces == [None]:
+        # One shard of one: the unsharded run, which covers the cohort by
+        # definition. `parse` returns None for it on purpose.
+        assert len(values) == 1
+        return
+
+    assert coverage_problems(pieces, task_ids=ids) == []
+
+
+@pytest.mark.parametrize("stage", ESCALATION)
+def test_no_shard_can_outlast_the_job_it_runs_in(stage):
+    """Worst case per shard, against the step timeout the workflow sets.
+
+    This is the number the split is for. If the plan's per-task ceiling rises,
+    or GitHub's limit falls, this is where it should be noticed -- not by a job
+    being killed with four hours of paid conversation in it.
+    """
+    explained = json.loads(_plan(stage, "--explain").stdout)
+
+    step_timeout_hours = 300 / 60
+    assert explained["worst_case_hours_per_shard"] <= step_timeout_hours, explained
+
+
+def test_the_five_task_stage_still_runs_as_one_job():
+    """The smallest stage must not pick up a matrix it does not need.
+
+    `advance_check_5` is the stage that has actually been approved for marking
+    as well as running, so it is the one whose results will be quoted most. It
+    should run the way it did before sharding existed.
+    """
+    assert json.loads(_plan("advance_check_5").stdout) == ["1/1"]
+
+
+def test_a_stage_nobody_registered_is_refused_by_name():
+    finished = _plan("full_500")
+
+    assert finished.returncode != 0
+    assert "invalid choice" in finished.stderr or "not a registered stage" in (
+        finished.stderr + finished.stdout
+    )
+
+
+# ── The workflow is wired to the script it is documented to use ───────────
+
+
+def test_the_paid_job_fans_out_over_what_the_free_job_worked_out(workflow):
+    """Not written by hand into the matrix, where it would go stale silently."""
+    free = workflow["jobs"]["free"]
+    paid = workflow["jobs"]["paid"]
+
+    assert free["outputs"]["shards"] == "${{ steps.shards.outputs.matrix }}"
+    assert paid["strategy"]["matrix"]["shard"] == (
+        "${{ fromJSON(needs.free.outputs.shards) }}"
+    )
+    assert any(
+        step.get("id") == "shards" and "plan_agentic_v2_shards.py" in step.get("run", "")
+        for step in free["steps"]
+    )
+
+
+def test_one_shard_failing_does_not_cancel_the_others(workflow):
+    """Each of them has already been charged for the turns it made.
+
+    ``fail-fast`` defaults to true, so this has to be written down. Left at the
+    default, the first shard to hit a bad task would throw away the paid work of
+    every shard still running.
+    """
+    assert workflow["jobs"]["paid"]["strategy"]["fail-fast"] is False
+
+
+def test_the_matrix_is_throttled_because_it_all_talks_to_one_deployment(workflow):
+    assert 1 <= workflow["jobs"]["paid"]["strategy"]["max-parallel"] <= 6
+
+
+def test_the_run_step_stops_before_the_job_does_and_the_job_before_github_does(
+    workflow,
+):
+    """Three limits, in an order that keeps the record.
+
+    A failed *step* leaves the rest of the job to run, and the rest of the job is
+    the upload. A job that hits its own limit, or GitHub's six hour kill, can
+    take the artifact of an already-charged run with it.
+    """
+    paid = workflow["jobs"]["paid"]
+    run_step = next(step for step in paid["steps"] if step.get("id") == "run")
+
+    assert run_step["timeout-minutes"] < paid["timeout-minutes"] < 6 * 60
+
+
+def test_the_artifact_of_each_shard_has_its_own_name(workflow):
+    """Seventeen archives called the same thing is not a record of anything.
+
+    Artifact names also have to be unique within a run, so this is both a
+    readability point and a correctness one.
+    """
+    upload = next(
+        step
+        for step in workflow["jobs"]["paid"]["steps"]
+        if "upload-artifact" in str(step.get("uses", ""))
+    )
+
+    assert "SHARD_SLUG" in upload["with"]["name"]
+    assert upload["if"] == "${{ always() }}"

--- a/batch-runner/tests/test_agentic_v2_sharding.py
+++ b/batch-runner/tests/test_agentic_v2_sharding.py
@@ -1,0 +1,285 @@
+"""Running one stage in several pieces, without the pieces becoming the stage.
+
+The split itself is four lines of arithmetic and would not be worth a test file.
+What is worth one is everything around it, because each of these failures is
+silent — a sharded run that is wrong still finishes, still writes results, and
+still prints a number:
+
+* a piece that is empty, or that does not exist, and reports success anyway;
+* pieces that were cut from different splits and are then added together;
+* a task that two pieces both ran, which is a task paid for twice;
+* a task no piece ran, in a set that otherwise looks complete;
+* a caller that passes ``--shard`` without meaning to shard anything, and gets
+  different behaviour for it.
+
+The last one is why ``1/1`` is ``None`` rather than a one-of-one shard: a
+workflow should be able to always pass the argument.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.agentic_v2_sharding import (  # noqa: E402
+    Shard,
+    ShardRefused,
+    coverage_problems,
+    how_many_shards_fit,
+    parse,
+    shard_of,
+    split,
+)
+
+#: Short enough to check by eye, which matters for the stride tests — a stride
+#: split is easy to assert vacuously against ids you cannot hold in your head.
+COHORT = ("a", "b", "c", "d", "e", "f", "g")
+
+
+# ── The split ─────────────────────────────────────────────────────────────
+
+
+def test_the_split_deals_the_cohort_out_rather_than_cutting_it_into_blocks():
+    """Stride, not block. Which tasks land together is the whole difference.
+
+    The cohort is ordered by a selection rule that puts related work next to
+    each other, so a block shard is a run of one kind of task. Lose it and what
+    is missing from the partial result is a category; lose a stride shard and
+    what is missing is a thin slice of everything.
+    """
+    assert split(COHORT, 3) == (("a", "d", "g"), ("b", "e"), ("c", "f"))
+
+
+def test_every_task_lands_in_exactly_one_piece():
+    for pieces in range(1, len(COHORT) + 1):
+        dealt = [task for piece in split(COHORT, pieces) for task in piece]
+        assert sorted(dealt) == sorted(COHORT), pieces
+        assert len(dealt) == len(set(dealt)), pieces
+
+
+def test_a_split_that_would_leave_a_piece_empty_is_refused():
+    """An empty run that reports success is worse than one that will not start.
+
+    It is worse because it is counted. A shard that ran nothing and exited zero
+    is indistinguishable, in every summary above it, from a shard that ran its
+    tasks and they all passed.
+    """
+    with pytest.raises(ShardRefused) as refused:
+        split(COHORT, len(COHORT) + 1)
+
+    assert "without leaving some piece empty" in str(refused.value)
+
+
+def test_fewer_than_one_piece_is_refused():
+    with pytest.raises(ShardRefused):
+        split(COHORT, 0)
+
+
+def test_a_piece_is_reproducible_from_the_cohort_and_its_two_numbers():
+    """Nothing about a split is stored, so nothing about it can go stale.
+
+    A shard that had to be looked up somewhere would be one more record that can
+    disagree with the cohort it came from.
+    """
+    assert shard_of(COHORT, 2, 3).task_ids == ("b", "e")
+    assert shard_of(COHORT, 2, 3).task_ids == split(COHORT, 3)[1]
+
+
+def test_a_shard_that_does_not_exist_is_refused_by_number():
+    for index in (0, 4, -1):
+        with pytest.raises(ShardRefused) as refused:
+            shard_of(COHORT, index, 3)
+        assert "shards are numbered 1 to 3" in str(refused.value)
+
+
+# ── What a shard admits to being ──────────────────────────────────────────
+
+
+def test_the_record_carries_the_whole_it_is_a_piece_of():
+    """Task ids with no denominator read as a small experiment, not a fragment."""
+    written = shard_of(COHORT, 1, 3).as_dict()
+
+    assert written["task_count"] == 3
+    assert written["cohort_size"] == 7
+    assert written["covers_whole_stage"] is False
+    assert "The stage has not run until all 3 shards have" in written["what_this_run_is"]
+
+
+def test_a_single_piece_says_it_is_the_whole_stage():
+    written = Shard(index=1, of=1, task_ids=COHORT, cohort_size=7).as_dict()
+
+    assert written["covers_whole_stage"] is True
+    assert written["what_this_run_is"] == "the whole stage, in one run"
+
+
+# ── Parsing what a person typed into a workflow input ─────────────────────
+
+
+@pytest.mark.parametrize("text", [None, "", "   ", "all", "1/1"])
+def test_not_sharding_gives_back_nothing_rather_than_a_trivial_shard(text):
+    """So a workflow may always pass --shard without changing what happens.
+
+    ``None`` rather than a one-of-one shard because the alternative is a second
+    code path that only runs in production: every unsharded run would start
+    going through shard handling on the day the option was added.
+    """
+    assert parse(text, COHORT) is None
+
+
+def test_a_total_of_one_is_the_unsharded_run_however_it_is_written():
+    assert parse("1/1", COHORT) is None
+
+
+@pytest.mark.parametrize("text", ["3", "3 of 20", "three/twenty", "3/", "/20"])
+def test_something_that_is_not_a_shard_is_refused_with_the_shape_to_use(text):
+    with pytest.raises(ShardRefused) as refused:
+        parse(text, COHORT)
+
+    assert "Write it as index/total" in str(refused.value)
+
+
+def test_whitespace_around_the_numbers_is_not_a_refusal():
+    """People paste these. A trailing space is not a reason to lose a paid run."""
+    assert parse(" 2 / 3 ", COHORT).task_ids == ("b", "e")
+
+
+# ── How many pieces the place this runs will actually hold ────────────────
+
+
+def test_the_count_is_sized_against_the_worst_case_and_not_the_usual_one():
+    """Every task assumed to take its full timeout.
+
+    Sizing against what most tasks do is how a job gets killed at hour six with
+    nothing collected — the tail is exactly where the long tasks are.
+    """
+    # Six hours × 0.75 = 16200s of usable time, 13 tasks of 1200s each.
+    assert how_many_shards_fit(
+        cohort_size=13, per_task_timeout_seconds=1200, job_limit_seconds=21600
+    ) == 1
+    assert how_many_shards_fit(
+        cohort_size=14, per_task_timeout_seconds=1200, job_limit_seconds=21600
+    ) == 2
+
+
+def test_the_three_real_stages_get_the_counts_the_workflow_is_built_around():
+    """These are the numbers in the workflow matrix, so they are held here.
+
+    If the timeout or the job limit moves, this is where it should be noticed —
+    not in a run that gets killed.
+    """
+    fits = lambda size: how_many_shards_fit(
+        cohort_size=size, per_task_timeout_seconds=1200, job_limit_seconds=21600
+    )
+    assert fits(5) == 1
+    assert fits(30) == 3
+    assert fits(220) == 17
+
+
+def test_a_task_that_cannot_fit_in_a_job_at_all_is_refused_rather_than_rounded():
+    """No number of pieces fixes one task that outlasts the job it runs in.
+
+    Returning a very large count would be arithmetically fine and practically a
+    lie: each of those pieces would still be killed.
+    """
+    with pytest.raises(ShardRefused) as refused:
+        how_many_shards_fit(
+            cohort_size=10, per_task_timeout_seconds=1200, job_limit_seconds=1000
+        )
+
+    assert "no split makes this fit" in str(refused.value)
+
+
+def test_a_cohort_with_no_tasks_is_refused():
+    with pytest.raises(ShardRefused):
+        how_many_shards_fit(
+            cohort_size=0, per_task_timeout_seconds=1200, job_limit_seconds=21600
+        )
+
+
+# ── Earning the sentence "the stage ran" ──────────────────────────────────
+
+
+def test_a_complete_set_of_pieces_has_nothing_wrong_with_it():
+    whole = [shard_of(COHORT, index, 3) for index in (1, 2, 3)]
+
+    assert coverage_problems(whole, task_ids=COHORT) == []
+
+
+def test_no_shard_at_all_is_reported_rather_than_passing_as_complete():
+    """The empty set satisfies "every shard that ran covered its tasks"."""
+    assert coverage_problems([], task_ids=COHORT) == [
+        "no shard ran, so the stage did not run"
+    ]
+
+
+def test_a_missing_piece_is_named_by_number():
+    assert "did not run: 2" in " ".join(
+        coverage_problems(
+            [shard_of(COHORT, 1, 3), shard_of(COHORT, 3, 3)], task_ids=COHORT
+        )
+    )
+
+
+def test_pieces_cut_from_different_splits_are_refused_before_being_added_up():
+    """Seventeen-way and twenty-way shards are not pieces of the same thing.
+
+    Reported and then stopped, because every later check compares against a
+    total that does not exist. This is the shape a re-dispatch takes after
+    somebody changes the matrix size mid-stage.
+    """
+    problems = coverage_problems(
+        [shard_of(COHORT, 1, 3), shard_of(COHORT, 1, 2)], task_ids=COHORT
+    )
+
+    assert len(problems) == 1
+    assert "disagree about how many there are" in problems[0]
+    assert "cannot be added up" in problems[0]
+
+
+def test_a_task_two_pieces_both_ran_is_reported_as_paid_for_twice():
+    """Counting would not catch it. This is why coverage is checked by identity.
+
+    Two overlapping shards can report the right total number of tasks between
+    them while one task ran twice and another never ran.
+    """
+    overlapping = [
+        Shard(index=1, of=2, task_ids=("a", "b", "c", "d"), cohort_size=7),
+        Shard(index=2, of=2, task_ids=("d", "e", "f", "g"), cohort_size=7),
+    ]
+
+    trouble = " ".join(coverage_problems(overlapping, task_ids=COHORT))
+
+    assert "1 tasks were covered by more than one shard" in trouble
+    assert "paid for twice" in trouble
+
+
+def test_a_task_no_piece_ran_is_reported_even_when_every_piece_did():
+    short = [
+        Shard(index=1, of=2, task_ids=("a", "b", "c"), cohort_size=7),
+        Shard(index=2, of=2, task_ids=("d", "e", "f"), cohort_size=7),
+    ]
+
+    trouble = " ".join(coverage_problems(short, task_ids=COHORT))
+
+    assert "1 of the 7 tasks in this stage were covered by no shard: g" in trouble
+
+
+def test_a_task_from_outside_the_stage_is_reported_rather_than_counted_in():
+    """A result set that silently gained a task is not this stage's result.
+
+    The count would be right, and the cohort seal it is quoted under would not
+    describe what ran.
+    """
+    strayed = [
+        Shard(index=1, of=1, task_ids=COHORT + ("z",), cohort_size=7),
+    ]
+
+    trouble = " ".join(coverage_problems(strayed, task_ids=COHORT))
+
+    assert "1 tasks were run that are not in this stage: z" in trouble

--- a/batch-runner/tests/test_free_checks_agree_on_the_loop.py
+++ b/batch-runner/tests/test_free_checks_agree_on_the_loop.py
@@ -54,16 +54,34 @@ def test_the_two_free_checks_give_the_same_answer_about_reaching_a_model():
     same conclusion by separate routes can drift apart the moment one of the
     routes changes, which is what happened here. One of them now asks the
     other, and this is what says so.
+
+    Checked in both directions, and the second direction is the one that
+    matters now. The stage-one check returns nothing today — a real model can
+    be reached and the amounts are approved — so requiring the readiness report
+    to print what it said would pass on an empty list without looking at
+    anything. What is required instead is that the report says nothing about
+    reaching a real model *except* what the other check produced. An empty
+    answer copied faithfully is still one answer; a sentence the report made up
+    on its own is the drift this file exists to stop.
     """
     settled = check_stage_one_cannot_reach_a_model()
     blockers = _agentic_entry().blockers
 
-    assert settled, "the other check stopped saying anything about a real model"
     for sentence in settled:
         assert sentence in blockers, (
             "the readiness report no longer prints what the stage-one check "
             f"established; it is missing {sentence!r}"
         )
+    invented = [
+        note
+        for note in blockers
+        if "reach a real model" in note or "no amount has been approved" in note
+        if note not in settled
+    ]
+    assert invented == [], (
+        "the readiness report is making its own claim about reaching a real "
+        f"model instead of asking: {invented!r}"
+    )
 
 
 def test_the_report_does_not_say_the_loop_is_missing_while_the_loop_exists():
@@ -92,22 +110,54 @@ def test_the_three_claims_are_three_blockers_rather_than_one_sentence():
     are three different pieces of work with three different people behind them.
     While they shared a sentence, finishing one of them changed nothing in the
     report — which is how the finished one went on being listed as outstanding.
+
+    Two of the three have since been finished, and the report shows it by
+    saying less: the model sentence is gone entirely, and the approval sentence
+    narrowed to the pipeline route that really is still shut. That is the
+    behaviour being pinned. A blocker that reappears without the fact behind it
+    coming back fails here, and so does a blocker that stays flat while the
+    fact under it moves — which is what this test was written about.
     """
-    blockers = _agentic_entry().blockers
+    entry = _agentic_entry()
+    blockers = entry.blockers
 
     holding_the_command_tool = [note for note in blockers if "exec_run" in note]
     holding_the_model = [note for note in blockers if "real model" in note]
-    holding_the_approval = [note for note in blockers if "no approval exists" in note]
+    holding_the_approval = [note for note in blockers if "not approved" in note]
 
     assert len(holding_the_command_tool) == 1
-    assert len(holding_the_model) == 1
+    # Nothing stands between this environment and a real model any more, so
+    # there is no sentence for it. Established by asking rather than by the
+    # absence itself: if the other check starts finding something again, the
+    # test above requires the report to carry it and this one to see it.
+    assert holding_the_model == check_stage_one_cannot_reach_a_model()
     assert len(holding_the_approval) == 1
-    assert (
-        len(
-            set(holding_the_command_tool + holding_the_model + holding_the_approval)
-        )
-        == 3
-    ), "two of the three claims are sharing one sentence again"
+
+    # Still separate sentences, which is the original point.
+    assert len(set(blockers)) == len(blockers)
+    assert not any(
+        "no approval exists to use this environment in a real experiment" in note
+        for note in blockers
+    ), "the approval blocker went back to the wording that outlived its fact"
+
+
+def test_the_approval_blocker_names_the_route_that_is_shut_and_the_one_that_is_not():
+    """An approval that exists must not be reported as though it does not.
+
+    Stage one is approved — two amounts, written in the plan. What is still
+    shut is reaching this environment through an experiment YAML. A blocker
+    that said neither was approved would send somebody to ask for permission
+    they already have, which is how the old sentence read for the whole of the
+    day after the approval landed.
+    """
+    blocker = next(note for note in _agentic_entry().blockers if "not approved" in note)
+
+    assert "ordinary experiment pipeline" in blocker
+    assert "step2_run_inference" in blocker
+    assert "core.executor" in blocker
+    # And it points at where the approval that does exist lives.
+    assert "agentic_stage_one_plan.yaml" in blocker
+    assert "run_agentic_v2_stage.py" in blocker
 
 
 def test_the_command_tool_blocker_says_it_was_called_rather_than_described():

--- a/batch-runner/tests/test_run_agentic_v2_stage.py
+++ b/batch-runner/tests/test_run_agentic_v2_stage.py
@@ -1,0 +1,328 @@
+"""The entry point that spends stage one's money, exercised without spending it.
+
+This is the only route by which an Agentic Sandbox V2 stage can run, so the
+parts that decide whether it is *allowed* to run are worth more here than the
+run itself. Four of them:
+
+* **the pricing guard.** The plan's two approved amounts are whole-run figures
+  worked out over the five tasks the plan pins. Nothing about them is per-task,
+  so a thirty- or two-hundred-and-twenty-task cohort run under them would go out
+  against an approval for a run forty-four times smaller — and the line printed
+  beside it would say it was within budget, because the arithmetic it came from
+  never saw the larger cohort. Refused instead, and the refusal says by how much.
+* **the free path really being free.** ``--dry-run`` is the whole path minus the
+  network. It is only worth anything if it genuinely cannot reach out, which is
+  proved here by running it with no Azure environment at all rather than by
+  asserting it.
+* **the answer columns never being read.** The pinned parquet carries the
+  expert's own deliverable next to the prompt. The binding is handed rows built
+  by hand for that reason, and this holds the column list to it.
+* **what the record admits.** A run whose isolation was a fixture and whose
+  record does not say so is a result that will eventually be quoted as something
+  it was not.
+
+Nothing here calls a model, builds a client or spends anything.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+RUNNER_PATH = BATCH_RUNNER_ROOT / "scripts" / "run_agentic_v2_stage.py"
+
+
+def _load_runner():
+    """Import the script by path, the way a script without a package is loaded.
+
+    Registered in ``sys.modules`` before it is executed, which the stage A
+    probe's loader does not need to do. ``DatasetRow`` is a dataclass, and
+    ``dataclasses`` resolves a field's type by looking the defining module up in
+    ``sys.modules`` — from a module that is not there yet, that lookup returns
+    ``None`` and the decorator fails at import.
+    """
+    spec = importlib.util.spec_from_file_location("run_agentic_v2_stage", RUNNER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+runner = _load_runner()
+
+#: The dataset is fetched by the workflow and cached on a developer's machine,
+#: but it is not in the repository. Skipped rather than failed when it is
+#: absent: a missing download is not a broken runner, and a test that reported
+#: one as the other would be noise in front of the real signal.
+HAVE_DATASET = runner.PINNED_DATASET_PARQUET.is_file()
+needs_dataset = pytest.mark.skipif(
+    not HAVE_DATASET,
+    reason=f"the pinned dataset is not at {runner.PINNED_DATASET_PARQUET}",
+)
+
+
+class _Bound:
+    """Just enough of a bound cohort to ask the guard about."""
+
+    def __init__(self, task_ids):
+        self._task_ids = tuple(task_ids)
+
+    @property
+    def task_ids(self):
+        return self._task_ids
+
+
+# ── The pricing guard ─────────────────────────────────────────────────────
+
+
+def test_a_cohort_the_plan_priced_is_allowed_through():
+    plan = {"task_ids": ["a", "b", "c"]}
+
+    assert runner.check_the_plan_priced_this_stage(plan, _Bound(["a", "b", "c"])) == []
+
+
+def test_a_cohort_larger_than_the_one_priced_is_refused_with_the_multiple():
+    """The number is the point. "Not priced" invites someone to wave it through.
+
+    Forty-four times an approved amount is a different conversation from a
+    mismatch, and the person reading the refusal is the person who would have
+    had it.
+    """
+    plan = {"task_ids": [f"t{n}" for n in range(5)]}
+
+    problems = runner.check_the_plan_priced_this_stage(
+        plan, _Bound([f"t{n}" for n in range(220)])
+    )
+
+    assert len(problems) == 1
+    assert "roughly 44 times what was approved" in problems[0]
+    assert "whole-run figures, not per-task ones" in problems[0]
+
+
+def test_a_cohort_of_the_same_size_but_different_tasks_is_refused():
+    """Same count, different work. Five tasks are not five tasks.
+
+    The amounts were worked out over particular prompts with particular
+    reference files. A cohort that merely matched on size would be a different
+    run wearing the approved run's number.
+    """
+    plan = {"task_ids": ["a", "b"]}
+
+    problems = runner.check_the_plan_priced_this_stage(plan, _Bound(["a", "c"]))
+
+    assert len(problems) == 1
+    assert "do not describe this run" in problems[0]
+
+
+def test_a_plan_that_prices_nothing_does_not_divide_by_zero():
+    """An empty plan is a refusal, not a crash inside the refusal."""
+    problems = runner.check_the_plan_priced_this_stage({}, _Bound(["a"]))
+
+    assert len(problems) == 1
+    assert "roughly 1 times what was approved" in problems[0]
+
+
+def test_the_guard_reads_the_cohort_rather_than_calling_it():
+    """A regression test for a real one-character bug.
+
+    ``BoundManifest.task_ids`` is a property. Calling it raised ``TypeError``
+    from inside the guard — which is to say the guard that stops an unpriced run
+    was itself broken, on every stage including the priced one. It failed loudly
+    and cost nothing, but it would have failed the same way on the run that was
+    allowed. Held here with an object that refuses to be called.
+    """
+
+    class RefusesToBeCalled:
+        @property
+        def task_ids(self):
+            return ("a",)
+
+    assert runner.check_the_plan_priced_this_stage({"task_ids": ["a"]}, RefusesToBeCalled()) == []
+
+
+# ── The free path is free ─────────────────────────────────────────────────
+
+
+def _run(*args, env=None):
+    """Run the entry point as a subprocess, with no Azure environment at all."""
+    clean = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith(("AZURE_", "FOUNDRY_", "OPENAI_"))
+    }
+    clean["PYTHONPATH"] = str(BATCH_RUNNER_ROOT)
+    clean.update(env or {})
+    return subprocess.run(
+        [sys.executable, str(RUNNER_PATH), *args],
+        cwd=BATCH_RUNNER_ROOT,
+        env=clean,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+
+
+@needs_dataset
+def test_the_priced_stage_dry_runs_to_zero_without_any_azure_environment():
+    """The whole path minus the network, with nothing configured to reach it."""
+    finished = _run("--stage", "advance_check_5", "--dry-run")
+
+    assert finished.returncode == 0, finished.stdout + finished.stderr
+    assert "Every condition for the paid run is met" in finished.stdout
+    assert "nothing was spent" in finished.stdout
+
+
+@needs_dataset
+@pytest.mark.parametrize("stage", ["trial_30", "full_220"])
+def test_an_unpriced_stage_is_refused_before_anything_is_reached(stage):
+    finished = _run("--stage", stage, "--dry-run")
+
+    assert finished.returncode == 1, finished.stdout + finished.stderr
+    assert "Refused before spending anything" in finished.stdout
+    assert "this stage is not priced" in finished.stdout
+
+
+@needs_dataset
+def test_the_dry_run_reports_both_amounts_against_their_own_ceilings():
+    """Running and marking are two purchases and print as two lines.
+
+    While they shared one approved figure, the settings that were actually being
+    chosen moved less than one percent of it. Two lines is what makes the choice
+    visible to whoever signs for it.
+    """
+    printed = _run("--stage", "advance_check_5", "--dry-run").stdout
+
+    running = next(line for line in printed.splitlines() if "running" in line)
+    marking = next(line for line in printed.splitlines() if "marking" in line)
+
+    assert "against $50.00 approved" in running
+    assert "against $2600.00 approved" in marking
+    assert "not spent by this script" in marking
+
+
+@needs_dataset
+def test_the_dry_run_says_what_is_missing_rather_than_only_what_is_ready():
+    """The handicap is printed on the way in, not discovered in the results."""
+    printed = _run("--stage", "advance_check_5", "--dry-run").stdout
+
+    assert "isolation      none — fixture backend, exec_run shut" in printed
+    assert "reference files that are not in the workspace" in printed
+
+
+# ── The expert's answer never travels ─────────────────────────────────────
+
+
+def test_only_the_five_columns_the_binding_may_see_are_read(monkeypatch, tmp_path):
+    """The parquet holds the answer next to the question.
+
+    ``deliverable_text`` and ``deliverable_files`` are the expert's own work. A
+    run that read them into the same structure the prompt travels in would be
+    one refactor away from showing the model the answer.
+    """
+    asked: dict = {}
+
+    # Grabbed before the stand-in goes into sys.modules. Reaching for it from
+    # inside the stand-in would resolve to the stand-in itself.
+    import pandas as real_pandas
+
+    class FakePandas:
+        @staticmethod
+        def read_parquet(path, columns=None):
+            asked["columns"] = columns
+            return real_pandas.DataFrame({name: [] for name in (columns or [])})
+
+    parquet = tmp_path / "pinned.parquet"
+    parquet.write_bytes(b"not read, only existence is checked")
+    monkeypatch.setitem(sys.modules, "pandas", FakePandas)
+
+    runner.read_pinned_dataset(parquet)
+
+    assert asked["columns"] == [
+        "task_id",
+        "prompt",
+        "sector",
+        "occupation",
+        "reference_files",
+    ]
+    assert "deliverable_text" not in asked["columns"]
+    assert "deliverable_files" not in asked["columns"]
+
+
+def test_a_missing_dataset_names_the_revision_to_fetch():
+    with pytest.raises(runner.StageRefused) as refused:
+        runner.read_pinned_dataset(Path("/nonexistent/pinned.parquet"))
+
+    assert "11e7900cdcac61bc4daf59e65feb238acda98fbf" in str(refused.value)
+    assert "openai/gdpval" in str(refused.value)
+
+
+# ── Ceilings are read, never defaulted ────────────────────────────────────
+
+
+class _Chosen:
+    tool_calls_per_attempt = 8
+    max_output_tokens_per_turn = 8192
+
+
+def test_every_ceiling_comes_from_something_somebody_wrote_down():
+    ceilings = runner.ceilings_from(
+        {"fixed_settings": {"per_task_timeout_seconds": 1200}}, _Chosen()
+    )
+
+    assert ceilings.max_model_calls == 9
+    assert ceilings.max_model_turns == 9
+    assert ceilings.max_written_tokens_per_turn == 8192
+    assert ceilings.max_seconds == 1200.0
+    assert ceilings.max_output_tokens == 8192 * 9
+    # Quadratic, because the loop re-sends the whole conversation every turn.
+    # Priced that way, so bounded that way.
+    assert ceilings.max_input_tokens == 8192 * 9 * 10
+
+
+def test_a_plan_with_no_timeout_fails_rather_than_running_without_one():
+    """A ceiling nobody set is not a ceiling. Better to stop than to invent 30s."""
+    with pytest.raises(KeyError):
+        runner.ceilings_from({"fixed_settings": {}}, _Chosen())
+
+
+# ── What the record admits ────────────────────────────────────────────────
+
+
+def test_the_record_says_the_isolation_was_not_exercised():
+    note = runner.environment_note({"policy_profile_id": "offline-full-v1"})
+
+    assert note["guest_booted"] is False
+    assert note["exec_run_open"] is False
+    assert "no guest booted" in " ".join(note["what_was_not_real"])
+    assert "capability_unavailable" in " ".join(note["what_was_not_real"])
+
+
+def test_the_record_carries_the_weaker_true_sentence_ready_to_be_quoted():
+    """Written out in full, because a reader will quote one sentence and stop.
+
+    If the only honest summary lives in a docstring, the sentence that travels
+    is the flattering one somebody writes later from the numbers.
+    """
+    sentence = runner.environment_note({})["so_the_honest_sentence_is"]
+
+    assert "real model drove a real tool loop" in sentence
+    assert "its isolation not exercised" in sentence
+    assert "not evidence that the sandbox contains anything" in sentence
+
+
+def test_what_was_real_does_not_quietly_include_the_isolation():
+    real = " ".join(runner.environment_note({})["what_was_real"])
+
+    assert "isolation" not in real
+    assert "exec_run" not in real
+    assert "the charge for every call" in real

--- a/batch-runner/tests/test_run_agentic_v2_stage.py
+++ b/batch-runner/tests/test_run_agentic_v2_stage.py
@@ -33,6 +33,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
 if str(BATCH_RUNNER_ROOT) not in sys.path:
@@ -71,83 +72,75 @@ needs_dataset = pytest.mark.skipif(
 )
 
 
-class _Bound:
-    """Just enough of a bound cohort to ask the guard about."""
-
-    def __init__(self, task_ids):
-        self._task_ids = tuple(task_ids)
-
-    @property
-    def task_ids(self):
-        return self._task_ids
-
-
 # ── The pricing guard ─────────────────────────────────────────────────────
+#
+# The guard used to live here as arithmetic over two counts, and these tests
+# pinned that arithmetic. It now prices the cohort that is really about to run
+# against the amount the plan approved for that stage by name, which is a
+# stronger check in both directions: it lets a correctly priced larger stage
+# through, and it would catch a cohort of the approved size whose tasks had
+# grown more expensive. The arithmetic moved to
+# ``core.agentic_v2_stage_one_budget.price_one_stage`` and is tested there,
+# against synthetic plans that need no dataset. What is left here is the thing
+# only this script can be asked: that the guard is wired into the path a real
+# run takes, with a real bound cohort and a real catalogue.
 
 
-def test_a_cohort_the_plan_priced_is_allowed_through():
-    plan = {"task_ids": ["a", "b", "c"]}
+@needs_dataset
+@pytest.mark.parametrize("stage", ["advance_check_5", "trial_30", "full_220"])
+def test_every_registered_stage_is_priced_and_dry_runs_to_zero(stage):
+    """All three, because an escalation with an unpriced rung cannot be climbed.
 
-    assert runner.check_the_plan_priced_this_stage(plan, _Bound(["a", "b", "c"])) == []
+    This test used to assert the opposite for two of the three — that the thirty
+    and the two hundred and twenty were *refused* as unpriced. They were, and
+    the refusal was correct while it was true. Approving them is what changed,
+    not the guard.
+    """
+    finished = _run("--stage", stage, "--dry-run")
+
+    assert finished.returncode == 0, finished.stdout + finished.stderr
+    assert "Every condition for the paid run is met" in finished.stdout
+    assert "nothing was spent" in finished.stdout
 
 
-def test_a_cohort_larger_than_the_one_priced_is_refused_with_the_multiple():
+@needs_dataset
+def test_a_stage_the_plan_does_not_name_is_still_refused(tmp_path):
+    """The guard is a guard, not a formality that happens to pass now.
+
+    Checked by taking the entry away rather than by trusting that it would be
+    caught if it were missing. A plan with the block deleted is the state the
+    repository was in this morning.
+    """
+    plan = yaml.safe_load(runner.STAGE_ONE_PLAN_PATH.read_text(encoding="utf-8"))
+    del plan["stages"]["full_220"]
+    narrowed = tmp_path / "plan.yaml"
+    narrowed.write_text(yaml.safe_dump(plan), encoding="utf-8")
+
+    finished = _run("--stage", "full_220", "--plan", str(narrowed), "--dry-run")
+
+    assert finished.returncode == 1, finished.stdout + finished.stderr
+    assert "this stage is not priced" in finished.stdout
+    assert "'full_220'" in finished.stdout
+    assert "whole-run figure" in finished.stdout
+
+
+@needs_dataset
+def test_a_stage_priced_too_low_is_refused_with_the_shortfall(tmp_path):
     """The number is the point. "Not priced" invites someone to wave it through.
 
-    Forty-four times an approved amount is a different conversation from a
-    mismatch, and the person reading the refusal is the person who would have
-    had it.
+    A shortfall in dollars is a different conversation from a mismatch, and the
+    person reading the refusal is the person who would have had it.
     """
-    plan = {"task_ids": [f"t{n}" for n in range(5)]}
+    plan = yaml.safe_load(runner.STAGE_ONE_PLAN_PATH.read_text(encoding="utf-8"))
+    plan["stages"]["full_220"]["running_approved_maximum_usd"] = 50.00
+    narrowed = tmp_path / "plan.yaml"
+    narrowed.write_text(yaml.safe_dump(plan), encoding="utf-8")
 
-    problems = runner.check_the_plan_priced_this_stage(
-        plan, _Bound([f"t{n}" for n in range(220)])
-    )
+    finished = _run("--stage", "full_220", "--plan", str(narrowed), "--dry-run")
 
-    assert len(problems) == 1
-    assert "roughly 44 times what was approved" in problems[0]
-    assert "whole-run figures, not per-task ones" in problems[0]
-
-
-def test_a_cohort_of_the_same_size_but_different_tasks_is_refused():
-    """Same count, different work. Five tasks are not five tasks.
-
-    The amounts were worked out over particular prompts with particular
-    reference files. A cohort that merely matched on size would be a different
-    run wearing the approved run's number.
-    """
-    plan = {"task_ids": ["a", "b"]}
-
-    problems = runner.check_the_plan_priced_this_stage(plan, _Bound(["a", "c"]))
-
-    assert len(problems) == 1
-    assert "do not describe this run" in problems[0]
-
-
-def test_a_plan_that_prices_nothing_does_not_divide_by_zero():
-    """An empty plan is a refusal, not a crash inside the refusal."""
-    problems = runner.check_the_plan_priced_this_stage({}, _Bound(["a"]))
-
-    assert len(problems) == 1
-    assert "roughly 1 times what was approved" in problems[0]
-
-
-def test_the_guard_reads_the_cohort_rather_than_calling_it():
-    """A regression test for a real one-character bug.
-
-    ``BoundManifest.task_ids`` is a property. Calling it raised ``TypeError``
-    from inside the guard — which is to say the guard that stops an unpriced run
-    was itself broken, on every stage including the priced one. It failed loudly
-    and cost nothing, but it would have failed the same way on the run that was
-    allowed. Held here with an object that refuses to be called.
-    """
-
-    class RefusesToBeCalled:
-        @property
-        def task_ids(self):
-            return ("a",)
-
-    assert runner.check_the_plan_priced_this_stage({"task_ids": ["a"]}, RefusesToBeCalled()) == []
+    assert finished.returncode == 1, finished.stdout + finished.stderr
+    assert "short by $" in finished.stdout
+    assert "nothing here may scale an approved amount on its own" in finished.stdout
 
 
 # ── The free path is free ─────────────────────────────────────────────────
@@ -183,16 +176,6 @@ def test_the_priced_stage_dry_runs_to_zero_without_any_azure_environment():
 
 
 @needs_dataset
-@pytest.mark.parametrize("stage", ["trial_30", "full_220"])
-def test_an_unpriced_stage_is_refused_before_anything_is_reached(stage):
-    finished = _run("--stage", stage, "--dry-run")
-
-    assert finished.returncode == 1, finished.stdout + finished.stderr
-    assert "Refused before spending anything" in finished.stdout
-    assert "this stage is not priced" in finished.stdout
-
-
-@needs_dataset
 def test_the_dry_run_reports_both_amounts_against_their_own_ceilings():
     """Running and marking are two purchases and print as two lines.
 
@@ -206,8 +189,84 @@ def test_the_dry_run_reports_both_amounts_against_their_own_ceilings():
     marking = next(line for line in printed.splitlines() if "marking" in line)
 
     assert "against $50.00 approved" in running
-    assert "against $2600.00 approved" in marking
+    assert "$2600.00 approved" in marking
     assert "not spent by this script" in marking
+
+
+@needs_dataset
+def test_a_stage_whose_marking_is_not_approved_prints_the_reason():
+    """A blank is read as an oversight; a refusal with a reason is read as one.
+
+    Running the two hundred and twenty is approved and marking them is not, and
+    those are different facts about the same run. The dry run has to make the
+    second one as visible as the first, or the milestone that has not been paid
+    for is the one nobody notices is missing.
+    """
+    printed = _run("--stage", "full_220", "--dry-run").stdout
+
+    assert "marking        not approved for this stage" in printed
+    assert "six-figure amount" in printed
+    assert "another" in printed  # running them is one milestone, marking another
+
+
+@needs_dataset
+def test_the_stage_figure_is_the_stage_s_own_and_not_the_five_task_one():
+    """The two are the same number only for the smallest stage.
+
+    Printing the five-task figure beside a two-hundred-task run is exactly how a
+    stage gets described as affordable by a line that was never about it.
+    """
+    printed = _run("--stage", "full_220", "--dry-run").stdout
+    running = next(line for line in printed.splitlines() if "running" in line)
+
+    assert "$18.47" not in running
+    assert "$884.62" in running
+    assert "against $1400.00 approved for the whole stage" in running
+
+
+# ── Shards ────────────────────────────────────────────────────────────────
+
+
+@needs_dataset
+def test_a_shard_runs_part_of_the_stage_and_says_so():
+    printed = _run("--stage", "full_220", "--shard", "3/17", "--dry-run").stdout
+
+    assert "tasks          220" in printed
+    assert "shard          3 of 17" in printed
+    assert "the stage has not run until every shard has" in printed
+
+
+@needs_dataset
+def test_a_shard_is_priced_against_the_whole_stage_and_not_against_itself():
+    """Seventeen runs that are each "within budget" must not spend seventeen
+    times the approval. A shard is where the work happens, not what was bought.
+    """
+    whole = _run("--stage", "full_220", "--dry-run").stdout
+    piece = _run("--stage", "full_220", "--shard", "3/17", "--dry-run").stdout
+
+    line_of = lambda text: next(
+        one for one in text.splitlines() if "running        at most" in one
+    )
+    assert line_of(whole) == line_of(piece)
+
+
+@needs_dataset
+def test_a_shard_that_does_not_exist_is_refused_rather_than_run_empty():
+    finished = _run("--stage", "full_220", "--shard", "25/17", "--dry-run")
+
+    assert finished.returncode == 1, finished.stdout
+    assert "does not exist; shards are numbered 1 to 17" in finished.stdout
+
+
+@needs_dataset
+def test_one_shard_of_one_is_the_unsharded_run():
+    """So that a workflow may always pass --shard without changing behaviour."""
+    plain = _run("--stage", "trial_30", "--dry-run").stdout
+    trivial = _run("--stage", "trial_30", "--shard", "1/1", "--dry-run").stdout
+
+    assert plain == trivial
+    assert "shard" not in trivial
+
 
 
 @needs_dataset

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
@@ -2658,6 +2658,10 @@ because the arithmetic it came from never saw the larger cohort. The runner
 refuses any stage the plan has not priced and names the multiple. `trial_30`
 and `full_220` are refused today and stay refused until somebody writes their
 task ids and their own two amounts down.
+> **Superseded on 2026-09-11 by stage G below.** All three stages are now
+> priced for running, so this paragraph's last sentence no longer describes the
+> repository. The guard it describes was also replaced: it compared counts, and
+> now prices the cohort that is actually bound.
 
 **The conditions are now recorded before the run, not reconstructed after it.**
 `run_conditions` in the pre-registration holds the model, deployment, account,
@@ -2668,6 +2672,10 @@ record, and the ceilings come from `agentic_v2_conversation_runner.ceilings_from
 the same function that enforces them. Writing the arithmetic twice would let the
 promise and the enforcement drift apart with nothing to say so. Seal:
 `54fa669216c22c9b50cae265a42c4d4eb9371b8e1dbfa8c9034f782a20e076af`.
+> **That seal is no longer current** — pricing the two larger stages changed the
+> record it is taken over. It is left here because it is what stage F was
+> registered under. The current one is in stage G below, and the committed
+> artefact is the only thing worth verifying against.
 
 Writing it down caught one error in this document's own claims. The record said
 seven tools were offered, on the reasoning that `exec_run` is shut. Nothing in
@@ -2683,6 +2691,8 @@ so 220 tasks is up to 73 hours against a ceiling of six. The cohort has to be
 split across jobs. The runner already takes `--run-id` and resumes on it, so the
 mechanism exists, but the sharding and its pricing are not written down and the
 guard will keep refusing until they are.
+> **Done on 2026-09-11 — see stage G.** Seventeen shards, priced against the
+> whole stage.
 
 **What this stage does *not* mean.** No V2 task has run — this is the
 environment being made startable, which is not the tasks running, which is not
@@ -2697,3 +2707,166 @@ gap is closed before the larger cohorts; `advance_check_5` runs first anyway,
 because it is what proves route → model → tools → files → ceilings → receipts →
 deliverables → record end to end, and a printed handicap keeps model failure
 distinguishable from environment defect.
+
+### Stage G — the two larger cohorts made runnable, 2026-09-11. Not run.
+
+Stage F's exit condition is "5, then 30, then 220". At the end of stage F
+neither of the last two could start, for two separate reasons that had nothing
+to do with the model: nobody had priced them, and neither fits in a job. Both
+are now settled, before the spend rather than four hours into one. Nothing in
+this section has been run and nothing has been charged.
+
+**What the three stages actually cost.** Priced with the repository's own
+arithmetic (`price_the_options`, eight tool calls and 8192 output tokens per
+turn, every figure a worst case where every task runs to every ceiling):
+
+| stage | tasks | running, at most | approved for running | marking, at most |
+|---|---|---|---|---|
+| `advance_check_5` | 5 | $18.47 | $50.00 | $2,504.67 |
+| `trial_30` | 30 | $114.61 | $200.00 | $13,770.99 |
+| `full_220` | 220 | $884.62 | $1,400.00 | $98,057.32 |
+
+The finding is the last column. Running all 220 tasks costs at most **$884.62**,
+which is an ordinary amount and sits inside the standing approval for running
+this work. Marking the same 220 answers costs at most **$98,057.32** — 111 times
+more than producing them, and more than every other cost in this project put
+together, because the grader asks on the order of 115,000 model questions to
+score 220 deliverables.
+
+So running and marking were separated in the plan rather than carried as one
+figure. `advance_check_5` keeps both of its approved amounts. `trial_30` and
+`full_220` have a running amount and an explicit **null** for marking, each with
+a `grading_not_approved_because` beside it. A null with no reason is
+indistinguishable from a figure somebody forgot to fill in, and the two want
+opposite responses from whoever reads it next; the runner refuses a stage block
+that gives a null without a reason, and refuses one that is silent about marking
+altogether. Finishing 220 runs is one milestone. Marking them is another, and
+the second does not follow from the first having been paid for.
+
+**The guard was replaced, not extended.** It used to compare two counts: the
+cohort about to run against the five the plan pins, refusing anything larger and
+naming the multiple. That was right while only the five were priced and wrong in
+both directions afterwards — it would refuse a correctly priced larger stage, and
+it would pass a cohort of the approved *size* whose tasks had grown more
+expensive. `price_one_stage` now prices the cohort that is actually bound against
+the amount the plan approved for that stage by name, and a shortfall is reported
+in dollars: *"short by $X ... nothing here may scale an approved amount on its
+own."* Task ids are deliberately **not** repeated in the pricing block — they
+come from the sealed catalogue, and a second copy is a second thing that can
+drift.
+
+**Why the cohorts have to be split, and how.** The plan fixes
+`per_task_timeout_seconds: 1200` and a GitHub job is killed at six hours, so at
+worst thirteen tasks fit in one job. 30 tasks is ten hours run as one job; 220 is
+seventy-three. `core/agentic_v2_sharding.py` deals the cohort out by stride
+(`task_ids[i::n]`) rather than in blocks. Both lose the same number of tasks when
+a piece is lost; only the stride split leaves a remainder that can still be
+described, because the cohort is ordered by a selection rule that groups related
+work together and a block shard is therefore a run of one kind of task.
+
+`scripts/plan_agentic_v2_shards.py` works the count out from the plan's timeout
+and GitHub's limit rather than from a number typed into the workflow: one shard
+for the five, three for the thirty, seventeen for the two hundred and twenty,
+each at most 4.3 hours of worst case. `advance_check_5` gets a matrix of one and
+`--shard 1/1` is the unsharded run rather than a new code path, so the smallest
+stage — the one whose results will be quoted most, because it is the only one
+approved for marking — runs exactly as it did before any of this existed.
+
+**A shard is not a smaller stage,** and three things enforce that rather than
+one. It is priced against the whole cohort, so seventeen jobs that are each
+"within budget" cannot spend seventeen times the approval. Its record carries
+`cohort_size` and the sentence *"the stage has not run until all 17 shards have"*,
+because twelve task ids with no denominator is indistinguishable from a
+twelve-task experiment. And `coverage_problems` is what earns the sentence "the
+stage ran": every task covered exactly once, checked by identity rather than by
+adding up counts — two overlapping shards can report the right total between them
+while one task ran twice and another never ran at all.
+
+In the workflow, `fail-fast` is off because each job has already been charged for
+the turns it made and cancelling its siblings would throw away paid work;
+`max-parallel` is 4 because the whole matrix talks to one deployment and a
+throttled call is still a call that was made; and the three time limits are
+ordered — step 300 minutes, job 330, GitHub 360 — so that the thing which stops
+first is a *step*, since a failed step leaves the rest of the job to run and the
+rest of the job is where the record gets uploaded.
+
+**Current pre-registration seal:**
+`6955e0f64bccdfe4138f1edade67a07c7d591c5e865328e43aa1a50ac64dcb87`.
+
+**What this stage does *not* mean.** No task has run. This is the two larger
+cohorts becoming *startable*, which is not the tasks running, which is not the
+answers being marked — the same three milestones, still deliberately not merged.
+`exec_run` is still shut and no guest boots, so the isolation remains
+unexercised and `environment_note` still writes that weaker true sentence into
+every record. The reference-file handicap is unchanged and grows with the
+cohort: 2 of 5, 14 of 30, **125 of 220** tasks name files that are not staged
+into the workspace. Closing that gap is a precondition for reading `trial_30` or
+`full_220` as a measurement of the model rather than of the environment, and it
+is not closed by anything above.
+
+### Stage H — the reference-file gap, measured, 2026-09-11. Nothing staged yet.
+
+The sentence directly above has appeared in every V2 record for a week, in the
+same shape each time: *125 of 220 tasks name files that are not staged*. It is
+true and it is useless, because it does not say whether closing the gap is an
+afternoon's copying or a redesign. So it was measured rather than restated.
+`batch-runner/scripts/measure_agentic_reference_files.py` reads the pinned
+snapshot and prints the shape; it makes no network call and spends nothing.
+
+| | |
+|---|---|
+| Tasks naming reference files | 125 of 220 |
+| Named files missing from the pinned snapshot | **0** |
+| All of it together | 1,656.7 MB |
+| Per task | median 53.6 KB, p90 2.4 MB, max 919.8 MB |
+| Files per task | 1 to 17, 261 in total |
+| Of those files | 86 xlsx + 74 pdf + 67 docx = 227 |
+
+Three findings, in the order they change the plan.
+
+**The bytes are already here.** Zero named files are missing from the snapshot.
+They sit at `reference_files/<folder>/<name>` and resolve directly against the
+snapshot root the workflow already downloads. Nothing has to be fetched,
+reconstructed or asked for. This had been an open question — the paths could
+have been names for files held somewhere else — and it is now answered.
+
+*A caution about that folder name.* It is a 32-character hex string and it is
+**not** reliably a digest of the file: an earlier check found it matches
+`sha256[:32]` for about 61% of reference files and for none of the deliverable
+files, while the repository's own wording claims it always does. It is treated
+here as an opaque identifier and never verified as a hash, because presenting a
+self-computed match as provenance would be exactly the overclaim this task is
+under standing instruction to avoid.
+
+**It is not one problem 125 times.** The median task needs about fifty
+kilobytes. Take out the three heaviest tasks and the remaining 122 come to
+**154.5 MB between them** — less than a tenth of the total. For the large
+majority of affected tasks, staging is a file copy of a few office documents,
+bounded well under every limit `core/agentic_compute.py` sets
+(`MAX_INPUT_FILES = 256`, `MAX_INPUT_TOTAL = 2 GiB`). The p90 of 2.4 MB is the
+number to design against, not the 1.66 GB total.
+
+**One file cannot be delivered at all.** `TWT_A001_03.mp4`, 689.1 MB, in task
+`a941b6d8-4289-4500-b45a-f8e4fc94a724`, is larger than the compute contract's
+own `MAX_INPUT_SINGLE` of 536.9 MB. That limit is not a staging bug to be raised
+out of the way. A file that size is not something a model reads; delivering it
+would mean choosing what the model gets *instead* — a transcript, sampled
+frames, a summary — and that choice changes what the task measures. It will be
+recorded per task as an unmet need, with the substitution named if one is ever
+made, rather than silently truncated. Two further tasks carry 339.0 MB and
+243.4 MB of media that fit the single-file limit but will dominate their own
+run.
+
+**What this stage does *not* mean.** Not one byte has been staged. This is a
+measurement, and the code that would copy these files into a task's workspace
+does not exist yet; `core/agentic_v2_manifest_binding.py` still says in as many
+words that a bound task is one whose reference files are *named and not
+present*. What has changed is that the fix is now designable: a copy for 122
+tasks, a size decision for 3, and one file that needs a recorded judgement
+before `full_220` can be read as a measurement of the model. It is deliberately
+not in this PR — one open PR at a time, and this one is about sharding.
+
+Noted alongside it, unfixed: the workflow's `hf download` has no `--include`, so
+the `free` job pulls all 1.66 GB when it needs only the parquet, and each of up
+to seventeen paid shards pulls it again. That is runner minutes rather than
+model spend, but it is seventeen times a gigabyte and a half for no reason.

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
@@ -2592,3 +2592,108 @@ identical as a number and are not the same fact.
 asks a model, or prices a call — all three modules are handed facts established
 elsewhere and arrange them. The blocker is still the single role assignment
 named in stage D, which remains reported and not requested.
+
+### Stage F — the entry point, and what is allowed to start it, 2026-09-11. Still not run.
+
+**First, retiring the sentence this document ended on.** Stage E closed with
+"the blocker is still the single role assignment named in stage D, which remains
+reported and not requested." That is no longer true and is left above rather
+than edited, because the dated sections are history and rewriting them would
+hide that the claim was ever made. What happened to it: the 401 that reading
+rested on was later shown to have arrived from *past* the authentication gate —
+a minted bearer token got 400 where a deliberately invalid one got 401 — so it
+was never evidence of a missing role. Stage A has since reached a real
+deployment and been charged for it. The blocker that actually stood after that
+was money, and on 2026-09-11 the owner approved two amounts.
+
+A disclaimer that outlives its fact is worse than none, because it is read as
+current: this one would have sent the next reader to request a permission
+nobody needs. Three more of the same kind were found and fixed in code rather
+than prose, so they cannot go stale again:
+
+* `core/agentic_v2_preregistration.py` stated both the role-assignment blocker
+  and "the amount is the owner's to fill in" as literal strings. They now come
+  from `_what_this_is_not()`, which asks
+  `stage_one_budget.stage_one_amount_note()` — so if an approval is ever
+  withdrawn the disclaimer turns back by itself. A test bars the retired
+  wording from returning.
+* `agentic_stage_one_plan.yaml` opened with "NOTHING HERE IS APPROVED AND
+  NOTHING HERE RUNS", four lines above the block holding two approved amounts.
+  Corrected in place, with what it used to say recorded, because the first
+  sentence of a file is the one a reader trusts.
+* `agentic-v2-stage-a-probe.yml` described marking as a share of a single
+  stage-one figure that no longer exists.
+
+**One approved amount became two, and the reason is in the arithmetic.** There
+used to be one `approved_maximum_usd` covering the whole of stage one. Marking
+the five answers is a flat $2504.67 whichever settings are chosen; running them
+moves from $3.37 to $493.70 across the candidate rows. Held as one number, the
+decision actually being made — what the model is given room to do — was under
+one per cent of the figure being signed and could have changed a hundredfold
+without moving it. The plan now carries `running_approved_maximum_usd: 50.00`
+and `grading_approved_maximum_usd: 2600.00`, the free check refuses a plan
+still carrying the old combined key, and the dry run prints the two on separate
+lines against their own ceilings. Chosen settings: 8 tool calls and 8192 output
+tokens per turn, $18.46 at most — the middle of three rows, recorded before the
+run with the reasoning, not after it.
+
+**The entry point.** `scripts/run_agentic_v2_stage.py` is the only route by
+which a V2 stage can run: free check, cohort binding, per-task ceilings, the
+conversation loop against a real deployment, collected deliverables, a cost
+receipt per task. It cannot run from a checkout — `core/azure_ai_clients.py`
+calls `_reject_static_azure_credential_env` before building anything, so the
+identity has to come from a federated OIDC session, and the only place one
+exists is a job holding `id-token: write`. Asked on this repository's own dev
+box, all thirteen route variables are unset. `.github/workflows/agentic-v2-stage-run.yml`
+is therefore the whole of how a stage starts: `workflow_dispatch` only, dry-run
+gating paid, the record uploaded under `always()` before the exit code is
+allowed to end the job.
+
+**The guard that refuses the cohorts nobody has priced.** The two approved
+amounts are whole-run figures for the five tasks the plan pins. Nothing about
+them is per-task. A 220-task stage run under them would go out against an
+approval for a run roughly 44 times smaller, and — this is the part worth
+stating — the line printed beside it would have said it was within budget,
+because the arithmetic it came from never saw the larger cohort. The runner
+refuses any stage the plan has not priced and names the multiple. `trial_30`
+and `full_220` are refused today and stay refused until somebody writes their
+task ids and their own two amounts down.
+
+**The conditions are now recorded before the run, not reconstructed after it.**
+`run_conditions` in the pre-registration holds the model, deployment, account,
+project and route profile; where the prompt wording comes from; the eight tools
+on offer; the per-task ceilings; and the retry rules. Almost none of it is
+written there — it is read from the plan, which is fingerprinted in the same
+record, and the ceilings come from `agentic_v2_conversation_runner.ceilings_from`,
+the same function that enforces them. Writing the arithmetic twice would let the
+promise and the enforcement drift apart with nothing to say so. Seal:
+`54fa669216c22c9b50cae265a42c4d4eb9371b8e1dbfa8c9034f782a20e076af`.
+
+Writing it down caught one error in this document's own claims. The record said
+seven tools were offered, on the reasoning that `exec_run` is shut. Nothing in
+the run narrows `tools_available`, whose default is the whole contract, so the
+model is offered all eight and `exec_run` answers `capability_unavailable` when
+chosen. That is the more interesting run — how a model reacts to a refused
+capability is a finding this stage can collect — but the record has to say what
+happens rather than what sounds tidier.
+
+**A structural finding about `full_220`, before rather than after the spend.**
+It will not fit in a GitHub job. The plan fixes `per_task_timeout_seconds: 1200`,
+so 220 tasks is up to 73 hours against a ceiling of six. The cohort has to be
+split across jobs. The runner already takes `--run-id` and resumes on it, so the
+mechanism exists, but the sharding and its pricing are not written down and the
+guard will keep refusing until they are.
+
+**What this stage does *not* mean.** No V2 task has run — this is the
+environment being made startable, which is not the tasks running, which is not
+the answers being marked. Three milestones, deliberately not merged. `exec_run`
+stays shut and no guest boots, so stage one exercises the loop and not the
+isolation, and `environment_note` writes that weaker true sentence into every
+record so it travels with the results. And the handicap is stated on the way in
+rather than discovered in the output: two of the five tasks in `advance_check_5`
+reference files that are not staged into the workspace, so the model will be
+answering without inputs an expert had. For `full_220` that is 125 of 220. The
+gap is closed before the larger cohorts; `advance_check_5` runs first anyway,
+because it is what proves route → model → tools → files → ceilings → receipts →
+deliverables → record end to end, and a printed handicap keeps model failure
+distinguishable from environment defect.

--- a/tasks/0822_saturday/v2_run_preregistration.json
+++ b/tasks/0822_saturday/v2_run_preregistration.json
@@ -423,7 +423,7 @@
       "task_wording_comes_from": "the pinned dataset revision in `manifest`"
     },
     "read_from": "batch-runner/experiments/execution_envelope/agentic_stage_one_plan.yaml",
-    "read_from_sha256": "1bdd87afc76bb6122737400b5351d5b5de061ccea0edc25d7762fa280996dc38",
+    "read_from_sha256": "c213a96e7e0353b6b29d905a6b5d6b221d93654475ab6ce6436e5c7eeb268e46",
     "retry": {
       "kinds_recorded_separately": [
         "infrastructure",
@@ -456,7 +456,7 @@
     },
     "what_stops_a_task": "any per-task ceiling above, or the per-task budget, whichever comes first. A task stopped by a ceiling is recorded as stopped by that ceiling and is not a model failure"
   },
-  "seal": "54fa669216c22c9b50cae265a42c4d4eb9371b8e1dbfa8c9034f782a20e076af",
+  "seal": "6955e0f64bccdfe4138f1edade67a07c7d591c5e865328e43aa1a50ac64dcb87",
   "stop_rules": [
     "the deployment or model reported back differs from the pinned one",
     "a run switches model or deployment on its own",

--- a/tasks/0822_saturday/v2_run_preregistration.json
+++ b/tasks/0822_saturday/v2_run_preregistration.json
@@ -389,7 +389,74 @@
     "the first five tasks not all succeeding; there is no target pass rate anywhere in this record, and a stage does not have to look good to proceed",
     "results disagreeing with A's Codex run"
   ],
-  "seal": "fa74921bdfcb9368c4f9140a1f990b6a60d2059963d2abb76e06d6d8eb9115ea",
+  "run_conditions": {
+    "how_the_ceilings_were_derived": {
+      "chosen_settings": {
+        "max_output_tokens_per_turn": 8192,
+        "tool_calls_per_attempt": 8
+      },
+      "comes_from": "core/agentic_v2_conversation_runner.py ceilings_from",
+      "input_tokens": "quadratic in the number of turns, because the loop re-sends the whole conversation every turn",
+      "seconds": "per_task_timeout_seconds, straight from the plan",
+      "turns": "one model call per tool call, plus the turn that finalises"
+    },
+    "model": {
+      "account": "hjeon-fdpo-foundry-eus2",
+      "automatic_model_switch_allowed": false,
+      "deployment": "gpt-5.4",
+      "project": "gdpval-realworks",
+      "resolved_model": "gpt-5.4",
+      "route_profile": "project-ci"
+    },
+    "per_task_ceilings": {
+      "max_input_tokens": 737280,
+      "max_model_calls": 9,
+      "max_model_turns": 9,
+      "max_output_tokens": 73728,
+      "max_repeats_of_one_request": 2,
+      "max_seconds": 1200.0,
+      "max_written_tokens_per_turn": 8192
+    },
+    "prompt": {
+      "self_review_enabled": false,
+      "standing_instruction_length_assumed_from": "experiments/execution_envelope/advance_check_plan.yaml",
+      "task_wording_comes_from": "the pinned dataset revision in `manifest`"
+    },
+    "read_from": "batch-runner/experiments/execution_envelope/agentic_stage_one_plan.yaml",
+    "read_from_sha256": "1bdd87afc76bb6122737400b5351d5b5de061ccea0edc25d7762fa280996dc38",
+    "retry": {
+      "kinds_recorded_separately": [
+        "infrastructure",
+        "semantic",
+        "internal"
+      ],
+      "max_attempts": 1,
+      "max_repeats_of_one_request": 2,
+      "reasons_allowed": [
+        "infrastructure_error"
+      ]
+    },
+    "tools": {
+      "comes_from": "core/agentic_v2_contract.py TOOL_NAMES",
+      "exec_run_open": false,
+      "narrowed_by_the_run": false,
+      "offered": [
+        "capabilities_query",
+        "workspace_apply",
+        "exec_run",
+        "environment_resolve",
+        "environment_activate",
+        "browser_run",
+        "verify_public",
+        "finalize"
+      ],
+      "offered_but_refuses_everything": [
+        "exec_run"
+      ]
+    },
+    "what_stops_a_task": "any per-task ceiling above, or the per-task budget, whichever comes first. A task stopped by a ceiling is recorded as stopped by that ceiling and is not a model failure"
+  },
+  "seal": "54fa669216c22c9b50cae265a42c4d4eb9371b8e1dbfa8c9034f782a20e076af",
   "stop_rules": [
     "the deployment or model reported back differs from the pinned one",
     "a run switches model or deployment on its own",
@@ -402,8 +469,8 @@
   ],
   "what_this_is": "what a V2 run is committed to before it starts. Committed ahead of execution so that a later result cannot be described as having been planned this way when it was not.",
   "what_this_is_not": [
-    "not a statement that the environment is ready -- at the time of writing no V2 task has run, and the blocker is a role assignment in the subscription that holds the model",
-    "not an approval to spend; the amount lives in experiments/execution_envelope/agentic_stage_one_plan.yaml and is the owner's to fill in",
+    "not a statement that the environment is ready. No V2 task has run. What stage one registers is a run with exec_run shut and no guest booted, so the isolation is not exercised by it and no result from it is evidence that the sandbox contains anything",
+    "not an approval to spend more than the five-task cohort. Two amounts are approved in experiments/execution_envelope/agentic_stage_one_plan.yaml -- one for running the five tasks and one for marking their answers -- and they are whole-run figures for those five. The thirty and the two hundred and twenty are not priced, and scripts/run_agentic_v2_stage.py refuses them until they are",
     "not a prediction of how the run will go"
   ]
 }


### PR DESCRIPTION
The V2 stage runner landed in #522, but nothing could start it — and three
sentences in the repository had quietly stopped being true.

## One approved amount becomes two

Marking the five stage-one answers is a flat **\$2504.67** whatever the settings
are. Running them moves from **\$3.37 to \$493.70** across the candidate rows.
Held as a single `approved_maximum_usd`, the decision actually being made — what
the model is given room to do — was under one per cent of the figure being
signed, and could have changed a hundredfold without moving it.

The plan now carries `running_approved_maximum_usd: 50.00` and
`grading_approved_maximum_usd: 2600.00`. The free check refuses a plan still
carrying the combined key, and the dry run prints the two on separate lines
against their own ceilings. Chosen settings — 8 tool calls, 8192 output tokens
per turn, \$18.46 at most — are recorded with the reasoning **before** the run.

## An entry point, and the only place it can run

`scripts/run_agentic_v2_stage.py` puts the parts in a line: free check, cohort
binding, per-task ceilings, the conversation loop against a real deployment,
collected deliverables, a cost receipt per task.

It cannot run from a checkout. `core/azure_ai_clients.py` calls
`_reject_static_azure_credential_env` before building anything, so the identity
has to come from a federated OIDC session, and the only place one exists is a
job holding `id-token: write`. Asked on this repo's own dev box, all thirteen
route variables are unset. Hence `.github/workflows/agentic-v2-stage-run.yml`:
`workflow_dispatch` only, dry-run gating paid, the record uploaded under
`always()` before the exit code is allowed to end the job.

## A guard against pricing 220 tasks with a five-task approval

Both amounts are whole-run figures over the five `task_ids` the plan pins.
Neither is a per-task rate. A 220-task stage run under them would have gone out
against an approval **roughly 44× smaller** — and the line printed beside it
would have said it was within budget, because the arithmetic it came from never
saw the larger cohort. Refused now, with the multiple named. `trial_30` and
`full_220` stay refused until someone writes their task ids and their own two
amounts down.

## The conditions are recorded before the run

`run_conditions` in the pre-registration holds the model, deployment, account,
project and route profile; the prompt's source; the eight tools; the per-task
ceilings; and the retry rules — read from the plan, which is fingerprinted in
the same record. `ceilings_from` moved into `agentic_v2_conversation_runner` so
the promise and the enforcement come from one function.

Writing it down caught a real error in my own claim: the record said seven tools
were offered, on the reasoning that `exec_run` is shut. Nothing narrows
`tools_available`, whose default is the whole contract, so the model is offered
**all eight** and `exec_run` answers `capability_unavailable` when chosen.

## Three stale sentences retired

| Where | Said | Actually |
|---|---|---|
| `agentic_v2_preregistration.py` | the blocker is a role assignment | that reading came from a 401 since shown to have arrived *past* the auth gate; stage A has reached a real deployment |
| `agentic_stage_one_plan.yaml` | "NOTHING HERE IS APPROVED" | four lines above two approved amounts |
| `agentic-v2-stage-a-probe.yml` | marking is a share of stage one's \$2543 | that combined figure no longer exists |

The first two now **read the plan** rather than state it, so they turn back by
themselves if an approval is withdrawn. A test bars the retired wording from
returning.

## Recorded, not fixed

- **`full_220` will not fit in a GitHub job.** 220 tasks at the plan's 1200s
  ceiling is up to 73 hours against a cap of six. The cohort needs sharding
  across `--run-id` resumes before it can be priced.
- **The reference-file handicap.** 2 of the 5 tasks in `advance_check_5`
  reference files not staged into the workspace (125 of 220 for the full
  cohort). Printed on the way in, so model failure stays distinguishable from
  environment defect.

## Shared files touched — for serial-merge ordering

- `.gitignore` — one allowlist negation. `batch-runner/scripts/*` is blanket
  ignored, so the 20KB entry point was invisible to git; added with the
  explanatory comment the ~49 existing negations all carry.
- `batch-runner/core/execution_environment_readiness.py` — carried in from #522's
  series, not newly touched here.

No CHANGELOG entry, following the convention #522 set for this series.

## Verification

Full backend suite **10776 passed, 18 skipped, exit 0**. No V2 task has run,
nothing here spends, `exec_run` stays shut and no guest boots. **\$0 this
branch.**