### PR TITLE
resume: do not run a content-filtered task again

### DIFF
--- a/batch-runner/step2_run_inference.py
+++ b/batch-runner/step2_run_inference.py
@@ -177,6 +177,36 @@ RETRYABLE_INFRA_ERROR_CATEGORIES = frozenset({
     "turn_start_failed",
 })
 
+#: The failures a resume round must not pick up.
+#:
+#: Resume rounds are a second mechanism, further out than the infra retries
+#: above: after a whole pass, `_get_failed_task_ids` gathers the tasks that
+#: did not end on `success` and runs them again. It gathered them by *status*
+#: alone -- `RETRIABLE_STATUSES` -- and never looked at why the task failed,
+#: which meant it did not honour the one rule stated next to
+#: `RETRYABLE_INFRA_ERROR_CATEGORIES`: that `content_filtered` must never be
+#: retried. Run `34540053904` has the shape of what that gathers -- task
+#: `11e1b169` ended `{"status": "error", "error_category": "content_filtered"}`
+#: and matches `RETRIABLE_STATUSES` exactly.
+#:
+#: Retrying that task does not recover a lost result. The provider read the
+#: answer and stopped it, which is an outcome the benchmark is asking for, so
+#: asking again until something gets through replaces one benchmark outcome
+#: with a different one and raises the score by the difference.
+#:
+#: `execution.resume_max_rounds` defaults to 3 in `core/experiment_config.py`,
+#: so before this set existed the protection was that every experiment file
+#: remembered to write `resume_max_rounds: 0`. exp034 and exp035 both do, and
+#: exp035 writes out why at length rather than omitting the key. That is a
+#: real precaution and it is also one an author has to know to take; a file
+#: that simply leaves the key out retries filtered tasks quietly.
+#:
+#: Only this one category is here. Every other failure is mechanical -- the
+#: connection broke, the runtime died, the deadline passed -- and asking again
+#: is an attempt at the same question. This one is the provider deciding about
+#: the content, and that decision *is* the result.
+NON_RESUMABLE_ERROR_CATEGORIES = frozenset({"content_filtered"})
+
 #: How long to wait before each infrastructure retry, by attempt.
 #:
 #: The first is sixty seconds because an Azure OpenAI rate limit is counted
@@ -2877,16 +2907,51 @@ def validate_restored_checkpoint(condition_key: str = "condition_a") -> dict:
 # ── Progress helpers ───────────────────────────────────────────────────────
 
 
+def _resume_refusal_category(result: dict) -> Optional[str]:
+    """The reason this result must not be run again, or ``None``.
+
+    Reads the same place `infra_retry_category` reads, so the two mechanisms
+    agree about what a task's failure was even though they disagree about what
+    to do with most of them.
+
+    A result that says nothing about why it failed is resumable. Unknown is
+    not treated as filtered here: `classify_execution_error` returns ``None``
+    for text it does not recognise, and a `pending` task never ran at all, so
+    refusing on absence would quietly turn resume off for the ordinary
+    failures it exists to recover.
+    """
+    if not isinstance(result, dict):
+        return None
+    observability = result.get("observability")
+    if not isinstance(observability, dict):
+        return None
+    category = observability.get("error_category")
+    if category in NON_RESUMABLE_ERROR_CATEGORIES:
+        return str(category)
+    return None
+
+
 def _get_failed_task_ids(progress: dict) -> list:
-    """progress.json에서 retriable status 태스크 추출."""
+    """progress.json에서 retriable status 태스크 추출.
+
+    A retriable status is necessary but not sufficient: a task the provider
+    stopped for content carries `status: "error"` and is skipped here, because
+    running it again would replace a benchmark outcome rather than recover a
+    lost one. See `NON_RESUMABLE_ERROR_CATEGORIES`.
+    """
     failed = []
     for r in progress.get("results", []):
-        if r.get("status") in RETRIABLE_STATUSES:
-            failed.append({
-                "task_id": r["task_id"],
-                "status": r["status"],
-                "error": r.get("error", ""),
-            })
+        if r.get("status") not in RETRIABLE_STATUSES:
+            continue
+        refused = _resume_refusal_category(r)
+        if refused is not None:
+            print(f"   ⏭️  {r['task_id']}: not resumed ({refused})")
+            continue
+        failed.append({
+            "task_id": r["task_id"],
+            "status": r["status"],
+            "error": r.get("error", ""),
+        })
     return failed
 
 

--- a/batch-runner/tests/test_a_filtered_answer_is_not_resumed_into_a_score.py
+++ b/batch-runner/tests/test_a_filtered_answer_is_not_resumed_into_a_score.py
@@ -1,0 +1,237 @@
+"""A task the provider stopped for content is not run again into a score.
+
+Resume rounds are the outer of two retry mechanisms in ``step2_run_inference``.
+The inner one — ``run_with_infra_retries`` — asks again inside a single task,
+and it has always been careful about *why* the task failed:
+``RETRYABLE_INFRA_ERROR_CATEGORIES`` holds two categories and the comment above
+it says of ``content_filtered`` that it "is not here, and must never be".
+
+The outer one did not read that rule. ``_get_failed_task_ids`` gathered every
+result whose *status* was in ``RETRIABLE_STATUSES`` and ran it again, and a
+filtered task's status is ``"error"`` — so it matched, every round.
+
+That is not a hypothetical shape. It is the shape run ``34540053904`` wrote
+down, and this file reads it from the committed excerpt of that run rather than
+constructing it, so the test cannot drift away from what the provider actually
+returned.
+
+Why it matters more than an ordinary retry bug: the provider read the answer
+and stopped it. That is a result the benchmark is asking for. Asking again
+until something gets through does not recover a lost outcome, it replaces one
+outcome with a different one — and the difference lands in the score.
+
+``execution.resume_max_rounds`` defaults to ``3``. Before this, the only thing
+standing between a filtered task and three more attempts was the experiment
+author remembering to write ``resume_max_rounds: 0``. exp034 and exp035 both
+remembered. A file that omits the key did not, and said nothing about it.
+
+Nothing here contacts a provider.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from step2_run_inference import (
+    NON_RESUMABLE_ERROR_CATEGORIES,
+    RETRIABLE_STATUSES,
+    RETRYABLE_INFRA_ERROR_CATEGORIES,
+    _get_failed_task_ids,
+    infra_retry_category,
+)
+
+RUN_RECORD = (
+    Path(__file__).parent / "fixtures" / "run_record" / "exp034_observability_excerpt.json"
+)
+
+
+def _recorded_results() -> list:
+    """The verbatim ``status``/``observability`` rows run 34540053904 wrote."""
+    return json.loads(RUN_RECORD.read_text(encoding="utf-8"))["results"]
+
+
+def _only(results, category):
+    return [
+        r for r in results
+        if (r.get("observability") or {}).get("error_category") == category
+    ]
+
+
+# ── the real row, read from the run that produced it ─────────────────────────
+
+
+def test_the_recorded_filtered_task_matches_a_retriable_status(tmp_path):
+    """The premise. Without this the rest of the file is guarding nothing."""
+    filtered = _only(_recorded_results(), "content_filtered")
+    assert filtered, "the excerpt no longer carries a content_filtered row"
+    for row in filtered:
+        assert row["status"] in RETRIABLE_STATUSES, (
+            "a filtered task used to be gathered by status alone; if its status "
+            "is no longer retriable, this guard is being kept for a shape that "
+            "cannot occur and the reason should be rewritten, not the test"
+        )
+
+
+def test_the_recorded_filtered_task_is_not_gathered_for_resume():
+    filtered = {r["task_id"] for r in _only(_recorded_results(), "content_filtered")}
+
+    gathered = {r["task_id"] for r in _get_failed_task_ids({"results": _recorded_results()})}
+
+    assert filtered and not (filtered & gathered)
+
+
+def test_the_recorded_rate_limited_task_is_still_gathered():
+    """The guard is about one category, not about failures in general.
+
+    ``rate_limited`` is the failure the retry machinery was written for. If
+    this stops being gathered, the fix has taken the resume rounds down with
+    it.
+    """
+    limited = {r["task_id"] for r in _only(_recorded_results(), "rate_limited")}
+
+    gathered = {r["task_id"] for r in _get_failed_task_ids({"results": _recorded_results()})}
+
+    assert limited and limited <= gathered
+
+
+def test_the_recorded_success_is_not_gathered():
+    results = _recorded_results()
+    succeeded = {r["task_id"] for r in results if r["status"] == "success"}
+
+    gathered = {r["task_id"] for r in _get_failed_task_ids({"results": results})}
+
+    assert succeeded and not (succeeded & gathered)
+
+
+# ── what still resumes ───────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("status", sorted(RETRIABLE_STATUSES))
+def test_every_retriable_status_still_resumes_without_a_category(status):
+    """A result that says nothing about why it failed is still recovered.
+
+    ``classify_execution_error`` returns ``None`` for text it does not
+    recognise, and a ``pending`` task never ran at all. Refusing on absence
+    would quietly turn resume off for the ordinary failures it exists for.
+    """
+    gathered = _get_failed_task_ids(
+        {"results": [{"task_id": "t", "status": status, "error": "boom"}]}
+    )
+
+    assert [r["task_id"] for r in gathered] == ["t"]
+
+
+def test_an_unrecognised_category_still_resumes():
+    gathered = _get_failed_task_ids({
+        "results": [{
+            "task_id": "t",
+            "status": "error",
+            "observability": {"error_category": "something_new"},
+        }]
+    })
+
+    assert [r["task_id"] for r in gathered] == ["t"]
+
+
+@pytest.mark.parametrize("observability", [None, "", [], 0, {"error_category": None}])
+def test_a_result_with_no_usable_observability_still_resumes(observability):
+    gathered = _get_failed_task_ids({
+        "results": [{"task_id": "t", "status": "error", "observability": observability}]
+    })
+
+    assert [r["task_id"] for r in gathered] == ["t"]
+
+
+def test_the_gathered_row_keeps_the_fields_the_resume_round_reads():
+    gathered = _get_failed_task_ids(
+        {"results": [{"task_id": "t", "status": "qa_failed", "error": "why"}]}
+    )
+
+    assert gathered == [{"task_id": "t", "status": "qa_failed", "error": "why"}]
+
+
+# ── what is refused ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("status", sorted(RETRIABLE_STATUSES))
+def test_a_filtered_task_is_refused_whatever_its_retriable_status(status):
+    gathered = _get_failed_task_ids({
+        "results": [{
+            "task_id": "t",
+            "status": status,
+            "observability": {"error_category": "content_filtered"},
+        }]
+    })
+
+    assert gathered == []
+
+
+def test_the_skip_is_announced(capsys):
+    """A task silently dropped from a resume round is its own kind of wrong.
+
+    The count printed by the resume round is the only place a reader learns
+    how many tasks it is about to run, so a task that vanishes from it without
+    a word looks like it was never failing.
+    """
+    _get_failed_task_ids({
+        "results": [{
+            "task_id": "11e1b169",
+            "status": "error",
+            "observability": {"error_category": "content_filtered"},
+        }]
+    })
+
+    printed = capsys.readouterr().out
+    assert "11e1b169" in printed and "content_filtered" in printed
+
+
+def test_refusing_one_task_does_not_drop_the_rest():
+    gathered = _get_failed_task_ids({
+        "results": [
+            {"task_id": "before", "status": "error", "error": "boom"},
+            {
+                "task_id": "filtered",
+                "status": "error",
+                "observability": {"error_category": "content_filtered"},
+            },
+            {"task_id": "after", "status": "error", "error": "boom"},
+        ]
+    })
+
+    assert [r["task_id"] for r in gathered] == ["before", "after"]
+
+
+# ── the two mechanisms agree about the category, and only about that ─────────
+
+
+def test_content_filtered_is_refused_by_both_mechanisms():
+    """The inner one refuses by omission; the outer one now refuses by name."""
+    filtered = {
+        "task_id": "t",
+        "status": "error",
+        "observability": {"error_category": "content_filtered"},
+    }
+
+    assert infra_retry_category(filtered) is None
+    assert _get_failed_task_ids({"results": [filtered]}) == []
+
+
+def test_the_two_sets_do_not_overlap():
+    """A category in both would mean the run disagrees with itself."""
+    assert not (NON_RESUMABLE_ERROR_CATEGORIES & RETRYABLE_INFRA_ERROR_CATEGORIES)
+
+
+def test_only_the_provider_s_own_decision_is_refused():
+    """Deliberately one category.
+
+    Every other failure is mechanical — the connection broke, the runtime
+    died, the deadline passed — and asking again is another attempt at the
+    same question. Widening this set would stop recovering results that were
+    genuinely lost, which is the opposite mistake and just as quiet.
+    """
+    assert NON_RESUMABLE_ERROR_CATEGORIES == frozenset({"content_filtered"})
+
+
+def test_the_set_cannot_be_widened_at_runtime():
+    assert isinstance(NON_RESUMABLE_ERROR_CATEGORIES, frozenset)


### PR DESCRIPTION
## 콘텐츠 필터로 막힌 문제를 **다시 풀어서 점수로 만들지 않습니다**

### 재시도가 두 군데 있는데, 한 쪽만 규칙을 지키고 있었습니다

| | 어디서 | 규칙을 읽나 |
|---|---|---|
| **안쪽** 재시도 | 문제 하나 안에서 바로 다시 | ✅ **왜 실패했는지 보고** 결정 |
| **바깥쪽** 재개(resume) 회차 | 한 바퀴 다 돈 뒤 실패한 것만 모아서 | ❌ **상태만 보고** 결정 |

안쪽 코드에는 이런 주석이 **원래부터** 붙어 있습니다:

> `content_filtered`는 여기 없고, **절대 있으면 안 된다.** … 뭔가 통과할 때까지 재시도하면 **필터된 문제를 점수 매겨진 문제로 바꿔서 성공률을 올리는 것** — 질문을 바꿔서 점수를 올리는 것이다.

그런데 바깥쪽 `_get_failed_task_ids`는 **상태(status)만** 봤습니다. 그리고 **필터로 막힌 문제의 상태는 `error`** 입니다. 그래서 **재개 회차마다 다시 풀렸습니다.**

### 가정이 아니라 **실제 실행이 남긴 모양입니다**

실행 `34540053904`의 기록입니다:

```json
{"task_id": "11e1b169-...", "status": "error",
 "observability": {"error_category": "content_filtered"}}
```

`status`가 `error` → **재개 대상에 그대로 들어갑니다.**

이 기록 파일은 **이미 저장소에 들어와 있습니다**(#525). 테스트가 그 파일에서 **필터된 줄을 직접 꺼내 씁니다.** 모양을 지어내지 않았기 때문에, 나중에 제공자 응답이 바뀌면 **테스트가 먼저 틀립니다.**

### 지금까지 이걸 막고 있던 건 **사람의 기억력**이었습니다

`resume_max_rounds`의 **기본값은 3**입니다(`core/experiment_config.py`).

exp034와 exp035는 둘 다 `resume_max_rounds: 0`을 적어놨고, exp035는 **왜 0인지 길게 써뒀습니다.** 그건 제대로 된 대비입니다.

**하지만 그건 "작성자가 알고 있어야만" 되는 대비입니다.** 이 키를 그냥 빼먹은 실험 파일은 **필터된 문제를 조용히 3번 더 풉니다.** 아무 말도 없이.

### 딱 **한 가지**만 막습니다

| | 다시 풀까? | 왜 |
|---|---|---|
| `content_filtered` | ❌ **안 함** | **제공자가 답을 읽고 멈춘 것.** 그 판단 자체가 결과입니다 |
| 그 밖의 전부 | ✅ 함 | 연결이 끊겼고, 런타임이 죽었고, 시간이 다 됐고 — **기계적 실패.** 다시 묻는 건 **같은 질문을 다시 하는 것** |

넓히면 **반대 방향의 실수**가 됩니다. 진짜로 잃어버린 결과를 못 건지게 되고, 그것도 똑같이 조용합니다.

### 모르는 실패는 **여전히 다시 풉니다**

"실패 이유를 모름"을 "필터"로 읽지 않습니다.

- `classify_execution_error`는 못 알아본 글자에 **`None`을 돌려줍니다**
- `pending` 문제는 **아예 실행된 적이 없습니다**

없다고 거부하면 **재개 기능이 통째로 조용히 꺼집니다.** 그래서 **이유를 말하지 않는 결과는 그대로 재개 대상**입니다.

### 건너뛴 건 **말로 합니다**

```
   ⏭️  11e1b169: not resumed (content_filtered)
```

재개 회차가 찍는 개수는 **"이제 몇 문제를 돌릴 건지" 읽는 사람이 알 수 있는 유일한 자리**입니다. 거기서 문제가 아무 말 없이 사라지면 **처음부터 실패한 적 없는 것처럼 보입니다.**

### 지금 돌고 있는 220 실행과의 관계 — **없습니다**

그 실행은 **이미 `resume_max_rounds: 0`** 입니다. 그래서:

- ❌ 이 변경이 그 실행을 **보호하지 않습니다** (보호할 게 없음)
- ✅ 그 실행을 **건드리지도 않습니다**

워크플로 파일도, 설정 파일도 안 바꿉니다.

### 건드린 파일

| 파일 | 무엇 |
|---|---|
| `step2_run_inference.py` | `NON_RESUMABLE_ERROR_CATEGORIES` 추가, `_get_failed_task_ids`가 이유를 보게 함 |
| `tests/test_a_filtered_answer_is_not_resumed_into_a_score.py` | 새 파일, 23개 |

기존 `test_silent_corruption_fixes.py`의 `_get_failed_task_ids` 테스트는 **한 줄도 안 고치고 통과**합니다.
