### PR TITLE
fix(report): 건너뛴 집계를 아티팩트에서 되살립니다 — exp034는 28개 중 22개

### DIFF
--- a/batch-runner/recover_file_rollup.py
+++ b/batch-runner/recover_file_rollup.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Recover a file-generation roll-up the run itself never recorded.
+
+`step6_report.py` reads `file_generation` from `workspace/validate_stats.json`,
+which only step 5 writes, and `batch-run.yml` skips step 5 on four independent
+conditions (`inputs.dry_run`, `sample_size <= 3`, a relay handover, and a
+failed step 2a). Any of them leaves the roll-up `null` in the published report
+— which means "not counted", never "0%".
+
+The count is not lost when that happens. Step 4 runs on a dry run, so the run's
+artifact still holds the upload-staging parquet, the needs-files manifest and
+the prepared task scope: everything step 5 reads. So the number can be produced
+afterwards, offline, from the artifact alone, with no model call and no cost.
+
+This does not re-run the pipeline and does not re-do step 5's job. It calls
+step 5's own `validate()` against an unpacked artifact, so the counting rule
+here cannot drift from the counting rule in a run that was not skipped.
+
+What it will not do:
+
+  * It will not overwrite `file_generation`. A run that recorded nothing must
+    go on saying it recorded nothing; the recovered figure lands beside it as
+    `file_generation_recovered`, carrying where it came from. Erasing the
+    difference between "measured during the run" and "reconstructed later"
+    would make the two look like the same kind of evidence.
+  * It will not touch a report whose roll-up is already populated. That would
+    be overwriting a measurement with a reconstruction.
+
+Input:
+  - an unpacked run artifact containing workspace/upload/data/train-*.parquet,
+    workspace/step0_needs_files_manifest.json, workspace/step1_tasks_prepared.json
+
+Output:
+  - <workspace>/validate_stats.json, exactly as step 5 writes it
+  - optionally, `file_generation_recovered` merged into a report_data.json
+
+Usage:
+    python recover_file_rollup.py --workspace /tmp/artifact/workspace \\
+        --run-id 34540053904 --skipped-by dry_run
+
+    python recover_file_rollup.py --workspace /tmp/artifact/workspace \\
+        --run-id 34540053904 --skipped-by dry_run \\
+        --report results/exp034_codex_foundry_trial30/report/report_data.json
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# The four conditions on the `if:` of `Step 5: Validate dataset`. Naming which
+# one fired is required rather than optional: a recovered figure whose absence
+# is unexplained invites the reading that the pipeline was broken, and for
+# exp034 that reading was wrong — every task that finished produced its file.
+SKIP_REASONS = {
+    "dry_run": "inputs.dry_run != true — no upload, so no validation",
+    "smoke_test": "sample_size <= 3",
+    "relay_handover": "this leg handed over to the next instead of finishing",
+    "step2a_failed": "inference did not succeed, so there was nothing to count",
+}
+
+
+def _load_step5(workspace: Path):
+    """step 5, pointed at an artifact instead of this checkout's workspace.
+
+    `core.config.WORKSPACE_DIR` is a module constant with no environment
+    override, and step 5 binds it at import. Rebinding it on the imported
+    module — rather than copying step 5's counting into this file — is what
+    keeps one counting rule instead of two that agree until they don't.
+    """
+    sys.path.insert(0, str(Path(__file__).parent))
+    import step5_validate
+
+    step5_validate.WORKSPACE_DIR = workspace
+    step5_validate.UPLOAD_DIR = workspace / "upload"
+    return step5_validate
+
+
+def recover(workspace: Path) -> dict:
+    """Run step 5's counting against `workspace` and return its stats."""
+    missing = [
+        name
+        for name in (
+            "upload/data",
+            "step0_needs_files_manifest.json",
+            "step1_tasks_prepared.json",
+        )
+        if not (workspace / name).exists()
+    ]
+    if missing:
+        raise SystemExit(
+            f"❌ {workspace} is not an unpacked run artifact — missing: "
+            + ", ".join(missing)
+        )
+
+    step5 = _load_step5(workspace)
+    step5.validate()
+
+    stats_path = workspace / "validate_stats.json"
+    if not stats_path.exists():
+        # step 5 writes nothing when the manifest check could not run. Saying
+        # so beats writing a roll-up of nulls that reads like a measurement.
+        raise SystemExit(
+            "❌ step 5 ran but produced no stats — the manifest check did not "
+            "execute, so there is no roll-up to recover"
+        )
+    return json.loads(stats_path.read_text(encoding="utf-8"))
+
+
+def annotate(report_path: Path, stats: dict, provenance: dict) -> None:
+    """Merge the recovered roll-up into a report, beside the null it explains."""
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    published = report.get("file_generation") or {}
+
+    if published.get("needs_files_total") is not None:
+        raise SystemExit(
+            f"❌ {report_path.name} already records "
+            f"needs_files_total={published['needs_files_total']} — refusing to "
+            "replace a measurement taken during the run with one reconstructed "
+            "afterwards"
+        )
+    if "file_generation_recovered" in report:
+        raise SystemExit(
+            f"❌ {report_path.name} already carries a recovered roll-up; delete "
+            "it by hand if it is genuinely wrong, so the replacement is a "
+            "deliberate act and not a re-run"
+        )
+
+    report["file_generation_recovered"] = {**stats, "provenance": provenance}
+    report_path.write_text(
+        json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    print(f"\n   📎 Merged into {report_path.name} as file_generation_recovered")
+    print(f"      file_generation stays null — the run still records what it recorded")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Recover a file-generation roll-up from a run artifact"
+    )
+    parser.add_argument(
+        "--workspace", required=True, help="unpacked artifact's workspace/ directory"
+    )
+    parser.add_argument(
+        "--run-id", required=True, help="the GitHub Actions run the artifact came from"
+    )
+    parser.add_argument(
+        "--skipped-by",
+        required=True,
+        choices=sorted(SKIP_REASONS),
+        help="which of step 5's four gates fired",
+    )
+    parser.add_argument(
+        "--report", help="report_data.json to annotate; omit to only print the stats"
+    )
+    args = parser.parse_args()
+
+    workspace = Path(args.workspace).resolve()
+    stats = recover(workspace)
+
+    # The run ID is the provenance. The unpacked path is not: it names a
+    # directory on whichever machine ran this, which no later reader can
+    # resolve and which does not belong in a published report.
+    provenance = {
+        "recovered_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "source_run_id": args.run_id,
+        "step5_skipped_by": args.skipped_by,
+        "step5_skipped_because": SKIP_REASONS[args.skipped_by],
+        "tool": Path(__file__).name,
+    }
+
+    if args.report:
+        annotate(Path(args.report), stats, provenance)
+    else:
+        print("\n" + json.dumps({**stats, "provenance": provenance}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/batch-runner/results/exp034_codex_foundry_trial30/report/report_data.json
+++ b/batch-runner/results/exp034_codex_foundry_trial30/report/report_data.json
@@ -3289,5 +3289,22 @@
       "rounds_used": 0,
       "per_round": {}
     }
+  },
+  "file_generation_recovered": {
+    "needs_files_total": 28,
+    "files_succeeded": 22,
+    "files_failed": 6,
+    "files_absent": 0,
+    "dummy_files_created": 0,
+    "dummy_task_ids": [],
+    "absent_task_ids": [],
+    "policy_caveat": null,
+    "provenance": {
+      "recovered_at": "2026-09-11T11:08:44+00:00",
+      "source_run_id": "34540053904",
+      "step5_skipped_by": "dry_run",
+      "step5_skipped_because": "inputs.dry_run != true — no upload, so no validation",
+      "tool": "recover_file_rollup.py"
+    }
   }
 }

--- a/batch-runner/tests/test_a_rollup_the_run_skipped_is_not_a_rollup_that_is_gone.py
+++ b/batch-runner/tests/test_a_rollup_the_run_skipped_is_not_a_rollup_that_is_gone.py
@@ -1,0 +1,171 @@
+"""A roll-up the run skipped is not a roll-up that is gone.
+
+``step6_report.py`` reads ``file_generation`` from ``validate_stats.json``,
+which only step 5 writes, and ``batch-run.yml`` skips step 5 on an ``&&`` of
+four terms. Any one of them leaves the published report carrying nulls, and a
+null there means "not counted" — the distinction already held on the reading
+side by ``scripts/__tests__/file-generation-denominator.test.mjs``.
+
+What was missing is that the count is still recoverable. Step 4's own gate does
+not include ``dry_run``, so a dry run's artifact keeps the upload-staging
+parquet; the manifest and the prepared scope are in the same artifact. That is
+every input step 5 reads. ``recover_file_rollup.py`` points step 5's own
+``validate()`` at an unpacked artifact and gets the number back, offline, with
+no model call and nothing spent.
+
+Measured, not argued: exp034 (run ``34540053904``, dispatched ``dry_run=true``)
+publishes ``needs_files_total: null``. Recovered from its artifact it is 28
+required, 22 produced, 6 failed — and all 8 rows with no file are exactly the 8
+tasks that errored, so every task that finished produced its deliverable. The
+shortfall is 5 rate limits and 3 content filters, not a file-generation defect.
+A reader looking at ``null`` cannot tell those two apart, which is the whole
+reason to recover it rather than leave it.
+
+These tests hold the two things that would quietly undo that:
+
+  * the recovered figure must not be able to overwrite a measured one, or
+    replace itself on a re-run — a reconstruction and a measurement are not
+    the same kind of evidence and the report has to keep saying which it has;
+  * the four skip reasons the tool offers must stay the four the workflow
+    actually has, so an operator cannot be forced to mislabel why a run was
+    skipped, and a fifth cannot appear with no name to give it.
+
+The end-to-end recovery is not re-run here: it needs the 431 MB artifact, and
+the manifest carries digest checks that a synthetic fixture could only satisfy
+by reimplementing them, which would test the fixture. It was run for real
+against ``34540053904`` and reproduced 28/22/6.
+
+Nothing here calls a model, signs in to a cloud account, or spends anything.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+REPOSITORY_ROOT = BATCH_RUNNER_ROOT.parent
+BATCH_RUN = REPOSITORY_ROOT / ".github" / "workflows" / "batch-run.yml"
+
+sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+import recover_file_rollup  # noqa: E402
+
+# What a recovery produces, shaped as step 5 writes it.
+RECOVERED = {
+    "needs_files_total": 28,
+    "files_succeeded": 22,
+    "files_failed": 6,
+    "files_absent": 0,
+    "dummy_files_created": 0,
+    "dummy_task_ids": [],
+    "absent_task_ids": [],
+    "policy_caveat": None,
+}
+
+PROVENANCE = {
+    "recovered_at": "2026-09-11T10:52:51+00:00",
+    "source_run_id": "34540053904",
+    "step5_skipped_by": "dry_run",
+}
+
+
+def _report(tmp_path: Path, file_generation: dict) -> Path:
+    path = tmp_path / "report_data.json"
+    path.write_text(
+        json.dumps({"meta": {"experiment_id": "expNNN"}, "file_generation": file_generation}),
+        encoding="utf-8",
+    )
+    return path
+
+
+# ── The recovered figure cannot displace a measured one ───────────────────
+
+
+def test_a_report_that_counted_its_files_is_not_overwritten(tmp_path):
+    """21 of this repository's runs carry a real denominator. None is a candidate."""
+    path = _report(tmp_path, {"needs_files_total": 185, "files_succeeded": 180})
+    before = path.read_text(encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        recover_file_rollup.annotate(path, RECOVERED, PROVENANCE)
+
+    assert "185" in str(exc.value), "the refusal does not say what it is protecting"
+    assert path.read_text(encoding="utf-8") == before, "the report was written anyway"
+
+
+def test_a_recovered_rollup_does_not_silently_replace_itself(tmp_path):
+    """A second run would rewrite the provenance, and the first would be gone."""
+    path = _report(tmp_path, {"needs_files_total": None})
+    recover_file_rollup.annotate(path, RECOVERED, PROVENANCE)
+    first = json.loads(path.read_text(encoding="utf-8"))["file_generation_recovered"]
+
+    with pytest.raises(SystemExit):
+        recover_file_rollup.annotate(
+            path, {**RECOVERED, "files_succeeded": 999}, {**PROVENANCE, "source_run_id": "x"}
+        )
+
+    again = json.loads(path.read_text(encoding="utf-8"))["file_generation_recovered"]
+    assert again == first, "the second attempt overwrote the first"
+
+
+def test_the_null_stays_null_and_the_recovery_says_where_it_came_from(tmp_path):
+    """The run goes on recording that it recorded nothing."""
+    path = _report(tmp_path, {"needs_files_total": None, "files_succeeded": None})
+    recover_file_rollup.annotate(path, RECOVERED, PROVENANCE)
+    report = json.loads(path.read_text(encoding="utf-8"))
+
+    assert report["file_generation"]["needs_files_total"] is None
+    assert report["file_generation"]["files_succeeded"] is None
+
+    got = report["file_generation_recovered"]
+    assert got["needs_files_total"] == 28 and got["files_succeeded"] == 22
+    # Without the run ID and the reason, the figure is a number with no account
+    # of why it had to be reconstructed — the thing that made exp034's null
+    # read as a pipeline defect in the first place.
+    assert got["provenance"]["source_run_id"] == "34540053904"
+    assert got["provenance"]["step5_skipped_by"] == "dry_run"
+
+
+# ── The reasons offered are the reasons the workflow has ──────────────────
+
+
+def test_every_skip_reason_names_a_condition_that_is_really_on_step_5():
+    """A reason the workflow no longer has would be a mislabel on a real report."""
+    workflow = BATCH_RUN.read_text(encoding="utf-8")
+    at = workflow.index("- name: 'Step 5: Validate dataset'")
+    start = workflow.index("if:", at)
+    gate = workflow[start : workflow.index("\n", start)]
+
+    expressions = {
+        "dry_run": "inputs.dry_run != true",
+        "smoke_test": "steps.check_smoke_test.outputs.is_smoke_test != 'true'",
+        "relay_handover": "steps.check_relay.outputs.needs_relay != 'true'",
+        "step2a_failed": "steps.step2a.outcome == 'success'",
+    }
+    assert set(expressions) == set(recover_file_rollup.SKIP_REASONS), (
+        "the tool's reasons and this test's expressions have drifted apart"
+    )
+    for reason, expression in expressions.items():
+        assert expression in gate, f"step 5 no longer skips on {reason}: {gate}"
+
+    # The count as well as the members: a fifth condition would be a fifth way
+    # to lose a roll-up, and `--skipped-by` would have no honest value for it.
+    terms = gate.removeprefix("if:").split("&&")
+    assert len(terms) == len(expressions), (
+        f"step 5 gained or lost a condition, so a run can now miss its roll-up "
+        f"for a reason this tool cannot name: {gate}"
+    )
+
+
+def test_an_unpacked_artifact_is_recognised_by_what_step_5_reads(tmp_path):
+    """Failing here beats failing inside step 5 with a path nobody chose."""
+    with pytest.raises(SystemExit) as exc:
+        recover_file_rollup.recover(tmp_path)
+
+    message = str(exc.value)
+    for needed in ("upload/data", "step0_needs_files_manifest.json", "step1_tasks_prepared.json"):
+        assert needed in message, f"the error does not say {needed} is missing"

--- a/scripts/__tests__/file-generation-denominator.test.mjs
+++ b/scripts/__tests__/file-generation-denominator.test.mjs
@@ -34,7 +34,7 @@
 //
 // `src/components/dashboard/fileGenerationReading.ts` is where the reading now
 // happens, and it is import-free so esbuild — already installed, as vite
-// depends on it — can hand the real decision to node. This file holds seven
+// depends on it — can hand the real decision to node. This file holds eight
 // things in place:
 //
 //   A. the producer's field names and the reader's lookups are the same names,
@@ -47,7 +47,9 @@
 //   E. no surface under `src/` divides by `needs_files_total` itself;
 //   F. the TypeScript contract admits the `null` `exp026c` actually contains;
 //   G. the workflow conditions that skip step 5 are all named and counted,
-//      since they alone decide which runs carry a roll-up at all.
+//      since they alone decide which runs carry a roll-up at all;
+//   H. a run the workflow skipped can still have its count rebuilt from its
+//      own artifact, and the rebuilt figure must not pass for a measured one.
 //
 // (E) is the guard that fails on the code this replaces.
 //
@@ -556,5 +558,90 @@ test('exp026c asked for the upload, so its null is not the dry-run gate', async 
     () => readFile(committed, 'utf8'),
     /ENOENT/,
     'exp026c now commits its report, so the Hub is no longer what proves step 7 ran',
+  );
+});
+
+// ── H. A roll-up the run skipped is not a roll-up that is gone ─────────────
+//
+// The four gates above decide which runs carry a count. They do not decide
+// which runs *can* carry one: step 4 is not gated on `dry_run`, so a dry run's
+// artifact still holds the upload-staging parquet, the needs-files manifest
+// and the prepared scope — every input step 5 reads. `recover_file_rollup.py`
+// points step 5's own `validate()` at the unpacked artifact and gets the
+// number back offline.
+//
+// It is written to `file_generation_recovered`, never into `file_generation`:
+// the run goes on recording that it recorded nothing. Which means a reader
+// taking `file_generation` alone still sees `not recorded` for a run whose
+// number is sitting in the same payload. `resolveFileGeneration` is the pick
+// between them, and it has to keep saying which one it picked.
+
+test('a measurement taken during the run beats one rebuilt afterwards', async () => {
+  const { resolveFileGeneration } = await loadReading();
+  const resolved = resolveFileGeneration({
+    file_generation: { needs_files_total: 10, files_succeeded: 9 },
+    file_generation_recovered: { needs_files_total: 28, files_succeeded: 22 },
+  });
+  assert.equal(resolved.fg.needs_files_total, 10, 'the reconstruction displaced the measurement');
+  assert.equal(resolved.recovered, false);
+});
+
+test('a run that recorded nothing reads the figure rebuilt from its artifact', async () => {
+  const { resolveFileGeneration, readFileGenerationRate, recoveredNote } = await loadReading();
+  const resolved = resolveFileGeneration({
+    file_generation: { needs_files_total: null, files_succeeded: null },
+    file_generation_recovered: {
+      needs_files_total: 28,
+      files_succeeded: 22,
+      provenance: { source_run_id: '34540053904', step5_skipped_by: 'dry_run' },
+    },
+  });
+  assert.equal(resolved.recovered, true);
+
+  const reading = readFileGenerationRate(resolved.fg, 'succeeded');
+  assert.equal(reading.standing, 'measured');
+  assert.equal(reading.value, '78.6%');
+
+  // Without this the figure is indistinguishable from one the run measured,
+  // and the two are not the same kind of evidence.
+  const note = recoveredNote(resolved);
+  assert.match(note, /34540053904/);
+  assert.match(note, /dry_run/);
+});
+
+test('no recovery leaves the null a null, and no note beside it', async () => {
+  const { resolveFileGeneration, readFileGenerationRate, recoveredNote } = await loadReading();
+  const resolved = resolveFileGeneration({ file_generation: { needs_files_total: null } });
+  assert.equal(resolved.recovered, false);
+  assert.equal(recoveredNote(resolved), undefined);
+  assert.equal(readFileGenerationRate(resolved.fg, 'succeeded').standing, 'not-recorded');
+});
+
+test('exp034 publishes the count its own run skipped, and says where from', async () => {
+  // The real anchor. exp034 is a dry run, so step 5 never counted; the figure
+  // below came from its artifact, and all 8 rows with no file are exactly the
+  // 8 tasks that errored — 5 rate limits and 3 content filters, not a
+  // file-generation defect. A reader looking at `null` cannot tell those apart.
+  const exp034 = (await publishedReports()).find((r) => r.short_id === 'exp034');
+  assert.ok(exp034, 'exp034 is not in the index');
+  assert.equal(
+    exp034.file_generation?.needs_files_total ?? null,
+    null,
+    'exp034 now records its own roll-up, so it is no longer the recovery case',
+  );
+
+  const recovered = exp034.file_generation_recovered;
+  assert.ok(recovered, 'the recovered roll-up did not survive aggregation into the index');
+  assert.equal(recovered.needs_files_total, 28);
+  assert.equal(recovered.files_succeeded, 22);
+  assert.equal(recovered.files_failed, 6);
+  assert.equal(recovered.provenance.source_run_id, '34540053904');
+  assert.equal(recovered.provenance.step5_skipped_by, 'dry_run');
+
+  // A path on whoever's machine ran the tool is not provenance, and does not
+  // belong in a published report.
+  assert.ok(
+    !('source_workspace' in recovered.provenance),
+    'the recovery is publishing a local filesystem path',
   );
 });

--- a/src/components/dashboard/ErrorAnalysisView.tsx
+++ b/src/components/dashboard/ErrorAnalysisView.tsx
@@ -11,7 +11,7 @@ import { parseTraceback } from '../../utils/tracebackParser'
 import InfoTooltip from '../common/InfoTooltip'
 import SectionHint from '../common/SectionHint'
 import { tooltipTexts, sectionHintTexts } from '../../data/tooltipTexts'
-import { readFileGenerationCount, readFileGenerationRate } from './fileGenerationReading'
+import { readFileGenerationCount, readFileGenerationRate, recoveredNote, resolveFileGeneration } from './fileGenerationReading'
 
 /* ─── props ─── */
 interface ErrorAnalysisViewProps {
@@ -269,7 +269,7 @@ export default function ErrorAnalysisView({ experiments, reports }: ErrorAnalysi
       </div>
 
       {/* ─── 5. File Generation Risk ─── */}
-      {reports.some((r) => r.file_generation) && (
+      {reports.some((r) => r.file_generation || r.file_generation_recovered) && (
         <div className="rounded-xl bg-dash-card border border-dash-border p-4">
           <div className="flex items-center gap-2 mb-4">
             <FileWarning className="w-4 h-4 text-amber-400" />
@@ -278,7 +278,10 @@ export default function ErrorAnalysisView({ experiments, reports }: ErrorAnalysi
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             {sortedExps.map((exp) => {
               const r = reports.find((rr) => rr.short_id === exp.short_id)
-              const fg = r?.file_generation
+              // A run whose step 5 was skipped records nothing here, but may
+              // carry a count rebuilt from its artifact beside the null.
+              const resolved = resolveFileGeneration(r)
+              const fg = resolved.fg
               if (!fg) return null
               // A failure rate needs a denominator. Four published 220-task
               // runs record none, and the old form here — `needs_files_total >
@@ -293,6 +296,11 @@ export default function ErrorAnalysisView({ experiments, reports }: ErrorAnalysi
               return (
                 <div key={exp.short_id} className="space-y-2">
                   <ExpBadge id={exp.short_id} />
+                  {resolved.recovered && (
+                    <span className="ml-2 text-[10px] text-sky-400/90" title={recoveredNote(resolved)}>
+                      rebuilt after the run
+                    </span>
+                  )}
                   <div className="grid grid-cols-2 gap-2 text-xs">
                     <div>
                       <div className="text-[10px] text-dash-text-muted">Needed</div>

--- a/src/components/dashboard/fileGenerationReading.ts
+++ b/src/components/dashboard/fileGenerationReading.ts
@@ -52,6 +52,8 @@ export interface FileGenerationLike {
   files_succeeded?: number | null
   files_failed?: number | null
   files_absent?: number | null
+  /** Read but not divided by: a count, rendered through `readFileGenerationCount`. */
+  dummy_files_created?: number | null
 }
 
 /** Which of the two outcomes the rate is being taken over. */
@@ -137,8 +139,7 @@ export function readFileGenerationRate(
   }
 }
 
-/**
- * A count that may itself be absent, rendered without turning that into a zero.
+/** A count that may itself be absent, rendered without turning that into a zero.
  *
  * The same payload that carries no denominator carries no counts, and
  * `{fg.files_failed}` on a `null` renders as an empty cell that reads as one
@@ -146,4 +147,73 @@ export function readFileGenerationRate(
  */
 export function readFileGenerationCount(value: number | null | undefined): string {
   return isNumber(value) ? String(value) : 'not recorded'
+}
+
+/**
+ * Which of the two roll-ups a run carries, and which one is being read.
+ *
+ * A run whose step 5 was skipped publishes an all-`null` `file_generation`. The
+ * count is still recoverable from its artifact — `recover_file_rollup.py` runs
+ * step 5's own `validate()` against it offline — and lands beside the null as
+ * `file_generation_recovered` rather than inside it, so the run goes on saying
+ * what it recorded.
+ *
+ * Which means a reader who takes `file_generation` alone sees `not recorded`
+ * for a run whose number is sitting in the same payload. This picks between
+ * them, and says which one it picked; it never merges fields across the two,
+ * because half a measurement and half a reconstruction is neither.
+ */
+export interface ResolvedFileGeneration {
+  /** The block to read counts and rates from, or nothing to read. */
+  fg: FileGenerationLike | null | undefined
+  /** True when the run recorded no denominator and this was rebuilt after it. */
+  recovered: boolean
+  /** The run the reconstruction was made from, when it is one. */
+  sourceRunId?: string
+  /** Which of step 5's four gates skipped the count, when it is one. */
+  skippedBy?: string
+}
+
+/** The two fields, named once so a rename cannot go unnoticed. */
+export interface ReportWithFileGeneration {
+  file_generation?: FileGenerationLike | null
+  file_generation_recovered?:
+    | (FileGenerationLike & {
+        provenance?: { source_run_id?: string; step5_skipped_by?: string }
+      })
+    | null
+}
+
+export function resolveFileGeneration(
+  report: ReportWithFileGeneration | null | undefined,
+): ResolvedFileGeneration {
+  const measured = report?.file_generation
+  // A measurement taken during the run always wins, even against a recovery
+  // that disagrees with it. Preferring the reconstruction would make the
+  // recovery tool able to overwrite a real count by being run twice.
+  if (isNumber(measured?.needs_files_total)) {
+    return { fg: measured, recovered: false }
+  }
+
+  const recovered = report?.file_generation_recovered
+  if (isNumber(recovered?.needs_files_total)) {
+    return {
+      fg: recovered,
+      recovered: true,
+      sourceRunId: recovered?.provenance?.source_run_id,
+      skippedBy: recovered?.provenance?.step5_skipped_by,
+    }
+  }
+
+  // Neither: hand back whichever block exists so the reading below can tell
+  // `absent` from `not-recorded`, which are different things to a reader.
+  return { fg: measured ?? recovered ?? undefined, recovered: false }
+}
+
+/** One line saying a figure was rebuilt after the run, for rendering beside it. */
+export function recoveredNote(resolved: ResolvedFileGeneration): string | undefined {
+  if (!resolved.recovered) return undefined
+  const from = resolved.sourceRunId ? ` from run ${resolved.sourceRunId}` : ''
+  const why = resolved.skippedBy ? ` (step 5 was skipped: ${resolved.skippedBy})` : ''
+  return `Reconstructed after the run${from}${why}. The run itself recorded no count.`
 }

--- a/src/pages/ExperimentDetail.tsx
+++ b/src/pages/ExperimentDetail.tsx
@@ -19,7 +19,7 @@ import { useExperimentPrompt } from '../hooks/useExperimentPrompt'
 import { useGrades, GradeResult } from '../hooks/useGrades'
 import PromptArchitectureView, { PromptArchitectureNotice } from '../components/dashboard/PromptArchitectureView'
 import { readPromptArchitecture } from '../components/dashboard/promptArchitectureReading'
-import { readFileGenerationCount, readFileGenerationRate } from '../components/dashboard/fileGenerationReading'
+import { readFileGenerationCount, readFileGenerationRate, recoveredNote, resolveFileGeneration } from '../components/dashboard/fileGenerationReading'
 import type { TaskResult } from '../types/report'
 import type { ReportMeta } from '../types/report'
 import type { CostReceipt, CostSummary } from '../types/cost'
@@ -592,15 +592,23 @@ function ExperimentDetail() {
 
         {/* ── File Generation & Resume Rounds ── */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
-          {report.file_generation && (() => {
+          {(report.file_generation || report.file_generation_recovered) && (() => {
             // Shown whenever the run published the block at all. The old
             // condition was `needs_files_total != null`, which dropped the
             // card for a run that recorded no denominator — and a missing card
             // is not readable as "there was no rate": it cannot be told from a
             // run whose card is simply further down the page.
-            const fg = report.file_generation
+            //
+            // A run whose step 5 was skipped records nothing here but may
+            // still carry a count rebuilt from its artifact afterwards.
+            // `resolveFileGeneration` picks between the two and says which it
+            // picked; without it, a number sitting in the same payload reads
+            // as `not recorded`.
+            const resolved = resolveFileGeneration(report)
+            const fg = resolved.fg
+            const note = recoveredNote(resolved)
             const genReading = readFileGenerationRate(fg, 'succeeded')
-            const absent = fg.files_absent ?? 0
+            const absent = fg?.files_absent ?? 0
             return (
             <motion.div
               initial={{ opacity: 0, y: 8 }}
@@ -611,17 +619,17 @@ function ExperimentDetail() {
               <h3 className="text-sm font-semibold text-dash-heading mb-3">File Generation</h3>
               <div className="space-y-2 text-xs">
                 {[
-                  { label: 'Tasks requiring files', value: readFileGenerationCount(fg.needs_files_total) },
+                  { label: 'Tasks requiring files', value: readFileGenerationCount(fg?.needs_files_total) },
                   // The count and the rate travel together, so a rate that
                   // stands on nothing cannot be printed beside a count that
                   // does. `n/a` and `not recorded` replace the whole cell.
                   {
                     label: 'Successfully generated',
                     value: genReading.standing === 'measured'
-                      ? `${readFileGenerationCount(fg.files_succeeded)} (${genReading.value})`
+                      ? `${readFileGenerationCount(fg?.files_succeeded)} (${genReading.value})`
                       : genReading.value,
                   },
-                  { label: 'Failed → dummy created', value: readFileGenerationCount(fg.files_failed) },
+                  { label: 'Failed → dummy created', value: readFileGenerationCount(fg?.files_failed) },
                   // Only when there are any. A report written before step5
                   // counted them carries no number here, and no number is not
                   // the same claim as none.
@@ -635,6 +643,11 @@ function ExperimentDetail() {
                   </div>
                 ))}
               </div>
+              {note && (
+                <p className="mt-2 text-[10px] leading-snug text-sky-400/90">
+                  {note}
+                </p>
+              )}
               {genReading.caveat && (
                 <p className="mt-2 text-[10px] leading-snug text-dash-text-muted">
                   {genReading.caveat}

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -314,6 +314,36 @@ export interface FileGeneration {
   dummy_task_ids: string[]
 }
 
+/**
+ * The same roll-up, reconstructed after the run instead of during it.
+ *
+ * `batch-run.yml` skips step 5 — the only step that counts files — on an `&&`
+ * of four conditions (a dry run, `sample_size <= 3`, a relay handover, and a
+ * failed step 2a). Any of them leaves `file_generation` all-`null`, which means
+ * *not counted* and never `0%`.
+ *
+ * Step 4 is not gated on `dry_run`, so the run's artifact still holds the
+ * upload-staging parquet, the needs-files manifest and the prepared scope —
+ * every input step 5 reads. `batch-runner/recover_file_rollup.py` points step
+ * 5's own `validate()` at the unpacked artifact and gets the number back,
+ * offline, with nothing spent.
+ *
+ * It lands here rather than in `file_generation` on purpose: the run goes on
+ * recording that it recorded nothing, and a reader can still tell a figure
+ * measured during the run from one reconstructed afterwards.
+ */
+export interface RecoveredFileGeneration extends FileGeneration {
+  provenance: {
+    recovered_at: string
+    /** The GitHub Actions run the artifact came from. */
+    source_run_id: string
+    /** Which of step 5's four gates fired. */
+    step5_skipped_by: string
+    step5_skipped_because: string
+    tool: string
+  }
+}
+
 export interface ErrorTask {
   task_id: string
   sector: string
@@ -331,6 +361,12 @@ export interface ReportData {
   narrative: Narrative
   recovery_stats: RecoveryStats
   file_generation?: FileGeneration
+  /**
+   * Present only when someone ran the recovery tool against this run's
+   * artifact. Read it through `resolveFileGeneration`, which will not let it
+   * stand in for a roll-up the run actually measured.
+   */
+  file_generation_recovered?: RecoveredFileGeneration
   execution_metrics?: ExecutionMetricsSummary
   agentic_metrics?: AgenticMetricsSummary
   /** task_id → Self-QA score (0–10). Enriched in scripts/aggregate-reports.mjs for Phase 1 calibration. */


### PR DESCRIPTION
## 한 줄 요약

**exp034의 "파일 생성률 비어 있음"을 아티팩트에서 되살렸습니다. 28개 중 22개(78.6%)입니다. 그리고 모자란 6개는 파일 만들기에 실패한 게 아닙니다.**

---

## 무슨 얘기냐

지난 PR(#531)에서 **숫자가 비는 이유 4가지**에 이름을 붙였습니다. exp034는 그 중 첫 번째(dry run)라서 비어 있습니다.

그런데 **안 셌을 뿐, 셀 수 없는 게 아니었습니다.**

세는 일은 step 5가 합니다. step 5는 건너뛰었습니다. 하지만 **step 4는 dry run에서도 돕니다** — 건너뛰는 조건에 `dry_run`이 없습니다. 그래서 실행이 남긴 아티팩트 안에 step 5가 읽을 재료가 **전부 그대로** 있습니다.

이 PR의 도구는 **step 5의 계산 함수 자체를** 그 아티팩트에 겨눕니다. 세는 규칙을 새로 짜지 않았으므로, 나중에 둘이 어긋날 일이 없습니다.

**모델 호출 0회, 비용 0원, 오프라인.**

---

## 되살린 숫자

| | |
|---|---|
| 파일이 필요했던 문제 | **28개** |
| 파일을 만든 문제 | **22개** |
| 못 만든 문제 | **6개** |

**여기서 중요한 게 하나 있습니다.**

끝까지 간 22개는 **하나도 빠짐없이** 파일을 만들었습니다. 예외가 없습니다.

못 만든 6개는 **오류가 난 8개 중 파일이 필요했던 6개**입니다. 나머지 2개는 애초에 파일이 필요 없는 문제였고, 그래서 분모 28에도 들어가지 않습니다.

즉 22/28 = 78.6%에서 모자란 부분은 **파일 만들기가 6번 실패한 게 아니라**, 그 6개가 **rate limit과 content filter로 끝까지 가지 못한** 결과입니다. 파일 생성 자체는 **성공률 100%**입니다 — 도달한 문제에 한해서요.

빈칸만 보고는 이 둘을 구분할 수 없습니다. 그게 되살리는 이유입니다. **저도 처음엔 Foundry 연결이 고장난 줄 알았습니다.**

(30개 전체로는 22 성공 / 8 오류이고, 8건의 내역은 rate limit 5 + content filter 3입니다.)

---

## 일부러 안 한 것

**기존 칸을 덮어쓰지 않습니다.** 실행이 "안 셌다"고 기록한 사실은 그대로 둡니다. 되살린 값은 **출처를 달고 옆자리에** 붙습니다(`file_generation_recovered`).

실행 중에 잰 값과 나중에 다시 만든 값은 **같은 종류의 증거가 아니기 때문입니다.** 한 칸에 섞으면 그 구분이 사라집니다.

이미 숫자가 있는 보고서에 대고 이 도구를 돌리면 **거부합니다.** 측정값을 재구성값으로 바꾸는 일이라서요. 테스트가 이걸 붙잡고 있습니다 — 거부 메시지에 **지키려는 값(185)이 들어 있는지까지** 봅니다.

---

## 대시보드

이제 화면에 **나옵니다.** 되살린 값을 읽은 경우에만 한 줄이 붙습니다:

> Reconstructed after the run from run 34540053904 (step 5 was skipped: dry_run). The run itself recorded no count.

측정값이 있으면 **언제나 측정값이 이깁니다.** 도구를 두 번 돌려서 진짜 숫자를 밀어내는 일이 생길 수 없게 해뒀습니다.

---

## 지금 돌고 있는 220문제 실행에 필요합니다

exp035도 dry run이라 **똑같이 빈칸으로 나옵니다.** 끝나면 이 도구로 되살릴 겁니다. 그때 가서 만들면 늦습니다.

---

## 검사

```
python      5개 신규 — 전부 통과
aggregate   507개 (file-generation 12 → 16)
tsc         통과
```

aggregate 전체 실행 중 `a-test-file-that-will-not-parse...`가 **간헐적으로** `Unable to deserialize cloned data`로 떨어집니다(5회 중 2회). 그 파일만 따로 돌리면 3/3 통과합니다. node 22 test runner의 IPC 문제이고 이 PR과 무관합니다 — 다만 CI가 빨개지면 이것일 수 있어 적어둡니다.
