### PR TITLE
숫자가 비는 이유가 4가지인데 아무 데도 안 적혀 있었습니다

### DIFF
--- a/scripts/__tests__/file-generation-denominator.test.mjs
+++ b/scripts/__tests__/file-generation-denominator.test.mjs
@@ -20,17 +20,21 @@
 //     (0.0%) |`. Not one of them generated a file badly; none was asked for a
 //     file at all.
 //   * **1 run publishes `needs_files_total: null`** — `exp026c`, a 1-task
-//     smoke whose `validate_stats.json` was never read. It carries no record
-//     of a denominator, which is not the same as recording that there was
-//     none, and `src/types/report.ts` declared the field non-null so no reader
-//     had to consider it.
+//     smoke whose `validate_stats.json` was never written, because the
+//     workflow skips step 5 for any run with `sample_size <= 3`. It looks like
+//     a counterexample and is not one: its report is served from the Hub
+//     rather than committed here, so step 7 ran and it was no dry run — a
+//     second, independent gate fired. It carries no record of a denominator,
+//     which is not the same as recording that there was none, and
+//     `src/types/report.ts` declared the field non-null so no reader had to
+//     consider it.
 //   * **21 runs publish a positive denominator**, from `exp003`'s 185 down to
 //     `exp030`'s 4. Those rates are measurements and must keep printing —
 //     including any genuine `0.0%`.
 //
 // `src/components/dashboard/fileGenerationReading.ts` is where the reading now
 // happens, and it is import-free so esbuild — already installed, as vite
-// depends on it — can hand the real decision to node. This file holds six
+// depends on it — can hand the real decision to node. This file holds seven
 // things in place:
 //
 //   A. the producer's field names and the reader's lookups are the same names,
@@ -41,7 +45,9 @@
 //      the four affected runs are named by the test rather than by a comment;
 //   D. a figure that stands on nothing is not comparable to one that does;
 //   E. no surface under `src/` divides by `needs_files_total` itself;
-//   F. the TypeScript contract admits the `null` `exp026c` actually contains.
+//   F. the TypeScript contract admits the `null` `exp026c` actually contains;
+//   G. the workflow conditions that skip step 5 are all named and counted,
+//      since they alone decide which runs carry a roll-up at all.
 //
 // (E) is the guard that fails on the code this replaces.
 //
@@ -60,6 +66,7 @@ const SRC_DIR = join(ROOT, 'src');
 const READING_FILE = join(SRC_DIR, 'components', 'dashboard', 'fileGenerationReading.ts');
 const REPORT_TYPES = join(SRC_DIR, 'types', 'report.ts');
 const STEP5_PY = join(ROOT, 'batch-runner', 'step5_validate.py');
+const BATCH_RUN_WORKFLOW = join(ROOT, '.github', 'workflows', 'batch-run.yml');
 const REPORTS_INDEX = join(ROOT, 'public', 'generated', 'reports-index.json');
 
 /** Everything `step5_validate` writes into `validate_stats.json`. */
@@ -463,4 +470,91 @@ test('FileGeneration declares the null exp026c actually publishes', async () => 
   const reports = await publishedReports();
   const nulls = reports.filter((r) => r.file_generation && r.file_generation.needs_files_total === null);
   assert.ok(nulls.length >= 1, 'no published report carries a null denominator any more');
+});
+
+// ── G. Why a roll-up is missing is a property of the workflow ──────────────
+
+test('every condition that skips step 5 is named, and there are no others', async () => {
+  // `not-recorded` is not one condition wearing four names. Step 6 reads the
+  // roll-up from workspace/validate_stats.json, which only step 5 writes, and
+  // batch-run.yml skips step 5 on four independent conditions:
+  //
+  //   dry run         — exp034; and exp035, the 220-task run dispatched
+  //                     2026-09-11 with dry_run=true, which will land here too
+  //   smoke test      — exp026c, whose sample_size is 1
+  //   relay handover  — every leg of a relayed run except the last
+  //   step 2a failed  — inference never finished, so there is nothing to count
+  //
+  // These four decide, by themselves, which runs carry a roll-up. If one is
+  // removed or renamed that set changes with nothing failing, and the runs
+  // named in section C above quietly become wrong. A *fifth* would do the same
+  // damage from the other direction, so the count is asserted too: this test
+  // claims the list is complete, not merely that these four are on it.
+  const wf = await readFile(BATCH_RUN_WORKFLOW, 'utf8');
+  const at = wf.indexOf("- name: 'Step 5: Validate dataset'");
+  assert.ok(at >= 0, 'Step 5 is gone from batch-run.yml, or was renamed');
+  const ifAt = wf.indexOf('if:', at);
+  const gate = wf.slice(ifAt, wf.indexOf('\n', ifAt));
+
+  const conditions = {
+    'dry run': 'inputs.dry_run != true',
+    'smoke test': "steps.check_smoke_test.outputs.is_smoke_test != 'true'",
+    'relay handover': "steps.check_relay.outputs.needs_relay != 'true'",
+    'failed inference': "steps.step2a.outcome == 'success'",
+  };
+  for (const [name, expr] of Object.entries(conditions)) {
+    assert.ok(gate.includes(expr), `the ${name} gate on step 5 is gone: ${gate}`);
+  }
+  assert.equal(
+    gate.replace(/^if:\s*/, '').split('&&').length,
+    Object.keys(conditions).length,
+    `step 5 gained or lost a condition, so a run can now miss its roll-up for a `
+      + `reason this file does not name: ${gate}`,
+  );
+
+  // The threshold itself, since exp026c sits one under it and exp035's 220
+  // sits far above it. Without this the smoke gate could be widened to swallow
+  // a real run and the assertions above would all still pass.
+  assert.match(wf, /IS_SMOKE_TEST=\$\(\[ "\$SAMPLE_SIZE" -le 3 \]/);
+});
+
+test('exp026c asked for the upload, so its null is not the dry-run gate', async () => {
+  // The evidence that exp026c needs a second gate to explain it, kept as an
+  // assertion rather than a claim in a comment. The run says so itself: its
+  // `publication_plan` is `step7_upload_requested`, where a dry run publishes
+  // `dry_run_no_step7` — exp034 does. The tree agrees, in the other direction:
+  // a dry run has no copy on the Hub, so its report_data.json has to be
+  // committed here (that rule is
+  // a-run-that-never-reached-the-hub-is-not-a-run-that-never-happened.test.mjs),
+  // and exp026c's is not committed and still reads. All checked offline.
+  const reports = await publishedReports();
+  const exp026c = reports.find((r) => r.short_id === 'exp026c');
+  assert.ok(exp026c, 'exp026c is not in the index');
+  assert.equal(exp026c.file_generation.needs_files_total, null);
+  assert.equal(
+    exp026c.meta.publication_plan,
+    'step7_upload_requested',
+    'exp026c is a dry run after all, and the comment above it is wrong',
+  );
+  // The distinction has to be one the corpus actually draws, or the line above
+  // is a constant compared against itself.
+  const plans = new Set(reports.map((r) => r.meta?.publication_plan));
+  assert.ok(
+    plans.has('dry_run_no_step7'),
+    'no published run is a dry run any more, so this no longer separates anything',
+  );
+
+  const committed = join(
+    ROOT,
+    'batch-runner',
+    'results',
+    'exp026c_cost_receipt_smoke',
+    'report',
+    'report_data.json',
+  );
+  await assert.rejects(
+    () => readFile(committed, 'utf8'),
+    /ENOENT/,
+    'exp026c now commits its report, so the Hub is no longer what proves step 7 ran',
+  );
 });


### PR DESCRIPTION
## 한 줄 요약

**"파일 생성률이 안 적힌 이유"가 4가지인데, 저장소 어디에도 그 4가지가 안 적혀 있었습니다.** 이제 테스트가 들고 있습니다.

---

## 무슨 얘기냐

대시보드에 "파일 생성률"이라는 칸이 있습니다. 어떤 실행은 거기가 **비어 있습니다**(`null`). 0%가 아니라 **안 셌다**는 뜻입니다 — 그건 이미 #526에서 구분해 놨습니다.

그런데 **왜** 안 셌는지는 아무 데도 없었습니다.

세는 건 step 5 하나뿐입니다. step 5가 안 돌면 숫자가 없습니다. 그리고 workflow에서 step 5를 건너뛰는 조건이 **한 줄에 4개** 붙어 있습니다:

| 건너뛰는 이유 | 해당 실행 |
|---|---|
| dry run (실제 업로드 안 하는 연습 실행) | exp034, 그리고 **지금 돌고 있는 exp035** |
| 1~3문제짜리 맛보기 실행 | exp026c (1문제) |
| 릴레이 중간 구간 (아직 안 끝남) | 이어달리기하는 실행의 마지막 빼고 전부 |
| **step 2a가 실패** (문제 풀이가 아예 못 끝남) | — |

---

## 제가 틀렸던 것 두 개

**하나.** exp026c가 비어 있는 걸 보고 저는 "dry run이라서"라고 적어놨었습니다. **아닙니다.** exp026c는 자기 기록에 `step7_upload_requested`라고 써 있습니다 — 진짜 dry run인 exp034는 `dry_run_no_step7`이라고 씁니다. exp026c는 **1문제짜리라서** 건너뛴 겁니다. 완전히 다른 이유입니다.

**둘.** 저는 이걸 **3개**라고 적어놨었습니다. **4개**입니다. 네 번째(`step 2a 실패`)를 못 본 이유가 첫 번째 실수와 똑같습니다 — **내가 찾을 거라고 생각한 것만 찾아봤습니다.** 줄 전체를 출력해 보니 거기 있었습니다.

같은 실수를 두 번 한 셈이라, 테스트가 **개수까지** 셉니다. 나중에 5번째 조건이 붙으면 **테스트가 깨집니다.** 그게 목적입니다 — 숫자가 사라지는 새로운 경로가 생겼는데 아무도 모르는 상황을 막습니다.

---

## 왜 지금 하냐

**지금 돌고 있는 220문제 실행(exp035)이 위 표의 첫 번째 칸입니다.**

그 실행이 끝나면 보고서의 파일 생성률 칸이 **비어서 나옵니다.** 그게 정상입니다. 고장이 아닙니다.

이 PR이 없으면 그날 그 빈칸을 보고 "Foundry 연결이 뭔가 잘못됐나"부터 의심하게 됩니다. **제가 이미 한 번 그렇게 의심했다가 틀렸습니다.**

---

## 숫자 하나 더 못 박음

`sample_size <= 3`의 **3**도 고정했습니다. exp026c는 1(바로 밑), exp035는 220(한참 위)입니다. 누가 이 3을 30으로 늘리면 진짜 실행까지 "맛보기"로 삼켜버리는데, 그래도 나머지 검사는 전부 통과합니다. 그래서 3 자체를 따로 붙잡아 둡니다.

---

## 검사

```
502 tests / 501 pass / 1 skipped / 0 fail
```

(#530에서 500개였고, 2개 추가입니다.)

**코드 변경 없음.** 테스트 파일 하나만 바뀝니다. 돌고 있는 실행에는 아무 영향 없습니다.
