### PR TITLE
목록 파일을, 짝꿍 문서가 못 버티면 아예 안 쓰게

### DIFF
--- a/scripts/__tests__/a-test-file-that-will-not-parse-is-not-zero-experiments.test.mjs
+++ b/scripts/__tests__/a-test-file-that-will-not-parse-is-not-zero-experiments.test.mjs
@@ -34,11 +34,11 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { loadAllTests } from '../aggregate-tests.mjs';
+import { loadAllTests, main } from '../aggregate-tests.mjs';
 
 const VALID_YAML = [
   'id: exp900',
@@ -143,4 +143,124 @@ test('importing the module does not run the aggregation', () => {
   // If main() still ran at import time, loading this test file would rewrite
   // public/generated/ from the real data/tests/ as a side effect.
   assert.equal(typeof loadAllTests, 'function');
+});
+
+// ── The markdown pass reads more than the loader used to promise ────────────
+//
+// Everything above is about a file that cannot be parsed. These are about one
+// that parses into an object and is still missing something the second half of
+// the script dereferences without a guard:
+//
+//     `${exp.condition_b.name} (${exp.condition_b.win_rate}%) | `
+//     experiments.reduce((s, e) => s + e.delta, 0)
+//
+// Reproduced before it was fixed: with a second file holding no condition_b,
+// the run printed `Found 2 experiments`, wrote experiments-index.json with
+// both, and then exited 1 with `Cannot read properties of undefined (reading
+// 'name')` at aggregate-tests.mjs:108 — a line number, naming no file, with
+// the index already on disk and llm-context.md left as whatever the previous
+// build had put there.
+
+const WITHOUT = (field) =>
+  VALID_YAML.split('\n')
+    .reduce(
+      (acc, line) => {
+        if (/^\S/.test(line)) acc.skipping = line.startsWith(`${field}:`);
+        if (!acc.skipping) acc.kept.push(line);
+        return acc;
+      },
+      { kept: [], skipping: false },
+    )
+    .kept.join('\n')
+    // condition_b is the last block, so dropping it takes the trailing blank
+    // line with it and the next appended field lands on the previous line.
+    .replace(/\n*$/, '\n');
+
+test('a file holding only one condition names itself instead of dying at a line number', async () => {
+  await withTestsDir({ 'exp900.yaml': WITHOUT('condition_b') }, async (dir) => {
+    await assert.rejects(
+      () => loadAllTests(dir),
+      /exp900\.yaml is present but holds no condition_b/,
+    );
+  });
+  await withTestsDir({ 'exp900.yaml': WITHOUT('condition_a') }, async (dir) => {
+    await assert.rejects(
+      () => loadAllTests(dir),
+      /exp900\.yaml is present but holds no condition_a/,
+    );
+  });
+});
+
+test('a condition that is a scalar or a list is refused like a missing one', async () => {
+  // `typeof null === 'object'`, and a list would index as one too, so both are
+  // named explicitly rather than left to a truthiness check.
+  for (const body of ['condition_b: just a name\n', 'condition_b:\n', 'condition_b:\n  - B\n']) {
+    await withTestsDir({ 'exp900.yaml': WITHOUT('condition_b') + body }, async (dir) => {
+      await assert.rejects(
+        () => loadAllTests(dir),
+        /exp900\.yaml is present but holds no condition_b/,
+      );
+    });
+  }
+});
+
+test('a delta that is not a number is refused before it becomes +NaN%p', async () => {
+  // This one never threw on its own. `s + e.delta` over a missing delta is
+  // NaN, and the run completed, exited 0, and published `평균 Delta: +NaN%p`
+  // into the document handed to an LLM as the whole truth about the corpus —
+  // the same silent-wrong outcome as the empty file above, one field deeper.
+  await withTestsDir({ 'exp900.yaml': WITHOUT('delta') }, async (dir) => {
+    await assert.rejects(
+      () => loadAllTests(dir),
+      /exp900\.yaml is present but its delta is not a number: undefined/,
+    );
+  });
+  await withTestsDir({ 'exp900.yaml': `${WITHOUT('delta')}delta: "4"\n` }, async (dir) => {
+    await assert.rejects(
+      () => loadAllTests(dir),
+      /exp900\.yaml is present but its delta is not a number: "4"/,
+    );
+  });
+});
+
+test('a corpus the markdown cannot render leaves no index behind', async () => {
+  // The ordering guarantee, tested rather than asserted in a comment: main()
+  // renders both documents before writing either, so a failure anywhere in the
+  // second one cannot leave the first published. Checked against the real
+  // failure — two files, one of them unrenderable — because the risk was never
+  // a single bad file on its own but a good one carrying a bad one into a
+  // half-written directory.
+  await withTestsDir(
+    { 'exp900.yaml': VALID_YAML, 'exp901.yaml': WITHOUT('condition_b') },
+    async (dir) => {
+      const out = await mkdtemp(join(tmpdir(), 'gdpval-aggregate-out-'));
+      try {
+        await assert.rejects(() => main(dir, out), /exp901\.yaml/);
+        assert.deepEqual(
+          await readdir(out).catch(() => []),
+          [],
+          'the index was written before the markdown pass failed',
+        );
+      } finally {
+        await rm(out, { recursive: true, force: true });
+      }
+    },
+  );
+});
+
+test('a corpus that renders writes both documents', async () => {
+  // Teeth for the test above: if main() wrote nothing at all, an empty output
+  // directory would prove nothing.
+  await withTestsDir({ 'exp900.yaml': VALID_YAML }, async (dir) => {
+    const out = await mkdtemp(join(tmpdir(), 'gdpval-aggregate-out-'));
+    try {
+      await main(dir, out);
+      assert.deepEqual((await readdir(out)).sort(), [
+        'experiments-index.json',
+        'llm-context.md',
+      ]);
+    } finally {
+      await rm(out, { recursive: true, force: true });
+    }
+  });
 });

--- a/scripts/aggregate-tests.mjs
+++ b/scripts/aggregate-tests.mjs
@@ -62,6 +62,29 @@ export async function loadAllTests(testsDir = TESTS_DIR) {
         }`
       );
     }
+    // The same line, one field deeper. generateLlmContext reads both
+    // conditions and `delta` without a guard, and it runs after the index has
+    // already been written, so a file missing one of them published a
+    // correct-looking experiments-index.json and then died at a line number
+    // naming no file — the exact shape the empty-file check above exists to
+    // prevent. `delta` does not even die: it reaches the document an LLM is
+    // handed as fact as `평균 Delta: +NaN%p`.
+    for (const side of ['condition_a', 'condition_b']) {
+      const condition = data[side];
+      if (condition === null || typeof condition !== 'object' || Array.isArray(condition)) {
+        throw new Error(
+          `${file} is present but holds no ${side}: an experiment in this ` +
+            `directory is a comparison of two conditions and both are read`
+        );
+      }
+    }
+    if (typeof data.delta !== 'number' || !Number.isFinite(data.delta)) {
+      throw new Error(
+        `${file} is present but its delta is not a number: ${
+          JSON.stringify(data.delta) ?? 'undefined'
+        }`
+      );
+    }
     experiments.push({ ...data, _sourceFile: file });
   }
 
@@ -169,28 +192,41 @@ function generateLlmContext(experiments) {
 }
 
 // ── Main
-async function main() {
+export async function main(testsDir = TESTS_DIR, outputDir = OUTPUT_DIR) {
   console.log('📦 Aggregating test files...');
 
-  const experiments = await loadAllTests();
+  const experiments = await loadAllTests(testsDir);
   console.log(`   Found ${experiments.length} experiments`);
 
-  await mkdir(OUTPUT_DIR, { recursive: true });
+  // Both documents are rendered before either is written. The index used to be
+  // written first and the markdown rendered after, so any failure in the
+  // markdown pass left a published index beside a companion document that was
+  // stale or absent — two files on disk describing different corpora, with the
+  // build exiting 1 over a line number. The loader's contract cannot anticipate
+  // every field a future section of the markdown will read; this ordering does
+  // not have to.
+  //
+  // Rendering once also fixes a smaller thing: each generator was called twice,
+  // once to write and once to measure, and generateIndexJson stamps
+  // `new Date().toISOString()`, so the size reported was of a string that was
+  // never the one written.
+  const indexJson = generateIndexJson(experiments);
+  const llmContext = generateLlmContext(experiments);
 
-  // 1. JSON for Dashboard
-  const jsonPath = join(OUTPUT_DIR, 'experiments-index.json');
-  await writeFile(jsonPath, generateIndexJson(experiments));
+  await mkdir(outputDir, { recursive: true });
+
+  const jsonPath = join(outputDir, 'experiments-index.json');
+  await writeFile(jsonPath, indexJson);
   console.log(`   ✅ ${jsonPath}`);
 
-  // 2. Markdown for LLM
-  const mdPath = join(OUTPUT_DIR, 'llm-context.md');
-  await writeFile(mdPath, generateLlmContext(experiments));
+  const mdPath = join(outputDir, 'llm-context.md');
+  await writeFile(mdPath, llmContext);
   console.log(`   ✅ ${mdPath}`);
 
-  // 사이즈 리포트
-  const jsonSize = Buffer.byteLength(generateIndexJson(experiments));
-  const mdSize = Buffer.byteLength(generateLlmContext(experiments));
-  console.log(`   📊 JSON: ${(jsonSize / 1024).toFixed(1)}KB, MD: ${(mdSize / 1024).toFixed(1)}KB`);
+  console.log(
+    `   📊 JSON: ${(Buffer.byteLength(indexJson) / 1024).toFixed(1)}KB, ` +
+      `MD: ${(Buffer.byteLength(llmContext) / 1024).toFixed(1)}KB`
+  );
   console.log('   Done!');
 }
 


### PR DESCRIPTION
## 대시보드 목록 파일이 **짝꿍 문서보다 먼저** 쓰이고 있었습니다

`aggregate-tests.mjs`는 두 개를 만듭니다.

| 파일 | 누가 읽나 |
|---|---|
| `experiments-index.json` | **대시보드** — 실험이 뭐가 있는지 |
| `llm-context.md` | **LLM 챗** — 전체 데이터를 글로 정리한 것 |

그런데 **json을 먼저 쓰고, md를 나중에 만들었습니다.**

### 뭐가 문제인가

md를 만드는 쪽은 **loader가 약속한 적 없는 칸 두 개**를 그냥 꺼내 씁니다.

```js
`${exp.condition_b.name} (${exp.condition_b.win_rate}%) | `
experiments.reduce((s, e) => s + e.delta, 0)
```

그래서 `condition_b`가 없는 파일이 하나 섞이면:

1. loader는 통과시킵니다 (**객체이긴 하니까**)
2. `Found 2 experiments` 찍고 **json을 씁니다**
3. md 만들다가 **죽습니다** — `Cannot read properties of undefined (reading 'name')` at `aggregate-tests.mjs:108`

**결과:** json은 디스크에 남고, md는 **지난번 빌드 것 그대로**. 두 파일이 **서로 다른 실험 목록**을 말하고 있습니다. 에러 메시지에는 **파일 이름이 안 나옵니다.** 줄 번호만 나옵니다.

실제로 재현해서 확인했습니다.

### `delta`는 **죽지도 않습니다** — 이게 더 나쁩니다

`delta`가 없으면 `s + undefined` = `NaN`인데, **에러가 아닙니다.**

빌드는 **끝까지 잘 돌고, 0으로 종료되고**, LLM에게 "이게 전부입니다" 하고 건네는 문서에 이렇게 적힙니다:

```
평균 Delta: +NaN%p
```

**아무도 안 멈춥니다.**

### 고친 것 — 두 가지

**1. loader가 파일 이름을 대고 거부합니다**

빈 파일·리스트를 거부하던 그 자리에, 같은 방식으로 한 겹 더 넣었습니다.

```
exp900.yaml is present but holds no condition_b: ...
exp900.yaml is present but its delta is not a number: "4"
```

조건을 **"있냐 없냐"가 아니라 "객체냐"로** 봅니다. `typeof null === 'object'`이고, 리스트도 `.name`을 꺼내려 하면 조용히 `undefined`가 나오기 때문입니다.

**2. 두 문서를 다 만든 다음에 씁니다**

```js
const indexJson  = generateIndexJson(experiments);
const llmContext = generateLlmContext(experiments);   // ← 여기서 죽으면
await mkdir(outputDir, { recursive: true });          // ← 여기부터는 실행 안 됨
```

**1번만으로는 부족합니다.** loader는 "md가 앞으로 어떤 칸을 꺼내 쓸지"를 미리 알 수 없습니다. **순서는 알 필요가 없습니다.**

덤으로 하나 더 고쳐졌습니다: 원래는 각 문서를 **두 번씩** 만들었습니다 — 한 번은 쓰려고, 한 번은 크기 재려고. 그런데 json 안에 `new Date().toISOString()`이 박혀서, **화면에 찍히던 KB는 실제로 쓰인 문자열의 크기가 아니었습니다.**

### 테스트로 박았습니다 (주석 말고)

`main()`이 폴더를 인자로 받게 해서, **진짜 임시 폴더**에 대고 순서를 확인합니다.

| 테스트 | 확인하는 것 |
|---|---|
| 못 만드는 실험이 섞이면 | 출력 폴더가 **완전히 비어 있음** |
| 정상 실험이면 | **두 파일 다** 생김 (← 위 테스트가 헛돌지 않는다는 증거) |

순서 테스트는 **파일 두 개**로 합니다 — 하나는 정상, 하나는 불량. 위험했던 건 불량 파일 하나가 아니라, **정상 파일이 불량 파일을 끌고 들어가 폴더를 반쯤 써놓는 것**이었기 때문입니다.

### 건드린 파일

| 파일 | 무엇 |
|---|---|
| `scripts/aggregate-tests.mjs` | loader 검사 2개 + 렌더 후 쓰기 |
| `a-test-file-that-will-not-parse-is-not-zero-experiments.test.mjs` | 7개 → **12개** |

로컬 aggregate 스위트: **500개 중 499개 통과, 실패 0** (1개는 원래 skip).
진짜 `data/tests/exp001.yaml`도 새 검사를 그대로 통과합니다.

### 지금 돌고 있는 220 실행과는 **무관합니다**

`batch-runner/`는 **한 줄도 안 건드립니다.** 이건 대시보드 빌드 스크립트입니다.
