### PR TITLE
하나의 429는 서로 다른 두 문제입니다 — 어느 쪽인지 기록합니다

### DIFF
--- a/batch-runner/core/codex_runner.py
+++ b/batch-runner/core/codex_runner.py
@@ -461,6 +461,77 @@ def _turn_failure_category(
     return category
 
 
+#: What the provider says when it refused for the tokens a turn reserved, and
+#: what it says when it refused for how often turns arrived. Azure returns the
+#: same ``429`` for both and separates them in one word of prose -- yet they
+#: have opposite fixes. A token refusal is answered by asking for less in a
+#: turn; a call refusal by asking less often. Acting on the wrong one costs a
+#: run and changes nothing.
+#:
+#: Kept apart from :data:`core.execution_errors._RATE_LIMIT_MARKERS`, which
+#: matches the bare substring ``rate limit`` and so folds both into
+#: ``rate_limited``. That fold is right about *what to do* -- both are retried
+#: the same way -- and says nothing about *what to change*.
+#:
+#: Not yet confirmed against this project's own logs: ``exp034``'s eight
+#: failures were recorded through :func:`core.public_error.public_task_error`,
+#: which is documented to return a message-free error identity, so the
+#: sentences that would settle these strings did not survive to the artifact.
+#: That is why an unmatched refusal is reported as ``unattributed`` rather than
+#: as nothing -- see :func:`_rate_limit_kind`.
+_TOKEN_RATE_MARKERS = (
+    "token rate limit",
+    "tokens per min",
+    "tokens per minute",
+)
+_REQUEST_RATE_MARKERS = (
+    "call rate limit",
+    "requests per min",
+    "requests per minute",
+)
+
+#: The only words :func:`_rate_limit_kind` may publish. A closed set, because
+#: the sentence these are read out of names the deployment, and the whole point
+#: of ``public_task_error`` is that such a sentence does not reach an artifact.
+#: One word from a fixed vocabulary carries the distinction without carrying
+#: the endpoint.
+RATE_LIMIT_KINDS = ("token", "request", "unattributed")
+
+
+def _rate_limit_kind(
+    failure: Any, *, http_status_code: int | None = None
+) -> str | None:
+    """Which of the provider's two rate refusals this was, in one word.
+
+    ``None`` means this failure was not a rate refusal at all. It is not a
+    quieter way of saying "a rate refusal we could not read" -- that is
+    ``unattributed``, and the difference is the whole value of the field. A run
+    that reports ``unattributed`` eight times has been refused eight times in
+    wording these markers do not cover, which is a finding about the markers.
+    A run that reports ``None`` eight times was not refused for rate.
+
+    Whether it was a rate refusal is not decided again here:
+    :func:`_turn_failure_category` already answers that, and a second rule for
+    the same question is a second rule to disagree with the first.
+
+    Matching both kinds is reported as ``unattributed``. Two contradictory
+    names are no more attributable than none, and picking the first would make
+    the answer depend on the order of a tuple.
+    """
+    if _turn_failure_category(failure, http_status_code=http_status_code) != (
+        "rate_limited"
+    ):
+        return None
+    text = str(failure).lower()
+    token = any(marker in text for marker in _TOKEN_RATE_MARKERS)
+    request = any(marker in text for marker in _REQUEST_RATE_MARKERS)
+    if token and not request:
+        return "token"
+    if request and not token:
+        return "request"
+    return "unattributed"
+
+
 #: Notification methods the turn stream is read for. Matched as strings
 #: because this module does not import the SDK -- see :func:`read_breakdown`.
 _NOTIFY_TOKEN_USAGE = "thread/tokenUsage/updated"
@@ -576,6 +647,9 @@ class CodexRunOutcome:
     usage_delta: CodexTokenTotals = field(default_factory=CodexTokenTotals)
     items_seen: int = 0
     http_status_code: int | None = None
+    #: One of :data:`RATE_LIMIT_KINDS`, or ``None`` when this was not a rate
+    #: refusal. Read here, where the provider's sentence still exists.
+    rate_limit_kind: str | None = None
     thread_id: str | None = None
     turn_id: str | None = None
     swept_pids: tuple[int, ...] = ()
@@ -1010,6 +1084,7 @@ class CodexAgentRunner(RecordsItsFirstRequest):
             # turns arrive.
             "items_seen": outcome.items_seen,
             "http_status_code": outcome.http_status_code,
+            "rate_limit_kind": outcome.rate_limit_kind,
             "usage_delta": {
                 "input_tokens": outcome.usage_delta.input_tokens,
                 "cached_input_tokens": outcome.usage_delta.cached_input_tokens,
@@ -1032,9 +1107,15 @@ class CodexAgentRunner(RecordsItsFirstRequest):
             # left behind here. What the turn spent is deliberately not
             # repeated: the cost ledger already carries it under this task id,
             # and a second copy is a second thing to disagree with the first.
+            #
+            # `rate_limit_kind` is here for the opposite reason: the sentence
+            # it is read from is deliberately not carried anywhere, so one word
+            # from a closed set is the only form in which the distinction can
+            # reach an artifact at all.
             "codex_diagnostics": {
                 "items_seen": outcome.items_seen,
                 "http_status_code": outcome.http_status_code,
+                "rate_limit_kind": outcome.rate_limit_kind,
             },
         }
         if outcome.error:
@@ -1177,6 +1258,9 @@ class CodexAgentRunner(RecordsItsFirstRequest):
                     usage_delta=measured,
                     items_seen=observed.items_seen,
                     http_status_code=status_code,
+                    rate_limit_kind=_rate_limit_kind(
+                        failure, http_status_code=status_code
+                    ),
                     thread_id=getattr(thread, "id", None),
                     turn_id=getattr(turn_handle, "id", None),
                 )

--- a/batch-runner/scripts/analyze_codex_run.py
+++ b/batch-runner/scripts/analyze_codex_run.py
@@ -225,6 +225,13 @@ def collect(root: Path) -> dict:
                 "http_status_code": codex.get(
                     "http_status_code", result.get("http_status_code")
                 ),
+                # Which of the provider's two rate limits refused it, when the
+                # refusal said. `None` here means it was not a rate refusal;
+                # `unattributed` means it was one in wording the markers in
+                # `codex_runner` do not cover, which is a finding about the
+                # markers rather than about the deployment. Runs made before
+                # the field existed carry neither, and read as `None`.
+                "rate_limit_kind": codex.get("rate_limit_kind"),
                 "latency_ms": result.get("latency_ms"),
                 "chars": len(statements.get(tid, "")),
                 "sector": sectors.get(tid, ""),
@@ -365,30 +372,71 @@ def report(data: dict) -> None:
         print(f"  carried on {len(seen)}/{len(tasks)} tasks   "
               f"min {min(values)}  max {max(values)}  median {statistics.median(values)}")
 
-        # The discriminator this field was added for. A 429 is the provider
-        # saying no; where in the turn it arrives is the part that says what
-        # it was refusing. Refused after many items points at what one turn
-        # consumes; refused at zero or near it points at something decided
-        # before the turn spent anything -- arrival rate, concurrency, or a
-        # reservation that was already full. This prints the two numbers side
-        # by side and stops there: which limit it is, is not a thing a table
-        # of item counts can settle on its own.
-        refused = [t for t in seen if t["http_status_code"] == 429]
-        if refused:
-            print()
-            print(f"  of those, refused with HTTP 429 : {len(refused)}")
-            for t in sorted(refused, key=lambda x: x["items_seen"]):
-                print(f"    {t['task_id'][:8]}  items_seen={t['items_seen']:<5} "
-                      f"attempts={t['attempts']}")
-            at_zero = sum(1 for t in refused if t["items_seen"] == 0)
+    # The discriminator this field was added for. A 429 is the provider saying
+    # no; where in the turn it arrives is the part that says what it was
+    # refusing. Refused after many items points at what one turn consumes;
+    # refused at zero or near it points at something decided before the turn
+    # spent anything -- arrival rate, concurrency, or a reservation that was
+    # already full.
+    #
+    # Selected by category as well as by status, because exp034 carried
+    # neither: all eight of its failures recorded `items_seen` and nothing
+    # else, so a filter on `http_status_code == 429` printed that run's five
+    # rate refusals as "no task carried HTTP 429" -- true, and read by nobody
+    # as "five tasks were refused for rate".
+    #
+    # Drawn from every task rather than from `seen`, so that a refusal which
+    # recorded no item count is still counted as a refusal. It is listed apart
+    # instead: its position in the turn is the one thing it cannot say, and
+    # that is exactly what the rest of this block is reading.
+    refused = [
+        t
+        for t in tasks
+        if t["http_status_code"] == 429 or t["error_category"] == "rate_limited"
+    ]
+    if refused:
+        print()
+        located = [t for t in refused if _items_seen_is_measured(t)]
+        adrift = [t for t in refused if t not in located]
+        print(f"  of those, refused for rate : {len(refused)}")
+        for t in sorted(located, key=lambda x: x["items_seen"]):
+            status = t["http_status_code"] or "-"
+            kind = t["rate_limit_kind"] or "not recorded"
+            print(f"    {t['task_id'][:8]}  items_seen={t['items_seen']:<5} "
+                  f"attempts={t['attempts']:<3} status={status:<5} {kind}")
+        for t in adrift:
+            status = t["http_status_code"] or "-"
+            kind = t["rate_limit_kind"] or "not recorded"
+            print(f"    {t['task_id'][:8]}  items_seen=NOT MEASURED  "
+                  f"attempts={t['attempts']:<3} status={status:<5} {kind}")
+        if located:
+            at_zero = sum(1 for t in located if t["items_seen"] == 0)
             print(f"    refused before any item : "
-                  f"{_pct(at_zero, len(refused), '429 tasks')}")
-        else:
-            statuses = sorted(
-                {str(t["http_status_code"]) for t in seen if t["http_status_code"]}
-            )
-            print(f"  no task carried HTTP 429 alongside a measured item count"
-                  f"{'   (statuses seen: ' + ', '.join(statuses) + ')' if statuses else ''}")
+                  f"{_pct(at_zero, len(located), 'rate refusals with a count')}")
+
+        # Which of the provider's two limits was reached. `token` and
+        # `request` have opposite fixes, so a run that cannot say which one
+        # cannot say what to change -- and a run made before the field existed
+        # says nothing at all, which must not be read as "neither".
+        kinds = Counter(t["rate_limit_kind"] for t in refused)
+        named = {k: v for k, v in kinds.items() if k in ("token", "request")}
+        if named:
+            print(f"    which limit : {named}")
+        unread = kinds.get(None, 0) + kinds.get("unattributed", 0)
+        if unread:
+            print(f"    which limit : UNDETERMINED for {unread} of "
+                  f"{len(refused)} -- no kind was recorded for them. Not "
+                  f"evidence for either limit.")
+            print("      -> `rate_limit_kind` in core/codex_runner.py reads it "
+                  "where the message still exists. Runs predating it say "
+                  "nothing; `unattributed` means the wording escaped the "
+                  "markers, which is a finding about the markers.")
+    else:
+        statuses = sorted(
+            {str(t["http_status_code"]) for t in tasks if t["http_status_code"]}
+        )
+        print(f"  no task was refused for rate"
+              f"{'   (statuses seen: ' + ', '.join(statuses) + ')' if statuses else ''}")
     print()
 
     # --- Cost: reported, never repaired, never added to grading ---

--- a/batch-runner/step2_run_inference.py
+++ b/batch-runner/step2_run_inference.py
@@ -53,6 +53,7 @@ from core.config import (
     DEFAULT_TOKENS,
 )
 from core.agentic_authorization import task_request_sha256
+from core.codex_runner import RATE_LIMIT_KINDS
 from core.executor import TaskExecutor
 from core.agentic_experiments import (
     AGENTIC_BASELINE_ID,
@@ -1236,7 +1237,7 @@ def _build_execution_observability(
 
 
 def _bounded_codex_diagnostics(raw: Optional[dict]) -> Optional[dict]:
-    """Allow only the two bounded numbers a Codex turn reports about itself.
+    """Allow only the bounded facts a Codex turn reports about itself.
 
     How far the turn got before it ended, and what answered it. A turn refused
     after forty completed items is a different fact from one refused after two,
@@ -1251,6 +1252,15 @@ def _bounded_codex_diagnostics(raw: Optional[dict]) -> Optional[dict]:
     A status is only published when it is one a server can send. ``None`` for
     an out-of-range value says nothing rather than saying something wrong,
     which is the same choice ``bounded_count`` makes beside it.
+
+    ``rate_limit_kind`` passes the same way, and only as one of
+    :data:`core.codex_runner.RATE_LIMIT_KINDS`. The word is read from a
+    provider sentence that names the deployment, and this allow-list is the
+    reason that sentence cannot follow it: membership of a closed set is
+    checked here, so no string the provider chose can reach an artifact through
+    this field. An unrecognised value is dropped rather than truncated --
+    truncating it would publish a prefix of exactly the sentence the projection
+    exists to withhold.
     """
     if not isinstance(raw, dict):
         return None
@@ -1261,6 +1271,9 @@ def _bounded_codex_diagnostics(raw: Optional[dict]) -> Optional[dict]:
     status = raw.get("http_status_code")
     if type(status) is int and 100 <= status <= 599:
         output["http_status_code"] = status
+    kind = raw.get("rate_limit_kind")
+    if type(kind) is str and kind in RATE_LIMIT_KINDS:
+        output["rate_limit_kind"] = kind
     return output or None
 
 

--- a/batch-runner/tests/test_a_refused_turn_still_reports_what_it_spent.py
+++ b/batch-runner/tests/test_a_refused_turn_still_reports_what_it_spent.py
@@ -679,7 +679,7 @@ def test_the_counts_satisfy_the_field_the_run_record_requires():
 # which backend ran cannot find it.
 
 
-def test_the_two_numbers_leave_the_runner_on_the_result(
+def test_what_the_runner_measured_leaves_the_runner_on_the_result(
     ledger: CostReceiptLedger,
 ):
     """Measured is not reported. This is the step between them."""
@@ -692,9 +692,14 @@ def test_the_two_numbers_leave_the_runner_on_the_result(
     )
     result = _run_the_task(_runner_over(handle, ledger))
 
+    # `unattributed` is the exp034 shape exactly: refused by a status, in
+    # prose that names neither of the provider's two rate limits. It is a
+    # reading of the message, not an absence of one -- see
+    # `test_one_429_is_two_different_problems`.
     assert result["codex_diagnostics"] == {
         "items_seen": 2,
         "http_status_code": 429,
+        "rate_limit_kind": "unattributed",
     }
 
 
@@ -707,6 +712,31 @@ def test_step_two_publishes_how_far_the_turn_got_and_what_refused_it():
     assert observability["codex"] == {
         "items_seen": 41,
         "http_status_code": 429,
+    }
+
+
+def test_step_two_publishes_which_of_the_two_rate_limits_refused_it():
+    """The last step of the chain: a kind read at the turn reaches the record.
+
+    Everything before this was measured and then discarded at one boundary or
+    another. A field that stops at the allow-list is as unreadable from a
+    downloaded run as one that was never read.
+    """
+    observability = step2._build_execution_observability(
+        {
+            "codex_diagnostics": {
+                "items_seen": 41,
+                "http_status_code": 429,
+                "rate_limit_kind": "token",
+            }
+        },
+        [],
+    )
+
+    assert observability["codex"] == {
+        "items_seen": 41,
+        "http_status_code": 429,
+        "rate_limit_kind": "token",
     }
 
 

--- a/batch-runner/tests/test_an_unanswerable_question_is_declined.py
+++ b/batch-runner/tests/test_an_unanswerable_question_is_declined.py
@@ -67,7 +67,9 @@ def build(root: Path, spec: list[tuple]) -> Path:
 
     A row may carry a seventh element, the HTTP status the turn was refused
     with. Rows without one are unchanged, because a status is a thing most
-    outcomes do not have.
+    outcomes do not have. An eighth element is ``rate_limit_kind``; rows
+    without one are how every run made before that field existed looks, which
+    is every run this project has so far.
     """
     workspace = root / "workspace"
     workspace.mkdir(parents=True, exist_ok=True)
@@ -76,6 +78,7 @@ def build(root: Path, spec: list[tuple]) -> Path:
     for row in spec:
         task_id, status, category, attempts, chars, items_seen = row[:6]
         http_status = row[6] if len(row) > 6 else None
+        rate_limit_kind = row[7] if len(row) > 7 else None
         task = {"task_id": task_id, "sector": "Finance"}
         if chars:
             task["instruction"] = "x" * chars
@@ -92,6 +95,8 @@ def build(root: Path, spec: list[tuple]) -> Path:
             codex = {"items_seen": items_seen}
             if http_status is not None:
                 codex["http_status_code"] = http_status
+            if rate_limit_kind is not None:
+                codex["rate_limit_kind"] = rate_limit_kind
             result["observability"]["codex"] = codex
         results.append(result)
 
@@ -317,8 +322,8 @@ def test_where_a_refusal_lands_in_the_turn_is_reported_beside_the_count(
     A 429 says the provider refused. How far the turn got before being
     refused is the part that distinguishes "this turn consumed too much" from
     "something was decided before this turn spent anything". The analyzer
-    prints both numbers together and declines to name the limit, because a
-    table of item counts cannot settle that on its own.
+    prints both numbers together and declines to name the limit from them,
+    because a table of item counts cannot settle that on its own.
     """
     build(tmp_path, [
         ("aaaa1111", "success", None, 1, 900, 37),
@@ -326,22 +331,104 @@ def test_where_a_refusal_lands_in_the_turn_is_reported_beside_the_count(
         ("eeee5555", "error", "rate_limited", 2, 2400, 22, 429),
     ])
     out = run(tmp_path, capsys)
-    assert "refused with HTTP 429 : 2" in out
+    assert "refused for rate : 2" in out
     assert "dddd4444  items_seen=0" in out
     assert "eeee5555  items_seen=22" in out
     assert "refused before any item : 1/2 = 50.0%" in out
 
 
+def test_a_refusal_that_recorded_no_status_is_still_a_refusal(tmp_path, capsys):
+    """exp034's actual shape, and the one this section used to print as none.
+
+    Selecting on ``http_status_code == 429`` alone was true and useless: all
+    eight of exp034's failures carried ``items_seen`` and nothing else, so its
+    five rate refusals were reported as "no task carried HTTP 429" -- a
+    sentence nobody reads as "five tasks were refused for rate". The category
+    is the other way in, and it is the way that works on every run so far.
+    """
+    build(tmp_path, [
+        ("aaaa1111", "success", None, 1, 900, 37),
+        ("dddd4444", "error", "rate_limited", 4, 1500, 30),
+        ("eeee5555", "error", "rate_limited", 4, 2400, 42),
+    ])
+    out = run(tmp_path, capsys)
+    assert "refused for rate : 2" in out
+    assert "dddd4444  items_seen=30" in out
+    assert "status=-" in out  # the status it does not have, said as absent
+    assert "no task was refused for rate" not in out
+
+
+def test_a_refusal_with_no_measured_count_is_listed_apart_not_dropped(
+    tmp_path, capsys
+):
+    """Its position in the turn is the one thing it cannot report.
+
+    Dropping it would undercount the refusals; folding its unset zero into the
+    rest would answer "was it refused before spending anything?" with a
+    dataclass default, in the direction that flatters the convenient reading.
+    It is counted as a refusal and excluded from the position figure.
+    """
+    build(tmp_path, [
+        ("aaaa1111", "success", None, 1, 900, 37),
+        ("dddd4444", "error", "rate_limited", 3, 1500, 12, 429),
+        ("ffff6666", "error", "rate_limited", 2, 2400, None, 429),
+    ])
+    out = run(tmp_path, capsys)
+    assert "refused for rate : 2" in out
+    assert "ffff6666  items_seen=NOT MEASURED" in out
+    # One refusal has a count; the unmeasured one is not a zero in it.
+    assert "refused before any item : 0/1 = 0.0%" in out
+
+
+def test_which_of_the_two_limits_refused_is_named_when_the_run_recorded_it(
+    tmp_path, capsys
+):
+    """``token`` and ``request`` have opposite fixes, so the count matters."""
+    build(tmp_path, [
+        ("aaaa1111", "success", None, 1, 900, 37),
+        ("dddd4444", "error", "rate_limited", 3, 1500, 12, 429, "token"),
+        ("eeee5555", "error", "rate_limited", 2, 2400, 30, 429, "token"),
+        ("ffff6666", "error", "rate_limited", 2, 2400, 4, 429, "request"),
+    ])
+    out = run(tmp_path, capsys)
+    assert "which limit : {'token': 2, 'request': 1}" in out
+    # Narrowly worded: the cost section says UNDETERMINED about dollars, for
+    # unrelated reasons, and a bare substring check passes on that instead.
+    assert "which limit : UNDETERMINED" not in out
+
+
+@pytest.mark.parametrize("kind", [None, "unattributed"])
+def test_a_run_that_cannot_say_which_limit_says_that_rather_than_neither(
+    tmp_path, capsys, kind
+):
+    """Absent and unattributed both mean undetermined, for different reasons.
+
+    A run predating ``rate_limit_kind`` records nothing; ``unattributed`` means
+    the refusal's wording escaped the markers in ``core/codex_runner.py``. Both
+    must print as UNDETERMINED rather than as an empty breakdown, which reads
+    as "neither limit was reached" -- the one thing that is certainly false
+    about a task that was refused for rate.
+    """
+    build(tmp_path, [
+        ("aaaa1111", "success", None, 1, 900, 37),
+        ("dddd4444", "error", "rate_limited", 3, 1500, 12, 429, kind),
+    ])
+    out = run(tmp_path, capsys)
+    assert "which limit : UNDETERMINED for 1 of 1" in out
+    assert "Not evidence for either limit" in out
+    assert "'token'" not in out
+
+
 def test_a_run_with_no_refusals_says_so_rather_than_printing_an_empty_table(
     tmp_path, capsys
 ):
-    """No 429 is a result. It must not read as a table that failed to print."""
+    """No refusal is a result. It must not read as a table that failed to print."""
     build(tmp_path, [
         ("aaaa1111", "success", None, 1, 900, 37),
         ("bbbb2222", "error", "turn_failed", 2, 1500, 9, 500),
     ])
     out = run(tmp_path, capsys)
-    assert "no task carried HTTP 429 alongside a measured item count" in out
+    assert "no task was refused for rate" in out
     assert "statuses seen: 500" in out
     assert "refused before any item" not in out
 

--- a/batch-runner/tests/test_one_429_is_two_different_problems.py
+++ b/batch-runner/tests/test_one_429_is_two_different_problems.py
@@ -1,0 +1,260 @@
+"""One 429 is two different problems, and the run could not tell them apart.
+
+Azure answers both of its rate refusals with the same status, and the runner
+files both under the same category. That is correct about what to *do* -- both
+are retried the same way -- and useless about what to *change*:
+
+  * a **token** refusal says a turn reserved more than the deployment allows at
+    once, and is answered by asking for less in a turn;
+  * a **call** refusal says turns arrived faster than the deployment allows, and
+    is answered by asking less often.
+
+Doing the second thing about the first problem costs a run and fixes nothing.
+
+The distinction exists in exactly one place: a sentence on ``TurnError.message``
+that also names the deployment. ``core.public_error.public_task_error`` is
+documented to return "an endpoint- and message-free public error identity", so
+that sentence is destroyed on the way to the artifact -- deliberately. These
+tests pin the way through: read the kind where the sentence still exists,
+publish one word from a closed set, and let the allow-list in step 2 check
+membership so no provider-chosen string can follow it out.
+
+``exp034``'s eight failures carry ``{"items_seen": N}`` and nothing else, so
+every ``rate_limited`` label this project holds was made by prose matching, and
+none of it recorded which kind. That is the gap these tests close.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.codex_runner import (  # noqa: E402
+    RATE_LIMIT_KINDS,
+    CodexRunOutcome,
+    _rate_limit_kind,
+)
+from core.execution_errors import classify_execution_error  # noqa: E402
+from step2_run_inference import _bounded_codex_diagnostics  # noqa: E402
+
+
+#: The two wordings the distinction turns on. Azure's own, with the deployment
+#: name left in, because that is what the runner actually receives and because
+#: a test that strips it first would not prove the name is withheld later.
+TOKEN_REFUSAL = (
+    "stream disconnected before completion: Requests to the "
+    "ChatCompletions_Create Operation under Azure OpenAI API version "
+    "2024-12-01-preview have exceeded token rate limit of your current "
+    "OpenAI S0 pricing tier."
+)
+CALL_REFUSAL = (
+    "stream disconnected before completion: Requests to the "
+    "ChatCompletions_Create Operation under Azure OpenAI API version "
+    "2024-12-01-preview have exceeded call rate limit of your current "
+    "OpenAI S0 pricing tier."
+)
+
+
+# ── The two refusals stop being one refusal ─────────────────────────────────
+
+
+def test_a_token_refusal_is_named_a_token_refusal():
+    assert _rate_limit_kind(TOKEN_REFUSAL) == "token"
+
+
+def test_a_call_refusal_is_named_a_call_refusal():
+    assert _rate_limit_kind(CALL_REFUSAL) == "request"
+
+
+def test_the_two_refusals_do_not_read_the_same():
+    # The point of the field. If this ever passes with both equal, the field
+    # has stopped earning its place.
+    assert _rate_limit_kind(TOKEN_REFUSAL) != _rate_limit_kind(CALL_REFUSAL)
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("Rate limit reached: 60000 tokens per min", "token"),
+        ("Rate limit reached: 60 requests per min", "request"),
+        ("have exceeded token rate limit of your current tier", "token"),
+        ("have exceeded call rate limit of your current tier", "request"),
+    ],
+)
+def test_the_providers_other_wordings_reach_the_same_two_answers(text, expected):
+    assert _rate_limit_kind(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "exceeded your tokens per minute limit",
+        "exceeded your requests per minute limit",
+    ],
+)
+def test_a_per_minute_phrase_alone_is_not_yet_a_rate_refusal(text):
+    """The boundary belongs to ``classify_execution_error``, not to this.
+
+    Neither sentence contains any of ``_RATE_LIMIT_MARKERS``, so the project's
+    one rule for *was this a rate refusal* answers ``execution_error`` and this
+    matcher is never consulted. Recorded rather than fixed: widening those
+    markers widens what gets **retried**, and ``core.execution_errors`` is
+    explicit that mistaking a real defect for a transient one is how a
+    deterministic failure gets attempted three times. A diagnostic field is not
+    a reason to change retry behaviour.
+
+    If a deployment is ever seen refusing in exactly these words, the fix is in
+    ``_RATE_LIMIT_MARKERS`` and this test is what will have to change with it.
+    """
+    assert classify_execution_error(text) == "execution_error"
+    assert _rate_limit_kind(text) is None
+
+
+# ── Not knowing is said out loud, and is not the same as not happening ──────
+
+
+def test_a_refusal_that_names_neither_kind_is_unattributed():
+    # What exp034 would have produced, had the field existed then: refused for
+    # rate, in wording these markers do not cover. `unattributed` eight times
+    # is a finding about the markers; `None` eight times would hide it.
+    assert _rate_limit_kind("Error code: 429 - too many requests") == (
+        "unattributed"
+    )
+
+
+def test_a_failure_that_is_not_a_rate_refusal_reads_as_none():
+    assert _rate_limit_kind("the model produced no answer") is None
+
+
+def test_a_content_filter_is_not_given_a_rate_limit_kind():
+    # A filtered answer is a benchmark result. Attaching a rate-limit kind to
+    # it would put an infrastructure explanation on a model outcome.
+    assert _rate_limit_kind("finish_reason: content_filter") is None
+
+
+def test_unattributed_and_none_are_different_answers():
+    assert _rate_limit_kind("Error code: 429") != _rate_limit_kind("boom")
+
+
+def test_naming_both_kinds_is_attributable_to_neither():
+    both = "exceeded token rate limit and call rate limit"
+    # Taking the first match would make the answer depend on tuple order.
+    assert _rate_limit_kind(both) == "unattributed"
+
+
+def test_a_429_status_with_silent_prose_is_still_read_for_a_kind():
+    # The status settles *that* it was a rate refusal; the prose settles which.
+    # A turn whose category comes from the status must still be asked.
+    assert _rate_limit_kind("", http_status_code=429) == "unattributed"
+    assert _rate_limit_kind(TOKEN_REFUSAL, http_status_code=429) == "token"
+
+
+def test_prose_about_rate_limiting_is_already_a_refusal_before_this_field():
+    """An inherited false positive, named so it is not re-discovered as new.
+
+    ``core.execution_errors`` matches the bare substring ``rate limit``, so a
+    sentence *about* rate limiting already classifies as ``rate_limited``
+    today, with or without this field. Naming its kind does not create the
+    mislabel; it does make it more confident-looking, which is the honest cost
+    of the field and the reason it is pinned here.
+
+    Reached only if such prose ever lands on ``TurnError.message`` -- this
+    matcher is called on the turn's failure, never on a task's text. The
+    filter side of the same risk is already pinned by
+    ``test_a_task_about_filtering_is_not_a_filtered_task``; narrowing the rate
+    markers to match would be a change to what gets retried, and belongs in its
+    own change with its own evidence.
+    """
+    about = "Write a report on token rate limit design for an API gateway."
+    assert classify_execution_error(about) == "rate_limited"  # pre-existing
+    assert _rate_limit_kind(about) == "token"  # inherited, not introduced
+
+
+# ── What may leave the runner is a word, never the sentence ─────────────────
+
+
+def test_every_answer_is_from_the_closed_set_or_nothing():
+    for text in (TOKEN_REFUSAL, CALL_REFUSAL, "Error code: 429", "boom", ""):
+        answer = _rate_limit_kind(text)
+        assert answer is None or answer in RATE_LIMIT_KINDS
+
+
+def test_the_published_word_does_not_carry_the_deployment_name():
+    # `public_task_error` exists because this sentence names an endpoint. A
+    # field read out of it must not reintroduce what that projection removes.
+    published = _bounded_codex_diagnostics(
+        {"items_seen": 3, "rate_limit_kind": _rate_limit_kind(TOKEN_REFUSAL)}
+    )
+    assert published == {"items_seen": 3, "rate_limit_kind": "token"}
+    assert "azure" not in repr(published).lower()
+    assert "ChatCompletions_Create" not in repr(published)
+
+
+def test_a_string_the_provider_chose_cannot_pass_the_allow_list():
+    # The allow-list is the reason the closed set is closed. Anything else is
+    # dropped, not truncated: a prefix of this sentence is still the sentence.
+    leaked = _bounded_codex_diagnostics(
+        {"items_seen": 3, "rate_limit_kind": TOKEN_REFUSAL}
+    )
+    assert leaked == {"items_seen": 3}
+
+
+@pytest.mark.parametrize("bad", [429, True, None, ["token"], {"kind": "token"}])
+def test_only_a_member_of_the_closed_set_is_published(bad):
+    assert _bounded_codex_diagnostics(
+        {"items_seen": 1, "rate_limit_kind": bad}
+    ) == {"items_seen": 1}
+
+
+def test_the_field_is_absent_rather_than_null_when_there_is_no_kind():
+    # An explicit `null` beside `items_seen` reads as "asked and unanswered".
+    # Absent reads as "not a rate refusal", which is what it is.
+    published = _bounded_codex_diagnostics(
+        {"items_seen": 7, "rate_limit_kind": None}
+    )
+    assert published == {"items_seen": 7}
+    assert "rate_limit_kind" not in published
+
+
+def test_the_numbers_already_published_are_undisturbed():
+    assert _bounded_codex_diagnostics(
+        {"items_seen": 41, "http_status_code": 429, "rate_limit_kind": "request"}
+    ) == {
+        "items_seen": 41,
+        "http_status_code": 429,
+        "rate_limit_kind": "request",
+    }
+
+
+# ── The outcome carries it, so the runner can hand it on ────────────────────
+
+
+def test_an_outcome_that_was_not_refused_carries_no_kind():
+    assert CodexRunOutcome(success=True, text="done").rate_limit_kind is None
+
+
+def test_the_outcome_field_is_what_the_diagnostics_are_built_from():
+    # Guards the wiring rather than the rule: a field added to the dataclass
+    # and never read would pass every test above and publish nothing.
+    outcome = CodexRunOutcome(
+        success=False,
+        text="",
+        items_seen=2,
+        http_status_code=429,
+        rate_limit_kind=_rate_limit_kind(CALL_REFUSAL),
+    )
+    assert _bounded_codex_diagnostics(
+        {
+            "items_seen": outcome.items_seen,
+            "http_status_code": outcome.http_status_code,
+            "rate_limit_kind": outcome.rate_limit_kind,
+        }
+    ) == {
+        "items_seen": 2,
+        "http_status_code": 429,
+        "rate_limit_kind": "request",
+    }


### PR DESCRIPTION
## 한 줄 요약

**요금 거절을 당해도 우리 기록에는 "요금 때문"까지만 남고, 어느 쪽 요금인지는 한 글자도 남지 않습니다. 이 PR이 그 칸을 만듭니다. 그리고 오늘 실행 로그를 읽어보니 — 제공자도 안 알려줍니다. 그 사실 자체가 기록됩니다.**

---

## 무슨 얘기냐

거절에는 두 종류가 있고, **고치는 방법이 정반대**입니다.

| 무엇 | 뜻 | 해야 할 일 |
|---|---|---|
| 토큰 쪽 | 한 번에 **너무 많이** 달라고 했다 | 한 번에 덜 요청 |
| 호출 쪽 | **너무 자주** 달라고 했다 | 덜 자주 요청 |

**둘 다 429입니다.** 우리 코드도 둘 다 `rate_limited` 하나로 넣습니다.

재시도할 때는 이게 맞습니다 — 어느 쪽이든 똑같이 다시 걸면 되니까요. 그런데 **무엇을 고칠지**에 대해서는 아무 말도 해주지 않습니다. 첫 번째 문제에 두 번째 조치를 하면 실행 한 번을 통째로 쓰고 아무것도 안 고쳐집니다.

---

## 오늘 확인한 것 — 제공자가 어느 쪽인지 안 알려줍니다

오늘 도는 220문제 실행(leg 1) 로그에서 **거절 문장 원본**을 꺼냈습니다. 10번 나왔고, 전부 똑같습니다.

```
Your requests to gpt-5.4 for gpt-5.4 in eastus2 have exceeded rate limit.
```

**끝입니다.** "토큰"도 "호출"도 없습니다. 재시도 시간도 없습니다.

이건 우리가 자른 게 아닙니다. 문장을 300자로 자르는 코드는 로그인 실패 쪽에만 있고, 이 경로에는 없습니다. 마침표까지 온전한 73글자입니다.

**그래서 이 필드는 이 배포에서 언제나 "판별 불가"를 적게 됩니다.** 그게 이 PR이 하려던 일의 실패가 아니라, 이 PR이 만든 칸이 처음으로 해내는 일입니다 — 지금까지는 **모른다는 사실조차 어디에도 안 적혔습니다.**

---

## 왜 지금까지 몰랐나 — 끊기는 곳이 세 군데입니다

**1. 문장이 일부러 지워집니다.**
`public_task_error()`가 문장을 지우고 넘깁니다. **버그가 아닙니다.** 위 문장을 보면 알 수 있듯 배포 이름과 지역이 같이 들어 있습니다. 안 내보내는 게 맞습니다.

**2. 걸러내는 코드가 둘을 합칩니다.**
`"rate limit"`이라는 글자만 찾습니다.

**3. `retry-after`는 아예 못 가져옵니다.**
쓰고 있는 SDK가 오류에 담아주는 건 상태 코드 숫자 하나뿐입니다. 헤더도 본문도 안 줍니다. 그래서 약속하지 않습니다.

---

## 확인한 것 — exp034에는 상태 코드조차 없었습니다

상태 코드를 기록하는 변경(#505)은 exp034가 쓴 코드에 **이미 들어 있었습니다.** 그런데 실패 8건 전부가 `{"items_seen": 숫자}` 하나만 들고 있습니다.

즉 **이 프로젝트의 모든 `rate_limited` 표시는 영어 문장 맞춰보기가 만들었습니다.**

---

## 만든 것

문장이 아직 살아 있는 자리에서 읽어서, **정해둔 세 단어 중 하나만** 내보냅니다.

    token / request / unattributed

- **`public_task_error`는 손대지 않습니다.** 막고 있는 걸 열어젖히는 게 아니라, 막는 것을 통과시키지 않는 형태를 따로 만듭니다.
- 밖으로 나가는 길목에서 **이 세 단어인지 확인**합니다. 제공자가 고른 문장이 이 칸으로 새어나갈 수 없습니다.
- 모르는 값은 **잘라내지 않고 버립니다.** 그 문장을 앞부분만 남겨도 여전히 그 문장이니까요.

**`unattributed`와 "없음"은 다릅니다.** 앞은 "요금 거절인데 표현이 우리가 아는 것과 다르다", 뒤는 "요금 거절이 아니다". 위에서 본 대로 이 배포는 **앞쪽이 계속 나옵니다.** 그건 우리 코드와 제공자 문구 양쪽에 대한 발견입니다. 둘을 합치면 그 발견이 사라집니다.

---

## 같이 고친 것 — 분석기가 거절 5건을 "없음"으로 찍고 있었습니다

분석 도구가 **상태 코드 429인 것만** 골라 세고 있었습니다. exp034에는 상태 코드가 없으니, 그 실행의 요금 거절 **5건을 "429인 문제 없음"으로 출력**했습니다. 틀린 말은 아닌데, 이걸 "5문제가 요금 때문에 거절당했다"로 읽을 사람은 없습니다.

이제 범주로도 골라냅니다. 그러자 안 보이던 게 나왔습니다.

```
  refused for rate : 5
    105f8ad0  items_seen=30  attempts=4  status=-  not recorded
    1d4672c8  items_seen=30  attempts=4  status=-  not recorded
    0353ee0c  items_seen=30  attempts=4  status=-  not recorded
    0e4fe8cd  items_seen=34  attempts=4  status=-  not recorded
    02aa1805  items_seen=42  attempts=4  status=-  not recorded
    refused before any item : 0/5 = 0.0%
    which limit : UNDETERMINED for 5 of 5
```

**5건 모두 30~42개를 만든 뒤에 거절당했습니다. 0에서 거절당한 건 하나도 없습니다.**

"너무 자주 불렀다"는 거절은 **일을 시작하기 전에** 떨어집니다. 문 앞에서 막는 거니까요. 5건 다 그 모양이 아닙니다.

측정된 개수가 없는 거절은 버리지 않고 따로 적습니다. 버리면 거절 수가 줄고, 섞으면 "아무것도 쓰기 전에 거절당했나"라는 질문에 **필드 기본값 0으로** 답하게 됩니다.

---

## 지금까지 좁혀진 것

| 후보 | 판정 | 근거 |
|---|---|---|
| 너무 자주 부름 | ❌ | 완전 직렬, 분당 0.3회. 그리고 위의 0/5 |
| 한 턴이 너무 큼 | ❌ | 거절된 턴 중앙값 20,964 / 성공한 턴 중앙값 35,059. **성공한 쪽이 더 컸습니다** |
| 호출 간격 | ❌ | 위와 같음 |
| **배포 전체 처리량** | **남음** | 배제할 근거가 없습니다 |

**남은 후보를 확정하는 길이 응답 문장이 아니라는 게 오늘 새로 안 것입니다.** 문장은 안 알려줍니다. 확정하려면 배포에 걸린 할당량 숫자를 봐야 합니다. 그건 이 PR 밖의 일입니다.

---

## 일부러 안 한 것 두 가지

테스트가 찾아냈고, **고치는 대신 못 박았습니다.** 둘 다 원래 있던 성질이지 이번에 생긴 게 아닙니다.

**하나.** `"exceeded your tokens per minute limit"`은 지금도 요금 거절로 분류되지 **않습니다.** 찾는 글자를 늘리면 분류가 늘어나는 게 아니라 **재시도되는 게 늘어납니다.** 진단용 칸 하나 때문에 재시도 동작을 바꿀 수는 없습니다.

**둘.** 요금 제한을 *주제로 쓴 글*은 오늘도 이미 요금 거절로 잘못 분류됩니다. 종류를 붙인다고 그 오분류가 생기는 건 아니지만, **더 그럴듯해 보이게는 만듭니다.** 이 필드의 정직한 대가이고, 그래서 테스트로 고정해뒀습니다.

---

## 지금 도는 220문제에는 못 씁니다

릴레이가 코드를 **첫 구간 시점으로 고정**합니다. exp035는 이 칸 없이 끝납니다.

---

## 검사

```
신규 28개   어느 쪽 거절인지 읽고 내보내는 부분
신규  5개   분석기 (거절 5건이 "없음"으로 찍히던 것 포함)
기존 36개   거절당한 턴이 쓴 비용 보고
지정범위 2,630개 통과
```

기존 분석기 테스트 2개가 바뀐 문구를 보고 실패해서 갱신했습니다.
