### PR TITLE
fix(v2): a task with input files finished, and was thrown away

### DIFF
--- a/.github/workflows/agentic-v2-stage-a-probe.yml
+++ b/.github/workflows/agentic-v2-stage-a-probe.yml
@@ -107,13 +107,19 @@ jobs:
       # No charge. The revision is the one the catalogue was built from and the
       # one every figure in the comparison rests on; the runner hashes the
       # wording it reads and refuses if it is not what was priced.
+      #
+      # Only `data/`, because this probe asks one question of one prompt and
+      # never opens a reference file. The rest of the repository is 2.2 GB
+      # fetched to be ignored. The stage runner, which does open them, fetches
+      # differently and for stated reasons -- see `agentic-v2-stage-run.yml`.
       - name: Fetch the pinned dataset
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           set -euo pipefail
           hf download openai/gdpval --repo-type dataset \
-            --revision 11e7900cdcac61bc4daf59e65feb238acda98fbf
+            --revision 11e7900cdcac61bc4daf59e65feb238acda98fbf \
+            --include 'data/*'
 
       - name: Dry run
         run: |
@@ -169,7 +175,8 @@ jobs:
         run: |
           set -euo pipefail
           hf download openai/gdpval --repo-type dataset \
-            --revision 11e7900cdcac61bc4daf59e65feb238acda98fbf
+            --revision 11e7900cdcac61bc4daf59e65feb238acda98fbf \
+            --include 'data/*'
 
       # Read from the plan rather than written here. The deployment appears in
       # exactly one place in the repository, so a workflow cannot come to

--- a/.github/workflows/agentic-v2-stage-run.yml
+++ b/.github/workflows/agentic-v2-stage-run.yml
@@ -146,8 +146,14 @@ jobs:
       # The tests that hold what a paid run rests on: that the money question
       # is answered from the plan rather than from a sentence, that the cohort
       # binds to the seal it was priced under, that a task stops at its own
-      # ceiling, and that the tool list cannot reach the grader. Run before the
-      # dataset is fetched, so a broken runner fails in a minute.
+      # ceiling, that the tool list cannot reach the grader, and that the files
+      # a task was told to open are the ones that arrive in its workspace. Run
+      # before the dataset is fetched, so a broken runner fails in a minute.
+      #
+      # The last three were added after the staging code was written, because
+      # until then nothing in this job exercised the one part of the path that
+      # had never run in CI at all. A cohort can be perfectly priced, sealed and
+      # bound and still hand every task an empty directory.
       - name: Test the runner
         run: |
           set -euo pipefail
@@ -157,18 +163,35 @@ jobs:
             tests/test_agentic_v2_manifest_binding.py \
             tests/test_agentic_v2_conversation_runner.py \
             tests/test_agentic_v2_run_driver.py \
-            tests/test_free_checks_agree_on_the_loop.py
+            tests/test_free_checks_agree_on_the_loop.py \
+            tests/test_agentic_v2_reference_staging.py \
+            tests/test_agentic_v2_preregistration.py \
+            tests/test_run_agentic_v2_stage.py
 
       # No charge. The revision is the one the catalogue was built from and the
       # one every figure in the plan rests on; the binding hashes the wording it
       # reads and refuses a prompt that drifted from what was sealed.
+      #
+      # `--local-dir` rather than the default cache. The default writes a tree
+      # of symlinks pointing at a blob store outside it, and the staging code
+      # will not follow a link out of the root it was given. Measured against
+      # the real cache: 301 of 301 reference files are links and none is a
+      # regular file, so a cohort fetched the old way hands every one of the
+      # 125 tasks that name files an empty workspace -- and those failures then
+      # read as the model's. `--local-dir` writes the bytes.
+      #
+      # `deliverable_files` is left behind: 595 MB of reference answers that no
+      # inference run opens. Not fetching them is faster and is one fewer way
+      # for an answer to be sitting on the same disk as a workspace.
       - name: Fetch the pinned dataset
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           set -euo pipefail
           hf download openai/gdpval --repo-type dataset \
-            --revision 11e7900cdcac61bc4daf59e65feb238acda98fbf
+            --revision 11e7900cdcac61bc4daf59e65feb238acda98fbf \
+            --local-dir "$RUNNER_TEMP/gdpval-pinned" \
+            --exclude 'deliverable_files/*'
 
       # Printed as well as captured. The one-line JSON is for `fromJSON`; the
       # object beside it is for whoever has to decide whether a run that has
@@ -184,12 +207,17 @@ jobs:
           MATRIX="$(python scripts/plan_agentic_v2_shards.py --stage "$STAGE")"
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
+      # Where the reference files come from is derived from `--parquet`, so the
+      # prompts and the files a task opens can only ever be one revision. This
+      # is also the step that catches a dataset fetched the wrong way: it
+      # refuses before the paid job below is allowed to start.
       - name: Dry run
         run: |
           set -euo pipefail
           cd batch-runner
           python scripts/run_agentic_v2_stage.py \
-            --stage '${{ inputs.stage }}' --dry-run
+            --stage '${{ inputs.stage }}' --dry-run \
+            --parquet "$RUNNER_TEMP/gdpval-pinned/data/train-00000-of-00001.parquet"
 
   # ── The run that spends ─────────────────────────────────────────────────
   paid:
@@ -267,13 +295,18 @@ jobs:
           cd batch-runner
           python scripts/azure_oidc_identity_preflight.py --verify-session
 
+      # Fetched the same way as in the free job above, for the reason given
+      # there: the default cache is a farm of symlinks the staging code refuses
+      # to follow, so the files a task is told to open would never arrive.
       - name: Fetch the pinned dataset
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           set -euo pipefail
           hf download openai/gdpval --repo-type dataset \
-            --revision 11e7900cdcac61bc4daf59e65feb238acda98fbf
+            --revision 11e7900cdcac61bc4daf59e65feb238acda98fbf \
+            --local-dir "$RUNNER_TEMP/gdpval-pinned" \
+            --exclude 'deliverable_files/*'
 
       # Read from the plan rather than written here. The deployment appears in
       # exactly one place in the repository, so a workflow cannot come to
@@ -333,7 +366,8 @@ jobs:
           set -euo pipefail
           cd batch-runner
           ARGS=(--stage "$STAGE" --shard "$SHARD" \
-                --into "$GITHUB_WORKSPACE/agentic-v2-run")
+                --into "$GITHUB_WORKSPACE/agentic-v2-run" \
+                --parquet "$RUNNER_TEMP/gdpval-pinned/data/train-00000-of-00001.parquet")
           if [ -n "$RUN_ID" ]; then
             # Namespaced per shard even when a run id was given. The shards are
             # separate journals of separate tasks, and two jobs resuming the

--- a/batch-runner/core/agentic_v2_fixture_backend.py
+++ b/batch-runner/core/agentic_v2_fixture_backend.py
@@ -65,6 +65,14 @@ class AgenticV2FixtureBackend:
             os.close(self._root_fd)
             raise ValueError("fixture work root identity changed")
         self._root_identity = (opened.st_dev, opened.st_ino)
+        # `mkdir(mode=...)` above is ignored when the directory already exists,
+        # and it is subject to the umask when it does not, so neither call
+        # actually settles the mode. The provenance replay models this root as
+        # 0o700, so set it here through the verified descriptor rather than by
+        # path. Without this a work root prepared by someone else -- reference
+        # file staging creates it before the backend is built -- keeps the
+        # umask's 0o755 and every state digest disagrees with the model.
+        os.fchmod(self._root_fd, 0o700)
         self.profile = profile
         package_catalog_value = dict(
             {"python:demo-pkg==1.0.0": "d" * 64}
@@ -316,6 +324,44 @@ class AgenticV2FixtureBackend:
                 ):
                     self.work.rmdir()
         self.closed = True
+
+    def initial_workspace_declaration(self) -> list[dict]:
+        """What the workspace holds right now, for the run's opening event.
+
+        Called once, before the first tool call, so what it returns is the
+        starting point rather than a snapshot of anything the model did. The
+        replay in :mod:`core.agentic_v2_provenance` models this workspace from
+        the empty directory up and re-derives every result; a task handed its
+        input files starts somewhere else, and without being told where, the
+        replay rejects a run that was correct.
+
+        Digests and sizes rather than bytes -- the inputs reach hundreds of
+        megabytes and the trace would otherwise carry a copy of the dataset.
+        ``decodes_as_utf8`` is included because ``workspace_apply(read)``
+        decodes and the replay cannot tell from a digest whether a read should
+        have succeeded; without it, a backend reporting every input as
+        unreadable would be believed.
+        """
+        _, entries, _ = self._workspace_snapshot()
+        declaration = []
+        for entry in entries:
+            if entry["kind"] == "directory":
+                declaration.append({"path": entry["path"], "kind": "directory"})
+                continue
+            try:
+                self._read_bytes(entry["path"]).decode("utf-8")
+            except (UnicodeDecodeError, OSError, ValueError):
+                decodes = False
+            else:
+                decodes = True
+            declaration.append({
+                "path": entry["path"],
+                "kind": "file",
+                "sha256": entry["sha256"],
+                "size": entry["size"],
+                "decodes_as_utf8": decodes,
+            })
+        return declaration
 
     def _capabilities(self) -> dict:
         return foundation_fixture_identity(

--- a/batch-runner/core/agentic_v2_preregistration.py
+++ b/batch-runner/core/agentic_v2_preregistration.py
@@ -56,7 +56,13 @@ from typing import Any, Mapping, Sequence
 
 import yaml
 
+from core.agentic_compute import (
+    MAX_INPUT_FILES,
+    MAX_INPUT_SINGLE,
+    MAX_INPUT_TOTAL,
+)
 from core.agentic_v2_contract import TOOL_NAMES
+from core.agentic_v2_reference_staging import MODEL_INPUT_PREFIX, TOO_LARGE
 from core.execution_envelope_tasks import (
     ADVANCE_CHECK_TASK_COUNT,
     FULL_RUN_TASK_COUNT,
@@ -624,8 +630,181 @@ def _run_conditions() -> dict[str, Any]:
     }
 
 
+#: The files in the pinned dataset that cannot be handed to the task that names
+#: them, with the size that decides it.
+#:
+#: Recorded here rather than measured at generation time, because a
+#: pre-registration has to derive on a machine that has not downloaded the
+#: dataset -- the committed copy is checked against the code in CI, where the
+#: files are absent. A written-down size is normally the thing that goes stale;
+#: this one cannot, because the revision it was measured against is pinned in
+#: the manifest beside it, and :func:`verify_input_disposition` turns it back
+#: into a measurement anywhere the files are present.
+UNDELIVERABLE_INPUTS: tuple[dict[str, Any], ...] = (
+    {
+        "task_id": "a941b6d8-4289-4500-b45a-f8e4fc94a724",
+        "occupation": "Film and Video Editors",
+        "path": "reference_files/67469cf2a7509f149c095cf4f6542f6d/TWT_A001_03.mp4",
+        "size_bytes": 689_061_330,
+        "reason": TOO_LARGE,
+    },
+)
+
+
+def input_disposition(catalog: TaskCatalog | None = None) -> dict[str, Any]:
+    """What each cohort is given to work from, and what it cannot be given.
+
+    Written before the run because the alternative is writing it after, when
+    the only task in the two hundred and twenty that loses a file has already
+    produced a result -- and a shortfall explained afterwards reads as an
+    excuse for it, whatever the record says.
+
+    The shape of the problem is narrow enough to state exactly. Across the
+    three cohorts one file is undeliverable: a 689 MB clip, over the compute
+    contract's own per-file limit by 152 MB. It belongs to a Film and Video
+    Editors task that names two clips, so the task is not left with nothing --
+    it is left with half its footage, which is the more dangerous outcome,
+    because an edit made from half the material looks like a bad edit rather
+    than a missing input. Neither smaller stage contains that task, so the
+    first two stages have nothing refused at all.
+
+    No substitute is made. Subtitles, extracted frames or a summary would each
+    be a different task from the one the dataset states, and swapping one in
+    silently would mean reporting a score for work nobody set.
+    """
+    catalog = catalog or load_task_catalog()
+    chosen = cohorts(catalog)
+    by_id = catalog.by_task_id()
+    by_task: dict[str, list[dict[str, Any]]] = {}
+    for one in UNDELIVERABLE_INPUTS:
+        by_task.setdefault(str(one["task_id"]), []).append(dict(one))
+
+    per_stage: dict[str, Any] = {}
+    for stage in ESCALATION:
+        task_ids = chosen[stage]
+        tasks = [by_id[one] for one in task_ids if one in by_id]
+        naming = [one for one in tasks if one.reference_file_count]
+        refused = [
+            dict(entry, task_id=task_id)
+            for task_id in task_ids
+            for entry in by_task.get(str(task_id), ())
+        ]
+        per_stage[stage] = {
+            "tasks": len(task_ids),
+            "tasks_naming_reference_files": len(naming),
+            "files_named": sum(one.reference_file_count for one in naming),
+            "files_that_cannot_be_delivered": refused,
+        }
+
+    return {
+        "staged_into": (
+            f"{MODEL_INPUT_PREFIX}/ inside each task's own workspace, one "
+            "workspace per attempt, copied from the same revision the prompt "
+            "text comes from"
+        ),
+        "limits": {
+            "max_files_per_task": MAX_INPUT_FILES,
+            "max_bytes_per_file": MAX_INPUT_SINGLE,
+            "max_bytes_per_task": MAX_INPUT_TOTAL,
+            "come_from": "core/agentic_compute.py",
+        },
+        "per_stage": per_stage,
+        "no_substitute_is_made": (
+            "a file that cannot be delivered is recorded as not delivered. "
+            "Nothing is put in its place -- subtitles, frames or a summary "
+            "would each be a different task from the one the dataset sets, and "
+            "a score reported against a task nobody set is worse than a gap"
+        ),
+        "what_a_failure_there_does_not_show": (
+            "a task that ran without a file it named is not evidence about the "
+            "model. It is recorded with the missing file's name so the two "
+            "cannot be read as one"
+        ),
+        "how_to_check_this": (
+            "core.agentic_v2_preregistration.verify_input_disposition, against "
+            "a copy of the pinned revision"
+        ),
+    }
+
+
+def verify_input_disposition(
+    snapshot_root: Path, catalog: TaskCatalog | None = None
+) -> list[str]:
+    """Everything the recorded disposition gets wrong about the files on disk.
+
+    Both directions, and the second is the one worth having. That a recorded
+    size is still the file's size catches an edit; that no *other* file has
+    grown past a limit catches the case nobody would look for -- a cohort
+    quietly losing an input that no record mentions, which is indistinguishable
+    from a model that did the work badly.
+
+    Sizes are read through whatever the name points at, links included. That is
+    the opposite of what staging does, and deliberately: this is measuring the
+    dataset, not handing bytes to a model, and refusing to measure a cache
+    would leave the check unrunnable on the machine most likely to run it.
+    """
+    catalog = catalog or load_task_catalog()
+    by_id = catalog.by_task_id()
+    recorded = {str(one["path"]): one for one in UNDELIVERABLE_INPUTS}
+    wrong: list[str] = []
+
+    for path, entry in recorded.items():
+        full = snapshot_root / path
+        if not full.exists():
+            wrong.append(f"{path} is recorded as undeliverable but is not present")
+            continue
+        size = full.stat().st_size
+        if size != entry["size_bytes"]:
+            wrong.append(
+                f"{path} is recorded as {entry['size_bytes']} bytes and is "
+                f"{size}. The pinned revision is supposed to make that "
+                "impossible, so either the root is a different revision or the "
+                "record was edited"
+            )
+        elif size <= MAX_INPUT_SINGLE:
+            wrong.append(
+                f"{path} is recorded as undeliverable but {size} bytes is "
+                f"within the {MAX_INPUT_SINGLE} byte limit"
+            )
+
+    for task_id in full_run_tasks(catalog):
+        task = by_id.get(str(task_id))
+        if task is None:
+            continue
+        running = 0
+        for path in task.reference_file_paths:
+            full = snapshot_root / path
+            if not full.exists():
+                wrong.append(f"{path}, named by {task_id}, is not in the snapshot")
+                continue
+            size = full.stat().st_size
+            running += size
+            if size > MAX_INPUT_SINGLE and path not in recorded:
+                wrong.append(
+                    f"{path}, named by {task_id}, is {size} bytes and over the "
+                    f"{MAX_INPUT_SINGLE} byte limit, and no record says so. A "
+                    "cohort would lose it without anything having planned for it"
+                )
+        if running > MAX_INPUT_TOTAL:
+            wrong.append(
+                f"{task_id} names {running} bytes in total, over the "
+                f"{MAX_INPUT_TOTAL} byte limit, and no record says so"
+            )
+        if task.reference_file_count > MAX_INPUT_FILES:
+            wrong.append(
+                f"{task_id} names {task.reference_file_count} files, over the "
+                f"{MAX_INPUT_FILES} file limit, and no record says so"
+            )
+
+    return wrong
+
+
 def record(catalog: TaskCatalog | None = None) -> dict[str, Any]:
     """The whole pre-registration, as it is committed before anything runs."""
+    # Loaded once and handed down. Two sections derive from the catalogue and
+    # each would otherwise load its own copy, which is slower and -- worse --
+    # would let one section describe a catalogue the other had not read.
+    catalog = catalog or load_task_catalog()
     comparisons = compare_with_codex_run()
     allowed, blockers = may_attribute_difference_to_environment(comparisons)
     body = {
@@ -637,6 +816,7 @@ def record(catalog: TaskCatalog | None = None) -> dict[str, Any]:
         "escalation": list(ESCALATION),
         "manifest": manifest(catalog),
         "run_conditions": _run_conditions(),
+        "inputs": input_disposition(catalog),
         "comparison_with_codex": {
             "source": str(CODEX_TRIAL_PLAN.relative_to(REPOSITORY_ROOT)),
             # The basis of the comparison, fingerprinted. If A's file moves, the

--- a/batch-runner/core/agentic_v2_preregistration.py
+++ b/batch-runner/core/agentic_v2_preregistration.py
@@ -62,7 +62,12 @@ from core.agentic_compute import (
     MAX_INPUT_TOTAL,
 )
 from core.agentic_v2_contract import TOOL_NAMES
-from core.agentic_v2_reference_staging import MODEL_INPUT_PREFIX, TOO_LARGE
+from core.agentic_v2_reference_staging import (
+    MODEL_INPUT_PREFIX,
+    TOO_LARGE,
+    TOO_LARGE_FOR_THE_WORKSPACE,
+    WORKSPACE_FILE_LIMIT,
+)
 from core.execution_envelope_tasks import (
     ADVANCE_CHECK_TASK_COUNT,
     FULL_RUN_TASK_COUNT,
@@ -651,6 +656,70 @@ UNDELIVERABLE_INPUTS: tuple[dict[str, Any], ...] = (
 )
 
 
+#: How many of the files the 220 tasks name the model could open by itself, if
+#: nothing were rendered for it.
+#:
+#: Measured by decoding every one of them as UTF-8 against the pinned revision,
+#: because that is exactly what ``workspace_apply(read)`` does and the only way
+#: the model can open anything while ``exec_run`` is shut. Three succeed: two
+#: CAD ``.STEP`` files, which are plain text, and one ``.txt``. The other 258 do
+#: not, and no amount of retrying changes that.
+#:
+#: This is the figure that decides whether a V2 result is about the model at
+#: all, so it is recorded rather than described. Before the renderings existed,
+#: a run of 220 tasks would have been 220 models writing from the prompt alone.
+FILES_THE_MODEL_COULD_OPEN_UNAIDED = 3
+FILES_NAMED_BY_THE_TASKS = 261
+
+
+#: The files that fit the compute contract but not the fixture workspace, with
+#: what a text rendering recovers from each.
+#:
+#: A second limit, found after the first and much worse behaved. The fixture
+#: workspace applies a 1 MiB per-file limit during a walk over everything it
+#: holds, and that walk runs on *write* -- so one oversized file staged anywhere
+#: under the workspace does not cost the task that file, it costs the task every
+#: deliverable it would ever write. The model is told only
+#: ``fixture_backend_error``, so it retries until its call budget is gone, and
+#: the record afterwards shows a model that produced nothing.
+#:
+#: Recorded by name for the same reason as the list above, and with the same
+#: consequence if it is wrong: a cohort losing an input that nothing planned for
+#: is indistinguishable from a model doing the work badly.
+#:
+#: ``rendered_characters`` is what :mod:`core.file_reader` reads out of the
+#: original, measured against the same revision. Five of the twenty-four hold
+#: real text -- a 14.5 MB spreadsheet comes back as 1,973 characters. Eighteen
+#: are recordings, archives or images, where the reader returns a label and the
+#: model is no worse off than before. One, a scanned PDF, renders to nothing.
+OVER_THE_WORKSPACE_FILE_LIMIT: tuple[dict[str, Any], ...] = (
+    {"task_id": "a941b6d8-4289-4500-b45a-f8e4fc94a724", "occupation": "Film and Video Editors", "path": "reference_files/67469cf2a7509f149c095cf4f6542f6d/TWT_A001_03.mp4", "size_bytes": 689_061_330, "rendered_characters": 129},
+    {"task_id": "75401f7c-396d-406d-b08e-938874ad1045", "occupation": "Film and Video Editors", "path": "reference_files/04fe2846f45b476d5231b53beeae767a/reel footage.zip", "size_bytes": 333_716_426, "rendered_characters": 39},
+    {"task_id": "a941b6d8-4289-4500-b45a-f8e4fc94a724", "occupation": "Film and Video Editors", "path": "reference_files/d88a33c7e63981a67e899cc8c1347ece/TWT_001_02.mp4", "size_bytes": 230_703_477, "rendered_characters": 127},
+    {"task_id": "4b894ae3-1f23-4560-b13d-07ed1132074e", "occupation": "Audio and Video Technicians", "path": "reference_files/10844d4ba6b1f18120245109db76f403/State of Affairs_STEM_DRUMS.wav", "size_bytes": 58_752_102, "rendered_characters": 146},
+    {"task_id": "4b894ae3-1f23-4560-b13d-07ed1132074e", "occupation": "Audio and Video Technicians", "path": "reference_files/2adacf89b84661aadd0c80d91a81fb73/State of Affairs_ROUGHMIX.wav", "size_bytes": 58_752_102, "rendered_characters": 144},
+    {"task_id": "4b894ae3-1f23-4560-b13d-07ed1132074e", "occupation": "Audio and Video Technicians", "path": "reference_files/88944520f1ce15927dd5a6a08d3ee9b2/State of Affairs_STEM_ORGAN.wav", "size_bytes": 58_752_102, "rendered_characters": 146},
+    {"task_id": "38889c3b-e3d4-49c8-816a-3cc8e5313aba", "occupation": "Audio and Video Technicians", "path": "reference_files/028fb83486152124cfecf2667c3cef37/DRUM REFERENCE TRACK.wav", "size_bytes": 33_554_432, "rendered_characters": 139},
+    {"task_id": "4b894ae3-1f23-4560-b13d-07ed1132074e", "occupation": "Audio and Video Technicians", "path": "reference_files/073946a18125717bdad58178466039fd/State of Affairs_STEM_BASS.wav", "size_bytes": 33_554_432, "rendered_characters": 145},
+    {"task_id": "4b894ae3-1f23-4560-b13d-07ed1132074e", "occupation": "Audio and Video Technicians", "path": "reference_files/48836e54ef271e8fd1a301d3e20ea470/State of Affairs_STEM_ACGTRS.wav", "size_bytes": 33_554_432, "rendered_characters": 147},
+    {"task_id": "ff85ee58-bc9f-4aa2-806d-87edeabb1b81", "occupation": "Audio and Video Technicians", "path": "reference_files/ca53448cbec7b57b575d9d0e229f08c4/TAVARUA_MUSIC ONLY.wav", "size_bytes": 32_140_902, "rendered_characters": 137},
+    {"task_id": "ff85ee58-bc9f-4aa2-806d-87edeabb1b81", "occupation": "Audio and Video Technicians", "path": "reference_files/758a72de9d221d7aa2707e554c20459d/TAVARUA_SAX RAW.wav", "size_bytes": 22_031_470, "rendered_characters": 133},
+    {"task_id": "11593a50-734d-4449-b5b4-f8986a133fd8", "occupation": "Real Estate Sales Agents", "path": "reference_files/1e15759c2909d91e9cd6024813a1a1f7/Massabama active listings.xlsx", "size_bytes": 14_509_694, "rendered_characters": 1_973},
+    {"task_id": "57b2cdf2-ad62-4591-aa91-aad489740320", "occupation": "Private Detectives and Investigators", "path": "reference_files/74e9b9b1de3156972930ebb7d4d5321a/Photographs.zip", "size_bytes": 9_507_893, "rendered_characters": 36},
+    {"task_id": "45c6237b-f9c9-4526-9a8d-6a5c404624ec", "occupation": "First-Line Supervisors of Retail Sales Workers", "path": "reference_files/2c0a245a7c98c858b2ae975c7bbab3b6/ORDER LIST.pdf", "size_bytes": 6_984_257, "rendered_characters": 0},
+    {"task_id": "75401f7c-396d-406d-b08e-938874ad1045", "occupation": "Film and Video Editors", "path": "reference_files/9f47a167476d2ff6ecc485f97e8341c9/action-energetic-rock-music-334316.mp3", "size_bytes": 5_302_229, "rendered_characters": 145},
+    {"task_id": "a46d5cd2-55fe-48fa-a4c6-6aaf6b9991b5", "occupation": "Private Detectives and Investigators", "path": "reference_files/f4c7bfae38d21c8ad4f4b624d194aab4/Photographs.zip", "size_bytes": 4_415_094, "rendered_characters": 36},
+    {"task_id": "3a4c347c-4aec-43c7-9a54-eb1f816ab1f9", "occupation": "Editors", "path": "reference_files/1389fc5af6430c02dd7bd93c7ce05cc7/Boilerplate.docx", "size_bytes": 2_898_134, "rendered_characters": 2_456},
+    {"task_id": "46b34f78-6c06-4416-87e2-77b6d8b20ce9", "occupation": "Financial and Investment Analysts", "path": "reference_files/40407caad9b871b09e3a075bdd971b15/Research Material.docx", "size_bytes": 2_799_328, "rendered_characters": 105},
+    {"task_id": "01d7e53e-0513-4109-a242-8ccaf442cd21", "occupation": "Recreation Workers", "path": "reference_files/21f10d79c065e77a3e36c952a0c3b3b8/Recreare Parks & Recreation Summer Fun Facilities.docx", "size_bytes": 2_315_023, "rendered_characters": 2_615},
+    {"task_id": "5d0feb24-e8b6-4ace-b64f-d5cd1a8b563d", "occupation": "News Analysts, Reporters, and Journalists", "path": "reference_files/c575a5476fac2f921cfd192ca5c48622/TRAPPIST-1 Reporter Draft.docx", "size_bytes": 1_913_096, "rendered_characters": 4_446},
+    {"task_id": "f2986c1f-2bbf-4b83-bc93-624a9d617f45", "occupation": "Pharmacists", "path": "reference_files/8860a54103b6edb9313d04c0f4434980/what are these.jpg", "size_bytes": 1_800_970, "rendered_characters": 49},
+    {"task_id": "4d1a8410-e9c5-4be5-ab43-cc55563c594c", "occupation": "First-Line Supervisors of Office and Administrative Support Workers", "path": "reference_files/6940c7b0ba1ffdcbce4266eba053a9e4/Floor Layout for Interviews.png", "size_bytes": 1_675_294, "rendered_characters": 63},
+    {"task_id": "3c19c6d1-672c-467a-8437-6fe21afb8eae", "occupation": "Project Management Specialists", "path": "reference_files/ca6c768fe272f61c00d001c884c42237/INPUT 4 BridgeMind AI POC deployment PROJECT LOG.docx", "size_bytes": 1_398_074, "rendered_characters": 8_794},
+    {"task_id": "ff85ee58-bc9f-4aa2-806d-87edeabb1b81", "occupation": "Audio and Video Technicians", "path": "reference_files/7b740f4720fe70f8b445fd059e1912f5/TAVARUA_SAX REFERENCE MP3.mp3", "size_bytes": 1_094_950, "rendered_characters": 135},
+)
+
+
 def input_disposition(catalog: TaskCatalog | None = None) -> dict[str, Any]:
     """What each cohort is given to work from, and what it cannot be given.
 
@@ -671,6 +740,27 @@ def input_disposition(catalog: TaskCatalog | None = None) -> dict[str, Any]:
     No substitute is made. Subtitles, extracted frames or a summary would each
     be a different task from the one the dataset states, and swapping one in
     silently would mean reporting a score for work nobody set.
+
+    Two later measurements sit underneath that and change what a result means.
+
+    *Almost nothing here can be opened.* The model's only reader decodes UTF-8,
+    and 258 of the 261 files fail to decode. Without help, a run of 220 tasks
+    would be 220 models writing from the prompt alone while their inputs sat
+    unopened beside them — and every one of those results would look like the
+    model's work. A text rendering is therefore staged beside each file that has
+    one. That is a compensation, it is lossy, and it is a difference from the
+    Codex run, whose model has a shell and opens these files itself. It is
+    recorded in all three of those terms rather than as a fix.
+
+    *A second size limit costs a task everything, not one file.* Twenty-four
+    files sit under the compute contract's per-file limit and over the fixture
+    workspace's, and the workspace applies its limit while walking everything it
+    holds — on write. One of them staged, and the task can write no deliverable
+    at all. Nought of the five advance-check tasks are affected, three of the
+    thirty, sixteen of the two hundred and twenty: stage one would have passed
+    clean and stage two would have failed about a fifth of the time for no
+    visible reason. They are refused by name instead, and the text inside them,
+    where there is any, is rendered.
     """
     catalog = catalog or load_task_catalog()
     chosen = cohorts(catalog)
@@ -678,6 +768,9 @@ def input_disposition(catalog: TaskCatalog | None = None) -> dict[str, Any]:
     by_task: dict[str, list[dict[str, Any]]] = {}
     for one in UNDELIVERABLE_INPUTS:
         by_task.setdefault(str(one["task_id"]), []).append(dict(one))
+    over_limit_by_task: dict[str, list[dict[str, Any]]] = {}
+    for one in OVER_THE_WORKSPACE_FILE_LIMIT:
+        over_limit_by_task.setdefault(str(one["task_id"]), []).append(dict(one))
 
     per_stage: dict[str, Any] = {}
     for stage in ESCALATION:
@@ -689,11 +782,20 @@ def input_disposition(catalog: TaskCatalog | None = None) -> dict[str, Any]:
             for task_id in task_ids
             for entry in by_task.get(str(task_id), ())
         ]
+        over_limit = [
+            dict(entry, task_id=task_id)
+            for task_id in task_ids
+            for entry in over_limit_by_task.get(str(task_id), ())
+        ]
         per_stage[stage] = {
             "tasks": len(task_ids),
             "tasks_naming_reference_files": len(naming),
             "files_named": sum(one.reference_file_count for one in naming),
             "files_that_cannot_be_delivered": refused,
+            "files_too_large_for_the_workspace": over_limit,
+            "tasks_affected_by_the_workspace_limit": len(
+                {str(one["task_id"]) for one in over_limit}
+            ),
         }
 
     return {
@@ -707,8 +809,56 @@ def input_disposition(catalog: TaskCatalog | None = None) -> dict[str, Any]:
             "max_bytes_per_file": MAX_INPUT_SINGLE,
             "max_bytes_per_task": MAX_INPUT_TOTAL,
             "come_from": "core/agentic_compute.py",
+            "max_bytes_per_file_in_the_workspace": WORKSPACE_FILE_LIMIT,
+            "the_workspace_limit_comes_from": (
+                "core/agentic_v2_fixture_backend.py, and it is enforced while "
+                "walking the whole workspace rather than on the file being "
+                "touched. The walk runs on write, so one file over it stops the "
+                "task writing anything at all and the model is told only "
+                "fixture_backend_error"
+            ),
         },
         "per_stage": per_stage,
+        "what_the_model_can_open_by_itself": {
+            "files_named_by_the_tasks": FILES_NAMED_BY_THE_TASKS,
+            "files_that_decode_as_utf8": FILES_THE_MODEL_COULD_OPEN_UNAIDED,
+            "how_that_was_measured": (
+                "every one of them decoded as UTF-8 against the pinned "
+                "revision, which is what workspace_apply(read) does. Two CAD "
+                ".STEP files and one .txt succeed; the other 258 do not"
+            ),
+            "why_it_matters": (
+                "with exec_run shut there is no shell, no pandas and no PDF "
+                "library, so a read is the only way in. A model that cannot "
+                "open its inputs and writes from the prompt alone produces a "
+                "result that looks exactly like a model that did the work badly"
+            ),
+        },
+        "text_renderings": {
+            "what_they_are": (
+                "a text extraction made by core.file_reader and staged beside "
+                f"the file it came from, under {MODEL_INPUT_PREFIX}/extracted/. "
+                "All 261 files extract without error; what comes out is text "
+                "for spreadsheets, PDFs and documents, and a one-line label for "
+                "images, recordings and archives"
+            ),
+            "never_a_replacement": (
+                "the original stays where it is whenever it can be staged, and "
+                "a rendering is never presented as the file. Layout, images, "
+                "styling and anything a picture carries are lost, and a long "
+                "one is cut to fit the workspace limit and says so at the cut"
+            ),
+            "this_is_a_difference_from_the_codex_run": (
+                "A's model has a real shell and opens these files itself. A V2 "
+                "result on a task whose work needed what a rendering loses is "
+                "not comparable to A's result on the same task, and this is the "
+                "record that says so before either is run"
+            ),
+            "how_to_check_this": (
+                "core.agentic_v2_reference_staging.stage_task_reference_files "
+                "with render_text=True, and the per-file outcomes it records"
+            ),
+        },
         "no_substitute_is_made": (
             "a file that cannot be delivered is recorded as not delivered. "
             "Nothing is put in its place -- subtitles, frames or a summary "
@@ -718,13 +868,38 @@ def input_disposition(catalog: TaskCatalog | None = None) -> dict[str, Any]:
         "what_a_failure_there_does_not_show": (
             "a task that ran without a file it named is not evidence about the "
             "model. It is recorded with the missing file's name so the two "
-            "cannot be read as one"
+            "cannot be read as one. Nor is a task that was handed files it "
+            "could not open: that one is recorded separately again, because a "
+            "task holding only unreadable files has nothing refused and would "
+            "otherwise be indistinguishable from a task given everything"
         ),
         "how_to_check_this": (
-            "core.agentic_v2_preregistration.verify_input_disposition, against "
-            "a copy of the pinned revision"
+            "core.agentic_v2_preregistration.verify_input_disposition for the "
+            "sizes and core.agentic_v2_preregistration.verify_reader_reach for "
+            "what can be opened, both against a copy of the pinned revision"
         ),
     }
+
+
+def _decodes_as_utf8(path: Path) -> bool:
+    """Whether the model's reader could open this file at all.
+
+    Streamed and abandoned at the first bad byte rather than read whole, because
+    the largest file here is 689 MB and the answer for it is settled inside the
+    first few. Incremental rather than chunk-by-chunk decoding, so a multi-byte
+    character split across a chunk boundary is not mistaken for binary.
+    """
+    import codecs
+
+    decoder = codecs.getincrementaldecoder("utf-8")()
+    try:
+        with path.open("rb") as handle:
+            while chunk := handle.read(65536):
+                decoder.decode(chunk)
+            decoder.decode(b"", final=True)
+    except (UnicodeDecodeError, OSError):
+        return False
+    return True
 
 
 def verify_input_disposition(
@@ -746,6 +921,9 @@ def verify_input_disposition(
     catalog = catalog or load_task_catalog()
     by_id = catalog.by_task_id()
     recorded = {str(one["path"]): one for one in UNDELIVERABLE_INPUTS}
+    over_workspace = {
+        str(one["path"]): one for one in OVER_THE_WORKSPACE_FILE_LIMIT
+    }
     wrong: list[str] = []
 
     for path, entry in recorded.items():
@@ -767,6 +945,27 @@ def verify_input_disposition(
                 f"within the {MAX_INPUT_SINGLE} byte limit"
             )
 
+    for path, entry in over_workspace.items():
+        full = snapshot_root / path
+        if not full.exists():
+            wrong.append(
+                f"{path} is recorded as over the workspace file limit but is "
+                "not present"
+            )
+            continue
+        size = full.stat().st_size
+        if size != entry["size_bytes"]:
+            wrong.append(
+                f"{path} is recorded as {entry['size_bytes']} bytes and is "
+                f"{size}, so the workspace-limit record was measured against "
+                "something other than this revision"
+            )
+        elif size <= WORKSPACE_FILE_LIMIT:
+            wrong.append(
+                f"{path} is recorded as over the workspace file limit but "
+                f"{size} bytes is within the {WORKSPACE_FILE_LIMIT} byte limit"
+            )
+
     for task_id in full_run_tasks(catalog):
         task = by_id.get(str(task_id))
         if task is None:
@@ -785,6 +984,17 @@ def verify_input_disposition(
                     f"{MAX_INPUT_SINGLE} byte limit, and no record says so. A "
                     "cohort would lose it without anything having planned for it"
                 )
+            if size > WORKSPACE_FILE_LIMIT and path not in over_workspace:
+                # The one worth having. An unrecorded file in this band does not
+                # cost its task that file, it costs the task every deliverable,
+                # and the model is told nothing usable about why.
+                wrong.append(
+                    f"{path}, named by {task_id}, is {size} bytes and over the "
+                    f"{WORKSPACE_FILE_LIMIT} byte workspace limit, and no "
+                    "record says so. Staged, that task could write nothing at "
+                    "all and would read afterwards as a model that produced "
+                    "nothing"
+                )
         if running > MAX_INPUT_TOTAL:
             wrong.append(
                 f"{task_id} names {running} bytes in total, over the "
@@ -796,6 +1006,57 @@ def verify_input_disposition(
                 f"{MAX_INPUT_FILES} file limit, and no record says so"
             )
 
+    return wrong
+
+
+def verify_reader_reach(
+    snapshot_root: Path, catalog: TaskCatalog | None = None
+) -> list[str]:
+    """Whether the model could still open only three of its own input files.
+
+    Kept apart from :func:`verify_input_disposition` because the two ask
+    different questions of the same files. That one reads sizes, which a tree of
+    empty files can answer; this one reads contents, which only the real bytes
+    can. Merged, the size check would have to be run against real data to pass,
+    and the machine most likely to run it has none.
+
+    The figure matters more than its precision. If it moves upward, some file
+    became readable and the renderings matter less; if it moves downward, a run
+    is closer to 220 models writing from the prompt alone. Either way the
+    pre-registration describes a different experiment from the one that ran.
+    """
+    catalog = catalog or load_task_catalog()
+    by_id = catalog.by_task_id()
+    missing: list[str] = []
+    readable = 0
+    seen = 0
+
+    for task_id in full_run_tasks(catalog):
+        task = by_id.get(str(task_id))
+        if task is None:
+            continue
+        for path in task.reference_file_paths:
+            full = snapshot_root / path
+            if not full.exists():
+                missing.append(f"{path}, named by {task_id}, is not in the snapshot")
+                continue
+            seen += 1
+            if _decodes_as_utf8(full):
+                readable += 1
+
+    wrong = list(missing)
+    if seen != FILES_NAMED_BY_THE_TASKS:
+        wrong.append(
+            f"{seen} files were measured and the record is written about "
+            f"{FILES_NAMED_BY_THE_TASKS}"
+        )
+    if readable != FILES_THE_MODEL_COULD_OPEN_UNAIDED:
+        wrong.append(
+            f"{readable} of the named files decode as UTF-8, and the record "
+            f"says {FILES_THE_MODEL_COULD_OPEN_UNAIDED}. That figure is what "
+            "decides whether a result is about the model, so a record that has "
+            "it wrong is worse than none"
+        )
     return wrong
 
 

--- a/batch-runner/core/agentic_v2_preregistration.py
+++ b/batch-runner/core/agentic_v2_preregistration.py
@@ -632,6 +632,25 @@ def _run_conditions() -> dict[str, Any]:
             "comes first. A task stopped by a ceiling is recorded as stopped "
             "by that ceiling and is not a model failure"
         ),
+        # Registered as a condition of the run rather than quietly fixed before
+        # it. `dispatch_one` ends a task on the first tool call that comes back
+        # not-ok: the model is told nothing and gets no second attempt, so one
+        # mistyped path costs the task and everything already spent on it.
+        # Changing that changes what a trace contains, which is a reviewable
+        # change of its own and not one to slip in beside the run it would
+        # alter. Written down instead, so a run where it fires often is read as
+        # a run under this condition rather than as a model that kept giving up.
+        "one_failed_tool_call_ends_the_task": {
+            "holds": True,
+            "the_model_is_told": "nothing, and is not asked for another turn",
+            "recorded_as": "stop_reason tool_desk_broke",
+            "is_not": (
+                "evidence about the model. It is the desk closing on the "
+                "first mistake, and a task that ends this way says what the "
+                "call was and what came back"
+            ),
+            "comes_from": "core/agentic_v2_runner.py dispatch_one",
+        },
     }
 
 

--- a/batch-runner/core/agentic_v2_provenance.py
+++ b/batch-runner/core/agentic_v2_provenance.py
@@ -778,6 +778,62 @@ def _terminal_finalize_event(private_trace: Mapping[str, Any]) -> dict:
     return terminal
 
 
+def _valid_initial_workspace(value: Any) -> bool:
+    """Is this a usable statement of what the workspace held before turn one?
+
+    Optional, and absent means empty -- which is what every run before staged
+    inputs was, so an old record still verifies unchanged and a backend that
+    does not declare one is held to the stricter starting point rather than a
+    looser one.
+
+    Ordering is required, not merely checked: the replay rebuilds the state
+    digest from this list and the backend built its own from a sorted walk. Two
+    lists with the same entries in different orders describe the same directory
+    and produce different digests, so an unordered declaration would fail
+    verification in a way that looks like tampering.
+    """
+    if not isinstance(value, list):
+        return False
+    seen: list[str] = []
+    for entry in value:
+        if not isinstance(entry, dict):
+            return False
+        kind = entry.get("kind")
+        if kind == "directory":
+            if set(entry) != {"path", "kind"}:
+                return False
+        elif kind == "file":
+            if set(entry) != {
+                "path", "kind", "sha256", "size", "decodes_as_utf8"
+            }:
+                return False
+            if not is_sha256(entry.get("sha256")):
+                return False
+            if not isinstance(entry.get("size"), int) or entry["size"] < 0:
+                return False
+            if not isinstance(entry.get("decodes_as_utf8"), bool):
+                return False
+        else:
+            return False
+        path = entry.get("path")
+        if not isinstance(path, str) or path == ".":
+            return False
+        try:
+            canonical = canonical_relative_path(path)
+        except ValueError:
+            # `canonical_relative_path` raises on anything that climbs out or
+            # is not a relative POSIX path. This is a predicate and its caller
+            # is a shape check, so a bad declaration has to come back as False
+            # here -- letting the exception through would turn "this record is
+            # invalid", which the chain knows how to report, into an unhandled
+            # error partway up the verifier.
+            return False
+        if canonical != path:
+            return False
+        seen.append(path)
+    return len(set(seen)) == len(seen)
+
+
 def _valid_started_payload(value: Any) -> bool:
     """Is this a startup event a run record may be built on?
 
@@ -797,10 +853,14 @@ def _valid_started_payload(value: Any) -> bool:
     only. Admitting a second backend is not the same as lifting that brake, and
     this is the line that keeps the two apart.
     """
-    if not isinstance(value, dict) or set(value) != {
+    if not isinstance(value, dict) or set(value) - {"initial_workspace"} != {
         "run_id", "condition", "task_id", "backend_identity", "capabilities",
         "policy_profile_id", "runtime",
     }:
+        return False
+    if "initial_workspace" in value and not _valid_initial_workspace(
+        value["initial_workspace"]
+    ):
         return False
     identity = value.get("backend_identity")
     capabilities = value.get("capabilities")
@@ -1286,6 +1346,7 @@ def _verify_fixture_result_semantics(
         arguments,
         semantic_ledger,
         canonical=canonical,
+        recorded=result,
     )
     expected_state_after = _fixture_state_sha256(semantic_ledger)
     expected_result = _fixture_result_envelope(
@@ -1374,17 +1435,86 @@ def _fixture_executed_error(
     return value
 
 
+@dataclass
+class _StagedFile:
+    """A file the workspace already held when the task began.
+
+    The replay models the fixture workspace from the empty directory the
+    backend opens, and re-derives every result from the calls that follow. That
+    is exact while the workspace starts empty. It stops being exact the moment a
+    task is given its input files, because the bytes arrived before the first
+    event and nothing in the trace says what they were -- which is why every
+    task with reference files failed verification with ``initial fixture state
+    mismatch`` and was recorded as a runner defect after finishing normally.
+
+    Held as a digest and a size rather than as bytes: the inputs run to
+    hundreds of megabytes across the 220 tasks, and putting them in the trace
+    would make each record carry a copy of the dataset. ``content`` is filled in
+    if the run reads the file whole, and only after the bytes in the recorded
+    result have been checked against ``sha256`` -- so the replay is using the
+    file it was told was staged, not whatever the result happened to contain.
+
+    ``decodes_as_utf8`` is declared because the replay cannot work it out from a
+    digest, and ``workspace_apply(read)`` decodes. Without it a backend could
+    report any file as unreadable and the replay would have to agree.
+    """
+
+    sha256: str
+    size: int
+    decodes_as_utf8: bool
+    content: bytes | None = None
+
+
+def _size_of(value: Any) -> int:
+    return value.size if isinstance(value, _StagedFile) else len(value)
+
+
+def _digest_of(value: Any) -> str:
+    return (
+        value.sha256
+        if isinstance(value, _StagedFile)
+        else hashlib.sha256(value).hexdigest()
+    )
+
+
+def _bytes_of(value: Any) -> bytes:
+    """The real bytes, or a refusal to pretend they are known.
+
+    Raised rather than returned as a tool error, because a tool error is a
+    verdict about the run and this is the replay saying it cannot reach one.
+    """
+    if isinstance(value, _StagedFile):
+        if value.content is None:
+            raise ValueError(
+                "agentic v2 staged file bytes are not in the trace, so this "
+                "call cannot be re-derived"
+            )
+        return value.content
+    return value
+
+
 def _new_fixture_semantic_ledger(started_payload: Mapping[str, Any]) -> dict:
     runtime = started_payload["runtime"]
     canonical = foundation_fixture_identity(
         started_payload["policy_profile_id"], runtime["budget_caps"]
     )
+    directories = {"."}
+    files: dict[str, Any] = {}
+    for entry in started_payload.get("initial_workspace") or ():
+        if entry["kind"] == "directory":
+            directories.add(str(entry["path"]))
+        else:
+            files[str(entry["path"])] = _StagedFile(
+                sha256=str(entry["sha256"]),
+                size=int(entry["size"]),
+                decodes_as_utf8=bool(entry["decodes_as_utf8"]),
+            )
     return {
         "profile": started_payload["policy_profile_id"],
         "budget_caps": deepcopy(runtime["budget_caps"]),
         "package_records": tuple(canonical["package_records"]),
-        "directories": {"."},
-        "files": {},
+        "directories": directories,
+        "files": files,
         "resolved_locks": set(),
         "active_locks": set(),
         "terminal_identity": None,
@@ -1488,8 +1618,8 @@ def _fixture_state_sha256(ledger: Mapping[str, Any]) -> str:
                 entries.append({
                     "path": path,
                     "kind": "file",
-                    "sha256": hashlib.sha256(content).hexdigest(),
-                    "size": len(content),
+                    "sha256": _digest_of(content),
+                    "size": _size_of(content),
                     "mode": 0o600,
                 })
 
@@ -1514,6 +1644,7 @@ def _replay_fixture_tool(
     ledger: dict[str, Any],
     *,
     canonical: Mapping[str, Any],
+    recorded: Any = None,
 ) -> dict:
     if name == "capabilities_query":
         kind = arguments["kind"]
@@ -1525,7 +1656,7 @@ def _replay_fixture_tool(
             },
         }
     if name == "workspace_apply":
-        return _replay_workspace_apply(arguments, ledger)
+        return _replay_workspace_apply(arguments, ledger, recorded=recorded)
     if name == "exec_run":
         return _replay_exec_run(arguments, ledger)
     if name == "environment_resolve":
@@ -1542,6 +1673,8 @@ def _replay_fixture_tool(
 def _replay_workspace_apply(
     arguments: Mapping[str, Any],
     ledger: dict[str, Any],
+    *,
+    recorded: Any = None,
 ) -> dict:
     operation = arguments["operation"]
     if operation == "copy":
@@ -1569,6 +1702,10 @@ def _replay_workspace_apply(
         content = ledger["files"].get(path)
         if content is None:
             return {"ok": False, "error_type": "fixture_backend_error"}
+        if isinstance(content, _StagedFile):
+            if not content.decodes_as_utf8:
+                return {"ok": False, "error_type": "fixture_backend_error"}
+            content = _learn_staged_bytes(content, arguments, recorded)
         try:
             text = content.decode("utf-8")
         except UnicodeDecodeError:
@@ -1613,6 +1750,60 @@ def _replay_workspace_apply(
     return {"ok": True, "data": {"path": path}}
 
 
+def _learn_staged_bytes(
+    staged: _StagedFile,
+    arguments: Mapping[str, Any],
+    recorded: Any,
+) -> bytes:
+    """Take a staged file's bytes from the recorded read, once they check out.
+
+    The replay does not hold the inputs, so a read of one cannot be re-derived
+    from the model alone. What it can do is refuse to accept bytes that are not
+    the ones the run was told it staged: the digest and the length come from the
+    startup declaration, which was made before the call, and the content comes
+    from the result being checked. A backend that returned a different file, a
+    truncated file, or a file it had quietly rewritten fails here.
+
+    Only a whole read teaches. A slice hashes to nothing the declaration knows,
+    so there is no check to pass, and accepting it would be the replay agreeing
+    with itself. The run is refused instead -- loudly, because a quiet downgrade
+    of a verification is worse than the thing it was verifying.
+    """
+    if staged.content is not None:
+        return staged.content
+    if int(arguments.get("offset", 0)) != 0:
+        raise ValueError(
+            "agentic v2 staged file was read from an offset, so the bytes "
+            "cannot be checked against what was staged"
+        )
+    if not isinstance(recorded, Mapping) or recorded.get("ok") is not True:
+        raise ValueError(
+            "agentic v2 staged file read has no result to take its bytes from"
+        )
+    text = (recorded.get("data") or {}).get("content")
+    if not isinstance(text, str):
+        raise ValueError("agentic v2 staged file read returned no content")
+    content = text.encode("utf-8")
+    # Against what was staged, not against what came back. A read cut short by
+    # a limit returns exactly that many characters, so comparing the limit to
+    # the returned length compares a number with itself and can never fire --
+    # the truncation then falls through to the digest check, which does refuse
+    # it, but under a message that says the backend returned the wrong bytes.
+    # The declared size is the only figure here that the call did not produce.
+    limit = arguments.get("limit")
+    if limit is not None and int(limit) < staged.size:
+        raise ValueError(
+            "agentic v2 staged file was read under a limit shorter than the "
+            "file, so the bytes cannot be checked against what was staged"
+        )
+    if len(content) != staged.size or _digest_of(content) != staged.sha256:
+        raise ValueError(
+            "agentic v2 staged file read does not match what was staged"
+        )
+    staged.content = content
+    return content
+
+
 def _replay_exec_run(
     arguments: Mapping[str, Any],
     ledger: dict[str, Any],
@@ -1635,7 +1826,7 @@ def _replay_exec_run(
     ):
         return {"ok": False, "error_type": "fixture_backend_error"}
     error = _virtual_write(
-        ledger, destination, ledger["files"][source].upper()
+        ledger, destination, _bytes_of(ledger["files"][source]).upper()
     )
     if error is not None:
         return {"ok": False, "error_type": error}
@@ -1693,7 +1884,7 @@ def _replay_browser_run(
         return {"ok": False, "error_type": "fixture_backend_error"}
     return {"ok": True, "data": {
         "path": path,
-        "sha256": hashlib.sha256(content).hexdigest(),
+        "sha256": _digest_of(content),
     }}
 
 
@@ -1707,19 +1898,19 @@ def _replay_artifact_tool(
     total = 0
     for path in arguments["deliverables"]:
         content = ledger["files"].get(path)
-        if not content:
+        if content is None or _size_of(content) == 0:
             return {"ok": False, "error_type": "artifact_not_openable"}
-        total += len(content)
+        total += _size_of(content)
         if total > 64 * 1024 * 1024:
             return {"ok": False, "error_type": "artifact_not_openable"}
         artifacts.append({
             "path": path,
-            "sha256": hashlib.sha256(content).hexdigest(),
-            "size": len(content),
+            "sha256": _digest_of(content),
+            "size": _size_of(content),
         })
         terminal_files.append({
             "filename": path,
-            "sha256": hashlib.sha256(content).hexdigest(),
+            "sha256": _digest_of(content),
         })
     if name == "finalize":
         ledger["terminal_identity"] = {
@@ -1730,13 +1921,15 @@ def _replay_artifact_tool(
     return {"ok": True, "data": {"artifacts": artifacts}}
 
 
-def _virtual_write(ledger: dict[str, Any], path: str, content: bytes) -> str | None:
-    if path == "." or path in ledger["directories"] or len(content) > 1048576:
+def _virtual_write(ledger: dict[str, Any], path: str, content: Any) -> str | None:
+    if path == "." or path in ledger["directories"] or _size_of(content) > 1048576:
         return "fixture_backend_error"
     error = _virtual_reserve_entries(ledger, path, temporary_leaf=True)
     if error is not None:
         return error
-    if sum(len(value) for value in ledger["files"].values()) + len(content) > (
+    if sum(
+        _size_of(value) for value in ledger["files"].values()
+    ) + _size_of(content) > (
         64 * 1024 * 1024
     ):
         return "fixture_backend_error"

--- a/batch-runner/core/agentic_v2_reference_staging.py
+++ b/batch-runner/core/agentic_v2_reference_staging.py
@@ -400,6 +400,30 @@ class _CannotCopy(Exception):
         self.detail = detail
 
 
+def _make_directory_0700(directory: Path) -> None:
+    """Create ``directory`` and any missing parent, each one at 0o700.
+
+    ``Path.mkdir(mode=..., parents=True)`` applies the mode to the last
+    component only; every parent it has to create takes the process umask
+    instead, which is 0o755 in the usual case. That is invisible until the
+    provenance replay runs, because it models every workspace directory as
+    0o700: a staged tree with 0o755 halfway down describes a starting state
+    whose digest the replay cannot reproduce, and the task is thrown away
+    after it has already been worked. Walk the chain and set each mode here,
+    with an explicit chmod so the umask cannot take bits off either.
+    """
+    missing: list[Path] = []
+    current = directory
+    while not current.exists():
+        missing.append(current)
+        if current.parent == current:
+            break
+        current = current.parent
+    for one in reversed(missing):
+        one.mkdir(exist_ok=True)
+        one.chmod(0o700)
+
+
 def _copy_one(
     *, snapshot_root: Path, relative: Path, destination: Path
 ) -> StagedFile:
@@ -435,7 +459,7 @@ def _copy_one(
                 TOO_LARGE,
                 f"{before.st_size} bytes is over the {MAX_INPUT_SINGLE} byte limit",
             )
-        destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        _make_directory_0700(destination.parent)
         digest = hashlib.sha256()
         with os.fdopen(os.dup(descriptor), "rb") as source, destination.open(
             "xb"
@@ -443,6 +467,11 @@ def _copy_one(
             for chunk in iter(lambda: source.read(65536), b""):
                 digest.update(chunk)
                 sink.write(chunk)
+        # 0o600 to match what the fixture backend gives a file the model
+        # writes, and so what the provenance replay models for every file it
+        # holds. A staged file left at the umask default describes a workspace
+        # whose state digest no re-derivation can reproduce.
+        os.chmod(destination, 0o600)
         after = os.fstat(descriptor)
         if _source_identity(after) != _source_identity(before):
             raise _CannotCopy(
@@ -555,8 +584,9 @@ def _extract_one(
 
     written = Path(EXTRACTION_PREFIX) / relative.with_suffix(relative.suffix + ".txt")
     destination = workspace / written
-    destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    _make_directory_0700(destination.parent)
     destination.write_text(text, encoding="utf-8")
+    destination.chmod(0o600)
     return ExtractedText(
         relative_path=relative.as_posix(),
         outcome=outcome,
@@ -594,6 +624,30 @@ def _write_inputs_guide(
         "you started. Paths are relative to your working directory.",
         "",
     ]
+    if not delivered and not refused:
+        # Written anyway, and this is the whole reason the guide is
+        # unconditional. The standing instructions tell the model to open this
+        # file first; when it was skipped for a task that names nothing, that
+        # read came back `ok: False`, and one failed tool call ends a task --
+        # see `dispatch_one` in core.agentic_v2_runner. So every task that
+        # names no files died on turn one, three attempts each, against an
+        # environment defect that would have read as the model failing. How
+        # many that is is counted from the catalogue in
+        # tests/test_agentic_v2_reference_staging.py rather than written here:
+        # the figure in this comment was wrong for a day and nothing noticed.
+        lines.append("## This task names no files")
+        lines.append("")
+        lines.append(
+            "It is not that they are missing: the dataset lists none for this"
+        )
+        lines.append(
+            "task. Nothing was lost on the way here and there is nothing to go"
+        )
+        lines.append(
+            "looking for. Do the task from its wording, and write your answer"
+        )
+        lines.append("into this directory.")
+        lines.append("")
     if delivered:
         lines.append("## Files you have")
         lines.append("")
@@ -658,6 +712,7 @@ def _write_inputs_guide(
     lines.append("the rest of the document exists and you have not been shown it.")
     destination = workspace / INPUTS_GUIDE
     destination.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    destination.chmod(0o600)
     return f"{MODEL_INPUT_PREFIX}/{INPUTS_GUIDE}"
 
 
@@ -700,7 +755,7 @@ def stage_task_reference_files(
     """
     snapshot_root = Path(snapshot_root).resolve()
     workspace = Path(into).resolve()
-    workspace.mkdir(mode=0o700, parents=True, exist_ok=True)
+    _make_directory_0700(workspace)
 
     delivered: list[StagedFile] = []
     refused: list[RefusedFile] = []
@@ -857,7 +912,11 @@ def stage_task_reference_files(
             )
 
     guide = None
-    if render_text and (delivered or refused):
+    if render_text:
+        # Unconditional. A task that names no files still needs the guide,
+        # because the instructions send the model to it first and a read that
+        # fails ends the task outright rather than returning an error the model
+        # can act on.
         guide = _write_inputs_guide(
             workspace=workspace,
             delivered=delivered,

--- a/batch-runner/core/agentic_v2_reference_staging.py
+++ b/batch-runner/core/agentic_v2_reference_staging.py
@@ -1,0 +1,565 @@
+"""Putting a task's reference files where the model can actually open them.
+
+Every V2 record so far has carried the same true, useless sentence: 125 of 220
+tasks name reference files that nothing copies into the workspace.
+:func:`core.agentic_v2_manifest_binding.unmet_needs` reports it per task and
+says outright that reporting is not fixing. This is the fixing.
+
+**Why this is not a new copy routine.** The hard part of moving a file from a
+downloaded dataset into a workspace is not the copy; it is doing it without
+following a link out of the tree, without accepting a file that changed halfway
+through, and without a path that climbs out of the destination.
+:mod:`core.agentic_input_manifest` already solved that for V1, carefully, and
+those primitives are imported here rather than written again. A second
+implementation of a security-critical copy is a second thing to get right and a
+second thing to keep right.
+
+**Why it is not simply V1's function, then.** Three things in
+:func:`core.agentic_input_manifest.build_input_manifest` are wrong for V2, and
+each is a deliberate difference rather than an oversight:
+
+*It stages into a temporary directory and deletes it.* V1 wants the identities
+— it computes hashes so the Docker backend can verify its own staging against
+them. V2 wants the bytes to still be there when a task starts. The destination
+here is real and outlives the call.
+
+*It takes V1's selection manifest.* ``validate_selection_manifest`` pins
+``schema_version == "agentic-task-subset-v1"`` and ``seed == "20260717"``. V2's
+cohort comes from :mod:`core.agentic_v2_preregistration` with its own seal.
+Neither could satisfy the other's check, and loosening V1's would weaken a
+frozen identity that other work depends on.
+
+*It raises on the first problem, which would refuse the whole cohort.* That is
+right for V1, where the manifest is all-or-nothing. It is wrong here, and the
+dataset says so: task ``a941b6d8-4289-4500-b45a-f8e4fc94a724`` carries a 689.1
+MB video, larger than ``MAX_INPUT_SINGLE``. Under V1's semantics that one file
+refuses all two hundred and twenty tasks. So refusal here is **per file**, it is
+**recorded by name and reason**, and the other files of that same task are still
+delivered.
+
+**What a refusal must never become.** A file that could not be staged is not the
+same as a task with no files, and neither is the same as a task that got
+everything. If those three collapse into one, a model failing because it was
+never given the spreadsheet reads afterwards as a model that could not do the
+work. So the record distinguishes them, per task, by name, and
+:func:`staging_record` is what the run record carries instead of the old flat
+``reference_file_bytes_are_in_the_guest: False``.
+
+**What this does not decide.** It does not choose a substitute for a file too
+large to deliver — a transcript, sampled frames, a summary. That choice changes
+what the task measures and belongs to whoever is willing to write down that it
+was made. Here the file is refused, named, and its size given.
+
+Nothing here calls a model, opens a guest, or spends anything.
+"""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import os
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from core.agentic_compute import (
+    MAX_DEPTH,
+    MAX_INPUT_FILES,
+    MAX_INPUT_SINGLE,
+    MAX_INPUT_TOTAL,
+    MAX_PATH_BYTES,
+    _open_regular_beneath_nofollow,
+    _sha256_descriptor,
+    _source_identity,
+)
+
+STAGING_SCHEMA_VERSION = "agentic-v2-reference-staging-v1"
+
+#: Where a staged file appears from the model's point of view.
+#:
+#: The same prefix V1's merkle records use, so a path quoted in a V2 record
+#: means the same thing as one quoted in a V1 record.
+MODEL_INPUT_PREFIX = "inputs"
+
+#: Why a file was not delivered.
+#:
+#: Short, stable strings rather than free prose, because these are counted and
+#: grouped across 220 tasks and a sentence that varies cannot be. The detail
+#: field beside them carries the specifics.
+TOO_LARGE = "larger_than_the_single_file_limit"
+TOO_MANY = "task_names_more_files_than_the_limit_allows"
+TOTAL_TOO_LARGE = "task_total_would_exceed_the_input_limit"
+NOT_IN_SNAPSHOT = "not_present_in_the_pinned_snapshot"
+UNSAFE_PATH = "path_is_not_a_safe_relative_component"
+NOT_A_PLAIN_FILE = "source_is_a_link_or_not_a_single_link_regular_file"
+CHANGED_WHILE_COPYING = "source_changed_while_it_was_being_copied"
+SNAPSHOT_IS_A_LINK_FARM = "snapshot_root_is_a_huggingface_cache_of_symlinks"
+
+#: What to do about it, said once, where the refusal is raised.
+#:
+#: Measured on this repository's own pinned snapshot: **301 of 301** files under
+#: ``reference_files/`` are symlinks and none is a regular file. That is not
+#: corruption, it is how ``huggingface_hub`` stores a cache — the snapshot tree
+#: is names, the bytes live once in a sibling ``blobs/`` directory, and every
+#: name points at them with a relative link that climbs *out* of the snapshot
+#: root.
+#:
+#: Two things follow, and both are easy to get wrong. Anything opened with
+#: ``O_NOFOLLOW`` — which is everything in this module and in
+#: :mod:`core.agentic_input_manifest` — refuses all 301 files. And "resolve the
+#: link, then check it is beneath the root" does not rescue it either, because
+#: the target genuinely is not beneath the root. So the fix is not to relax the
+#: opener. It is to ask for the bytes instead of the names, which ``hf
+#: download --local-dir`` does: the same command against the same revision then
+#: writes real files.
+#:
+#: Worth the paragraph because the generic refusal for this is "source is a
+#: link", which reads as a planted link and a security finding rather than as
+#: the ordinary shape of an ordinary cache.
+LINK_FARM_DETAIL = (
+    "the snapshot root is a huggingface_hub cache, whose files are symlinks "
+    "into a sibling blobs/ directory outside the root. Nothing is wrong with "
+    "it and nothing here will follow it. Fetch with `hf download ... "
+    "--local-dir <dir>` against the same revision, which writes the bytes, and "
+    "stage from that directory."
+)
+
+
+@dataclass(frozen=True)
+class StagedFile:
+    """One file that arrived, with what it is."""
+
+    relative_path: str
+    size_bytes: int
+    sha256: str
+
+    @property
+    def model_path(self) -> str:
+        return f"{MODEL_INPUT_PREFIX}/{self.relative_path}"
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "relative_path": self.relative_path,
+            "model_path": self.model_path,
+            "size_bytes": self.size_bytes,
+            "sha256": self.sha256,
+        }
+
+
+@dataclass(frozen=True)
+class RefusedFile:
+    """One file that did not arrive, and why — by name, never as a count."""
+
+    relative_path: str
+    reason: str
+    detail: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "relative_path": self.relative_path,
+            "reason": self.reason,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class TaskStaging:
+    """What one task was actually given, and what it was not."""
+
+    task_id: str
+    workspace: str
+    delivered: tuple[StagedFile, ...]
+    refused: tuple[RefusedFile, ...]
+
+    @property
+    def named(self) -> int:
+        return len(self.delivered) + len(self.refused)
+
+    @property
+    def everything_arrived(self) -> bool:
+        """True only when the task needed files and got all of them.
+
+        A task naming no files is not "complete" here; it is a task the whole
+        question does not apply to. Merging the two would let a stage of tasks
+        with no inputs report as fully staged.
+        """
+        return bool(self.delivered) and not self.refused
+
+    @property
+    def ran_without_its_inputs(self) -> bool:
+        """The condition a result must be read in the light of."""
+        return bool(self.refused)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "workspace": self.workspace,
+            "files_named": self.named,
+            "delivered": [one.as_dict() for one in self.delivered],
+            "refused": [one.as_dict() for one in self.refused],
+            "everything_arrived": self.everything_arrived,
+        }
+
+
+def snapshot_problem(snapshot_root: str | Path) -> str | None:
+    """Whether a root can be staged from at all, answered before 220 tasks try.
+
+    Per-file refusal is right for a file, and wrong for a root: a cache of
+    symlinks produces the same refusal 261 times and looks like 125 broken
+    tasks rather than one wrong directory. This is the question asked once, by
+    whoever is about to stage, so the answer arrives before the work does.
+
+    Returns ``None`` when the root looks stageable. Deliberately cheap: it
+    looks at the shape of ``reference_files/`` rather than reading anything.
+    """
+    root = Path(snapshot_root)
+    if not root.is_dir():
+        return f"{root} is not a directory"
+
+    references = root / "reference_files"
+    if not references.is_dir():
+        return (
+            f"{references} does not exist, so no task can be given its inputs "
+            "from here. Fetch the dataset with `--local-dir` pointed at the "
+            "root being staged from."
+        )
+
+    links = 0
+    plain = 0
+    for path in references.rglob("*"):
+        if path.is_symlink():
+            links += 1
+        elif path.is_file():
+            plain += 1
+        if links and plain:
+            break
+
+    if links and not plain:
+        return (
+            f"every file under {references} is a symlink ({links} seen and no "
+            f"regular file): {LINK_FARM_DETAIL}"
+        )
+    if not links and not plain:
+        return f"{references} holds no files"
+    return None
+
+
+def _unsafe_reason(relative: Path) -> str | None:
+    """Whether a dataset-supplied path may be joined onto a destination.
+
+    The same conditions V1 refuses on, kept identical on purpose: this decides
+    where bytes get written, and two staging paths that disagree about what a
+    safe path is would be a gap nobody notices until one of them is used.
+    """
+    if relative.is_absolute():
+        return "path is absolute"
+    if not relative.parts:
+        return "path is empty"
+    if ".." in relative.parts:
+        return "path climbs out of the tree"
+    if any(part.startswith(".") for part in relative.parts):
+        return "path has a hidden component"
+    if len(relative.parts) > MAX_DEPTH:
+        return f"path is deeper than {MAX_DEPTH}"
+    if len(relative.as_posix().encode("utf-8")) > MAX_PATH_BYTES:
+        return f"path is longer than {MAX_PATH_BYTES} bytes"
+    return None
+
+
+class _CannotCopy(Exception):
+    """A copy that stopped, carrying which refusal it is.
+
+    One exception type with a ``reason`` on it rather than several types, or a
+    bare ``ValueError`` sorted out by the caller. The first version did the
+    latter, and it quietly labelled a file with a second hard link as
+    ``source_changed_while_it_was_being_copied`` — a record asserting a race
+    that never happened, in the one module whose purpose is that a record can be
+    read against a result. The reason travels with the refusal so the two cannot
+    drift apart.
+    """
+
+    def __init__(self, reason: str, detail: str) -> None:
+        super().__init__(detail)
+        self.reason = reason
+        self.detail = detail
+
+
+def _copy_one(
+    *, snapshot_root: Path, relative: Path, destination: Path
+) -> StagedFile:
+    """Copy one file, or raise :class:`_CannotCopy` saying which refusal it is.
+
+    Opened beneath the snapshot root with ``O_NOFOLLOW`` at every component, so
+    a link planted in the dataset cannot redirect the read. Hashed while being
+    copied, then the source is checked twice more — its identity and its digest
+    — because a file that changed halfway through produces a destination that
+    matches neither version and would otherwise be indistinguishable from a
+    clean copy.
+    """
+    try:
+        descriptor = _open_regular_beneath_nofollow(snapshot_root, relative)
+    except OSError as exc:
+        raise _CannotCopy(
+            NOT_A_PLAIN_FILE,
+            f"could not be opened without following a link: "
+            f"{errno.errorcode.get(exc.errno, exc.errno)} {exc.strerror}",
+        ) from exc
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode):
+            raise _CannotCopy(NOT_A_PLAIN_FILE, "source is not a regular file")
+        if before.st_nlink != 1:
+            raise _CannotCopy(
+                NOT_A_PLAIN_FILE,
+                f"source has {before.st_nlink} hard links, so another name for "
+                "the same bytes could change them between the check and the read",
+            )
+        if before.st_size > MAX_INPUT_SINGLE:
+            raise _CannotCopy(
+                TOO_LARGE,
+                f"{before.st_size} bytes is over the {MAX_INPUT_SINGLE} byte limit",
+            )
+        destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        digest = hashlib.sha256()
+        with os.fdopen(os.dup(descriptor), "rb") as source, destination.open(
+            "xb"
+        ) as sink:
+            for chunk in iter(lambda: source.read(65536), b""):
+                digest.update(chunk)
+                sink.write(chunk)
+        after = os.fstat(descriptor)
+        if _source_identity(after) != _source_identity(before):
+            raise _CannotCopy(
+                CHANGED_WHILE_COPYING, "source identity changed during the copy"
+            )
+        if _sha256_descriptor(descriptor) != digest.hexdigest():
+            raise _CannotCopy(
+                CHANGED_WHILE_COPYING, "source contents changed during the copy"
+            )
+    finally:
+        os.close(descriptor)
+    return StagedFile(
+        relative_path=relative.as_posix(),
+        size_bytes=before.st_size,
+        sha256=digest.hexdigest(),
+    )
+
+
+def stage_task_reference_files(
+    *,
+    task_id: str,
+    reference_files: Sequence[Any],
+    snapshot_root: str | Path,
+    into: str | Path,
+) -> TaskStaging:
+    """Give one task its files, and say exactly what it did not get.
+
+    Never raises for a file it cannot deliver. A task that names twenty files
+    and can be given nineteen is given nineteen, and the twentieth is in the
+    record by name — which is the whole point, because the alternative is a task
+    that quietly ran short.
+    """
+    snapshot_root = Path(snapshot_root).resolve()
+    workspace = Path(into).resolve()
+    workspace.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+    delivered: list[StagedFile] = []
+    refused: list[RefusedFile] = []
+    running_total = 0
+
+    named = [str(one) for one in (reference_files or [])]
+    over_the_count = named[MAX_INPUT_FILES:]
+    for path in over_the_count:
+        refused.append(
+            RefusedFile(
+                relative_path=path,
+                reason=TOO_MANY,
+                detail=(
+                    f"the task names {len(named)} files and the limit is "
+                    f"{MAX_INPUT_FILES}"
+                ),
+            )
+        )
+
+    for raw in named[:MAX_INPUT_FILES]:
+        relative = Path(raw)
+        unsafe = _unsafe_reason(relative)
+        if unsafe is not None:
+            refused.append(
+                RefusedFile(relative_path=raw, reason=UNSAFE_PATH, detail=unsafe)
+            )
+            continue
+
+        source = snapshot_root / relative
+        if source.is_symlink():
+            # Checked before `is_file`, which follows the link and would report
+            # a file that this module will then refuse to open -- the confusing
+            # pair of answers that cost the first attempt at this an hour.
+            refused.append(
+                RefusedFile(
+                    relative_path=relative.as_posix(),
+                    reason=SNAPSHOT_IS_A_LINK_FARM,
+                    detail=LINK_FARM_DETAIL,
+                )
+            )
+            continue
+        if not source.is_file():
+            refused.append(
+                RefusedFile(
+                    relative_path=relative.as_posix(),
+                    reason=NOT_IN_SNAPSHOT,
+                    detail=f"no file at {relative.as_posix()} under the snapshot root",
+                )
+            )
+            continue
+
+        size = source.stat().st_size
+        if size > MAX_INPUT_SINGLE:
+            refused.append(
+                RefusedFile(
+                    relative_path=relative.as_posix(),
+                    reason=TOO_LARGE,
+                    detail=(
+                        f"{size} bytes, over the {MAX_INPUT_SINGLE} byte "
+                        "single-file limit. Delivering it would mean choosing "
+                        "what the model gets instead, which changes what the "
+                        "task measures."
+                    ),
+                )
+            )
+            continue
+        if running_total + size > MAX_INPUT_TOTAL:
+            refused.append(
+                RefusedFile(
+                    relative_path=relative.as_posix(),
+                    reason=TOTAL_TOO_LARGE,
+                    detail=(
+                        f"{running_total + size} bytes would pass the "
+                        f"{MAX_INPUT_TOTAL} byte total for one task"
+                    ),
+                )
+            )
+            continue
+
+        destination = workspace / relative
+        try:
+            staged = _copy_one(
+                snapshot_root=snapshot_root,
+                relative=relative,
+                destination=destination,
+            )
+        except _CannotCopy as exc:
+            # Whatever landed before the refusal is removed. A short file left
+            # in the workspace is worse than no file: the model opens it, reads
+            # it as the whole thing, and the record says it was refused.
+            destination.unlink(missing_ok=True)
+            refused.append(
+                RefusedFile(
+                    relative_path=relative.as_posix(),
+                    reason=exc.reason,
+                    detail=exc.detail,
+                )
+            )
+            continue
+
+        running_total += staged.size_bytes
+        delivered.append(staged)
+
+    return TaskStaging(
+        task_id=task_id,
+        workspace=str(workspace),
+        delivered=tuple(delivered),
+        refused=tuple(refused),
+    )
+
+
+def stage_cohort(
+    *,
+    tasks: Iterable[Any],
+    snapshot_root: str | Path,
+    into: str | Path,
+) -> tuple[TaskStaging, ...]:
+    """Stage every task in a bound cohort, each into its own directory.
+
+    Per task rather than per cohort, because the tasks do not share a workspace
+    and because a file that one task may open is not a file every task may open.
+    The directory is named by the task id's digest for the same reason V1 does
+    it: a task id is dataset-supplied and a directory name is a filesystem
+    decision, and the two should not be the same string.
+    """
+    into = Path(into)
+    return tuple(
+        stage_task_reference_files(
+            task_id=task.task_id,
+            reference_files=getattr(task, "reference_files", ()) or (),
+            snapshot_root=snapshot_root,
+            into=into
+            / hashlib.sha256(str(task.task_id).encode("utf-8")).hexdigest(),
+        )
+        for task in tasks
+    )
+
+
+def staging_record(stagings: Sequence[TaskStaging]) -> dict[str, Any]:
+    """What the run record carries about which tasks got their inputs.
+
+    Replaces the flat ``reference_file_bytes_are_in_the_guest: False`` that
+    :func:`core.agentic_v2_manifest_binding.unmet_needs` writes today. That
+    field was honest when nothing was staged; once something is, a single
+    boolean for a whole cohort is the field most likely to be read as "all of
+    them" or "none of them" when the truth is "most".
+
+    The summary counts are for a reader skimming. The per-task detail underneath
+    is what a result gets read against, and it is not summarised away: every
+    refused file appears by name.
+    """
+    stagings = list(stagings)
+    needed = [one for one in stagings if one.named]
+    short = [one for one in needed if one.ran_without_its_inputs]
+    reasons: dict[str, int] = {}
+    for one in stagings:
+        for refusal in one.refused:
+            reasons[refusal.reason] = reasons.get(refusal.reason, 0) + 1
+
+    return {
+        "schema_version": STAGING_SCHEMA_VERSION,
+        "tasks_seen": len(stagings),
+        "tasks_naming_reference_files": len(needed),
+        "tasks_given_everything_they_named": len(needed) - len(short),
+        "tasks_that_ran_without_some_input": len(short),
+        "files_delivered": sum(len(one.delivered) for one in stagings),
+        "bytes_delivered": sum(
+            file.size_bytes for one in stagings for file in one.delivered
+        ),
+        "refusals_by_reason": dict(sorted(reasons.items())),
+        "what_that_means": (
+            f"{len(needed) - len(short)} of {len(needed)} tasks that name "
+            "reference files were given all of them. "
+            f"{len(short)} were not, and each missing file is named below. A "
+            "failure on one of those is not evidence about the model."
+        ),
+        "tasks": [one.as_dict() for one in stagings],
+    }
+
+
+__all__ = [
+    "CHANGED_WHILE_COPYING",
+    "LINK_FARM_DETAIL",
+    "MODEL_INPUT_PREFIX",
+    "NOT_A_PLAIN_FILE",
+    "NOT_IN_SNAPSHOT",
+    "SNAPSHOT_IS_A_LINK_FARM",
+    "STAGING_SCHEMA_VERSION",
+    "RefusedFile",
+    "StagedFile",
+    "TOO_LARGE",
+    "TOO_MANY",
+    "TOTAL_TOO_LARGE",
+    "TaskStaging",
+    "UNSAFE_PATH",
+    "snapshot_problem",
+    "stage_cohort",
+    "stage_task_reference_files",
+    "staging_record",
+]

--- a/batch-runner/core/agentic_v2_reference_staging.py
+++ b/batch-runner/core/agentic_v2_reference_staging.py
@@ -73,6 +73,8 @@ from core.agentic_compute import (
     _sha256_descriptor,
     _source_identity,
 )
+from core.agentic_v2_fixture_backend import _MAX_FILE_BYTES
+from core.file_reader import get_supported_extensions, read_reference_file
 
 STAGING_SCHEMA_VERSION = "agentic-v2-reference-staging-v1"
 
@@ -88,6 +90,7 @@ MODEL_INPUT_PREFIX = "inputs"
 #: grouped across 220 tasks and a sentence that varies cannot be. The detail
 #: field beside them carries the specifics.
 TOO_LARGE = "larger_than_the_single_file_limit"
+TOO_LARGE_FOR_THE_WORKSPACE = "larger_than_the_workspace_file_limit"
 TOO_MANY = "task_names_more_files_than_the_limit_allows"
 TOTAL_TOO_LARGE = "task_total_would_exceed_the_input_limit"
 NOT_IN_SNAPSHOT = "not_present_in_the_pinned_snapshot"
@@ -124,6 +127,49 @@ LINK_FARM_DETAIL = (
     "--local-dir <dir>` against the same revision, which writes the bytes, and "
     "stage from that directory."
 )
+
+#: The biggest file the fixture workspace can hold, read from the code that
+#: enforces it.
+#:
+#: Imported rather than written down, and imported past the underscore on
+#: purpose. That name is what :meth:`AgenticV2FixtureBackend._read_bytes`
+#: measures every file against while it walks the workspace, so it is the only
+#: number that is true by construction. A copy here would be a second number to
+#: keep correct, and the day it drifted this module would stage files the
+#: backend then refused.
+#:
+#: The limit matters far more than its size suggests, because of *where* the
+#: backend applies it. It is not a read limit on the file the model asked for;
+#: the walk reads every regular file under the workspace root, so one oversized
+#: file makes the walk raise, and the walk runs on ``write``. Measured on this
+#: repository's own fixture backend: a 900 KiB input leaves ``list``, ``read``
+#: and ``write`` all working, and a 2 MiB input leaves ``list`` and ``read``
+#: working and makes ``write`` raise. A task staged that way can look at its
+#: inputs and can never save a deliverable.
+#:
+#: That failure is also invisible from inside the loop. The dispatcher turns any
+#: exception into ``{"ok": False, "error_type": "fixture_backend_error"}``, so
+#: the model is told only that something went wrong, tries again, and spends its
+#: whole call budget on writes that cannot succeed. The record would show a model
+#: that produced nothing.
+WORKSPACE_FILE_LIMIT = _MAX_FILE_BYTES
+
+#: Where a text rendering of a file appears, beneath the inputs prefix.
+EXTRACTION_PREFIX = "extracted"
+
+#: What came of trying to render one file as text.
+#:
+#: Separate strings rather than a boolean, because "no rendering" covers four
+#: quite different situations and only one of them is a defect. Counting them
+#: together would hide the one that is.
+EXTRACTION_IS_TEXT = "text_was_read_out_of_it"
+EXTRACTION_IS_A_LABEL = "the_reader_describes_this_kind_rather_than_reading_it"
+EXTRACTION_IS_EMPTY = "the_reader_found_no_text_in_it"
+EXTRACTION_TRUNCATED = "text_was_read_out_of_it_and_cut_to_the_workspace_limit"
+EXTRACTION_FAILED = "the_reader_could_not_open_it"
+
+#: The name of the one file in the workspace that says what the others are.
+INPUTS_GUIDE = "INPUTS.md"
 
 
 @dataclass(frozen=True)
@@ -164,6 +210,51 @@ class RefusedFile:
 
 
 @dataclass(frozen=True)
+class ExtractedText:
+    """What a text rendering of one file came to, including nothing.
+
+    A rendering is not the file and is never described as one. It is what this
+    repository's own reader — :func:`core.file_reader.read_reference_file`, the
+    same one V1 puts in its prompts — could get out of the bytes. For a
+    spreadsheet that is the cells; for a photograph it is the word "photograph"
+    and its pixel dimensions, which is a label rather than a rendering and is
+    recorded as one.
+
+    The reason to keep all four outcomes apart is that only one of them is a
+    defect. A ``.png`` yielding no text is the format; a ``.pdf`` yielding no
+    text is a scan, and a task that needs it read is a task nobody can do here.
+    Counting them together would report nine images and five scans as fourteen
+    unreadable files and lose which five mattered.
+    """
+
+    relative_path: str
+    outcome: str
+    characters: int
+    label: str = ""
+    written_to: str | None = None
+
+    @property
+    def model_path(self) -> str | None:
+        """Where the model finds it, or ``None`` when nothing was written."""
+        if self.written_to is None:
+            return None
+        return f"{MODEL_INPUT_PREFIX}/{self.written_to}"
+
+    @property
+    def is_readable(self) -> bool:
+        return self.outcome in (EXTRACTION_IS_TEXT, EXTRACTION_TRUNCATED)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "relative_path": self.relative_path,
+            "outcome": self.outcome,
+            "characters": self.characters,
+            "label": self.label,
+            "model_path": self.model_path,
+        }
+
+
+@dataclass(frozen=True)
 class TaskStaging:
     """What one task was actually given, and what it was not."""
 
@@ -171,6 +262,8 @@ class TaskStaging:
     workspace: str
     delivered: tuple[StagedFile, ...]
     refused: tuple[RefusedFile, ...]
+    extractions: tuple[ExtractedText, ...] = ()
+    guide: str | None = None
 
     @property
     def named(self) -> int:
@@ -191,6 +284,25 @@ class TaskStaging:
         """The condition a result must be read in the light of."""
         return bool(self.refused)
 
+    @property
+    def could_open_nothing(self) -> bool:
+        """Files arrived and not one of them can be opened.
+
+        Worth its own name because it is the state most easily mistaken for a
+        lazy model. The task is handed a directory, the directory has files in
+        it, every attempt to read one comes back as an error, and the answer is
+        written from the prompt alone.
+
+        Answered from the renderings, so it is ``False`` where none was
+        attempted. That is a limit of the field rather than a claim: without a
+        rendering pass nothing here has opened anything, and a run that reports
+        this as ``False`` for every task should be checked for having asked for
+        renderings at all.
+        """
+        if not self.delivered or not self.extractions:
+            return False
+        return not any(one.is_readable for one in self.extractions)
+
     def as_dict(self) -> dict[str, Any]:
         return {
             "task_id": self.task_id,
@@ -198,7 +310,10 @@ class TaskStaging:
             "files_named": self.named,
             "delivered": [one.as_dict() for one in self.delivered],
             "refused": [one.as_dict() for one in self.refused],
+            "extractions": [one.as_dict() for one in self.extractions],
+            "guide": self.guide,
             "everything_arrived": self.everything_arrived,
+            "could_open_nothing": self.could_open_nothing,
         }
 
 
@@ -346,12 +461,214 @@ def _copy_one(
     )
 
 
+#: Room left under the workspace limit for the note that says text was cut.
+_TRUNCATION_ROOM = 512
+
+#: How the reader reports a file it recognised and then could not open.
+#:
+#: :func:`core.file_reader.read_reference_file` swallows the exception and hands
+#: back this sentence as though it were the document. Harmless where it was
+#: written — a prompt reader shows it to a person — and not harmless here, where
+#: the string would be written into the workspace as the file's rendering and the
+#: model would read "[Error reading x.xlsx: ...]" as the contents of x.xlsx.
+#:
+#: Matched on rather than caught, because there is nothing to catch. That makes
+#: this a dependency on a detail of another module's behaviour, which is exactly
+#: the kind of thing that changes without anyone noticing, so
+#: ``test_the_reader_still_swallows`` runs the reader against a corrupt file and
+#: fails if it ever starts raising instead.
+_READER_ERROR_PREFIX = "[Error reading "
+
+
+def _extract_one(
+    *,
+    source: Path,
+    relative: Path,
+    workspace: Path,
+    limit: int,
+) -> ExtractedText:
+    """Render one file as text beside it, or say why there is no rendering.
+
+    Never raises. A file that cannot be rendered is a file the model will have
+    to work without, which is a fact about the run to be recorded rather than an
+    error to be handled — the task still goes ahead, and the record carries what
+    it went ahead without.
+    """
+    suffix = relative.suffix.lower()
+    mode = get_supported_extensions().get(suffix)
+    if mode != "text":
+        # A photograph, a recording, an archive. The reader has a sentence for
+        # each and that sentence is worth carrying, but it is a label and is
+        # never written into the workspace as if it were the file's contents.
+        try:
+            label = read_reference_file(str(source)).strip()
+        except Exception as exc:  # pragma: no cover - the reader swallows
+            label = f"{type(exc).__name__}"
+        return ExtractedText(
+            relative_path=relative.as_posix(),
+            outcome=EXTRACTION_IS_A_LABEL,
+            characters=0,
+            label=label[:200],
+        )
+
+    try:
+        text = read_reference_file(str(source))
+    except Exception as exc:  # pragma: no cover - the reader swallows
+        return ExtractedText(
+            relative_path=relative.as_posix(),
+            outcome=EXTRACTION_FAILED,
+            characters=0,
+            label=f"{type(exc).__name__}: {exc}"[:200],
+        )
+
+    if text.startswith(_READER_ERROR_PREFIX):
+        return ExtractedText(
+            relative_path=relative.as_posix(),
+            outcome=EXTRACTION_FAILED,
+            characters=0,
+            label=text.strip()[:200],
+        )
+    if not text.strip():
+        # The five scanned PDFs in the pinned revision land here. Writing an
+        # empty file would be the worst of the options: the model opens it,
+        # reads nothing, and concludes the document is blank rather than that
+        # it is a picture of a document.
+        return ExtractedText(
+            relative_path=relative.as_posix(),
+            outcome=EXTRACTION_IS_EMPTY,
+            characters=0,
+            label="the reader opened it and found no text",
+        )
+
+    encoded = text.encode("utf-8")
+    outcome = EXTRACTION_IS_TEXT
+    if len(encoded) > limit - _TRUNCATION_ROOM:
+        # Cut on bytes, because bytes are what the backend counts, and then
+        # back to a character boundary so the file is still valid UTF-8.
+        encoded = encoded[: limit - _TRUNCATION_ROOM]
+        text = encoded.decode("utf-8", errors="ignore")
+        text += (
+            f"\n\n[This rendering was cut here to stay under the "
+            f"{limit} byte workspace file limit. The original file is longer.]\n"
+        )
+        outcome = EXTRACTION_TRUNCATED
+
+    written = Path(EXTRACTION_PREFIX) / relative.with_suffix(relative.suffix + ".txt")
+    destination = workspace / written
+    destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    destination.write_text(text, encoding="utf-8")
+    return ExtractedText(
+        relative_path=relative.as_posix(),
+        outcome=outcome,
+        characters=len(text),
+        label="",
+        written_to=written.as_posix(),
+    )
+
+
+def _write_inputs_guide(
+    *,
+    workspace: Path,
+    delivered: Sequence[StagedFile],
+    refused: Sequence[RefusedFile],
+    extractions: Sequence[ExtractedText],
+) -> str:
+    """Write the one file that says what the others are, and return its name.
+
+    Needed because nothing else tells the model its inputs exist. The task
+    wording comes from the dataset and is sealed against edits by
+    :mod:`core.agentic_v2_manifest_binding`, so it cannot be the carrier; it
+    describes work, not a directory layout. Without this the files are staged
+    into a path the model has never been given and has no reason to guess.
+
+    A file rather than more prompt on purpose. It costs nothing per turn, it can
+    say more than a system message reasonably should, and a model that never
+    opens it is a fact the tool log records — which a sentence in the prompt
+    would not be.
+    """
+    renderings = {one.relative_path: one for one in extractions}
+    lines = [
+        "# Your input files",
+        "",
+        "These are the files the task refers to. They were copied here before",
+        "you started. Paths are relative to your working directory.",
+        "",
+    ]
+    if delivered:
+        lines.append("## Files you have")
+        lines.append("")
+        for one in sorted(delivered, key=lambda f: f.relative_path):
+            rendered = renderings.get(one.relative_path)
+            lines.append(f"- `{one.model_path}` — {one.size_bytes:,} bytes")
+            if rendered is not None and rendered.model_path:
+                lines.append(
+                    f"  - text version: `{rendered.model_path}`"
+                    + (
+                        " (cut short)"
+                        if rendered.outcome == EXTRACTION_TRUNCATED
+                        else ""
+                    )
+                )
+            elif rendered is not None and rendered.label:
+                lines.append(f"  - no text version: {rendered.label}")
+        lines.append("")
+    if refused:
+        lines.append("## Files the task names that are not here")
+        lines.append("")
+        for one in sorted(refused, key=lambda f: f.relative_path):
+            rendered = renderings.get(one.relative_path)
+            lines.append(f"- `{one.relative_path}` — {one.reason}")
+            if rendered is not None and rendered.model_path:
+                lines.append(
+                    f"  - a text version is here instead: `{rendered.model_path}`"
+                )
+            elif rendered is not None and rendered.label:
+                lines.append(f"  - {rendered.label}")
+        lines.append("")
+        lines.append(
+            "Nothing was found to stand in for these. Where a text version is"
+        )
+        lines.append(
+            "listed, it was read out of that same file and is not a replacement"
+        )
+        lines.append(
+            "for it. Do the task with what you have, and say in your answer what"
+        )
+        lines.append("you could not see.")
+        lines.append("")
+    lines.append("## How to read them")
+    lines.append("")
+    lines.append(
+        "`workspace_apply` with `operation: read` returns text and only text. A"
+    )
+    lines.append(
+        "spreadsheet, a PDF or a document read that way fails, because the bytes"
+    )
+    lines.append(
+        "are not text — that failure is the format, not a mistake you made. Read"
+    )
+    lines.append("the text version listed above instead, where there is one.")
+    lines.append("")
+    lines.append(
+        "A text version is an extraction, not the file. Layout, images, styling"
+    )
+    lines.append(
+        "and anything a picture carries are lost. Where one is marked cut short,"
+    )
+    lines.append("the rest of the document exists and you have not been shown it.")
+    destination = workspace / INPUTS_GUIDE
+    destination.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return f"{MODEL_INPUT_PREFIX}/{INPUTS_GUIDE}"
+
+
 def stage_task_reference_files(
     *,
     task_id: str,
     reference_files: Sequence[Any],
     snapshot_root: str | Path,
     into: str | Path,
+    render_text: bool = False,
+    workspace_file_limit: int = WORKSPACE_FILE_LIMIT,
 ) -> TaskStaging:
     """Give one task its files, and say exactly what it did not get.
 
@@ -359,6 +676,27 @@ def stage_task_reference_files(
     and can be given nineteen is given nineteen, and the twentieth is in the
     record by name — which is the whole point, because the alternative is a task
     that quietly ran short.
+
+    ``render_text`` adds a text rendering beside each file that has one, and a
+    short guide naming everything. Off by default, so the plain staging path
+    stays exactly what it was and a caller has to ask for the rest. The stage
+    runner asks, for a reason worth stating where it is easy to find:
+
+    With ``exec_run`` shut, ``workspace_apply(read)`` is the only way the model
+    can open anything, and it decodes UTF-8. Measured against the pinned
+    revision by decoding all 261 files the 220 tasks name, 258 of them fail —
+    86 spreadsheets, 74 PDFs, 67 documents, and the images, recordings and
+    archives after them. Three decode: two CAD ``.STEP`` files and one ``.txt``.
+    So without a rendering the model can list its inputs and open three of them.
+    Every other read comes back as a bare ``fixture_backend_error``, and the
+    answer gets written from the prompt alone by a model that has no way to say
+    it was never shown the file.
+
+    That is an environment defect and not a model failure, and the two are
+    indistinguishable in a result. Which is why the compensation is made
+    explicit here, recorded per file, and named in the pre-registration as a
+    difference from the Codex run, whose model has a real shell and opens these
+    files itself.
     """
     snapshot_root = Path(snapshot_root).resolve()
     workspace = Path(into).resolve()
@@ -366,6 +704,7 @@ def stage_task_reference_files(
 
     delivered: list[StagedFile] = []
     refused: list[RefusedFile] = []
+    extractions: list[ExtractedText] = []
     running_total = 0
 
     named = [str(one) for one in (reference_files or [])]
@@ -428,6 +767,48 @@ def stage_task_reference_files(
                     ),
                 )
             )
+            if render_text:
+                extractions.append(
+                    _extract_one(
+                        source=source,
+                        relative=relative,
+                        workspace=workspace,
+                        limit=workspace_file_limit,
+                    )
+                )
+            continue
+        if size > workspace_file_limit:
+            # Refused so that the rest of the task can work. Staging it would
+            # not give the model the file -- the backend cannot read anything
+            # this big either -- it would make the walk over the workspace raise,
+            # and the walk runs on `write`. One 2 MB spreadsheet left in place
+            # costs the task every deliverable it tries to save.
+            #
+            # 24 of the 261 files in the pinned revision are in this band, and
+            # 5 of them have a text rendering worth having. The rendering is
+            # made below and named in the guide; the original is recorded here
+            # as not delivered, because it is not.
+            refused.append(
+                RefusedFile(
+                    relative_path=relative.as_posix(),
+                    reason=TOO_LARGE_FOR_THE_WORKSPACE,
+                    detail=(
+                        f"{size} bytes, over the {workspace_file_limit} byte "
+                        "limit the fixture workspace applies to every file it "
+                        "holds. Staged, it would make every write fail rather "
+                        "than only this file's read."
+                    ),
+                )
+            )
+            if render_text:
+                extractions.append(
+                    _extract_one(
+                        source=source,
+                        relative=relative,
+                        workspace=workspace,
+                        limit=workspace_file_limit,
+                    )
+                )
             continue
         if running_total + size > MAX_INPUT_TOTAL:
             refused.append(
@@ -465,12 +846,32 @@ def stage_task_reference_files(
 
         running_total += staged.size_bytes
         delivered.append(staged)
+        if render_text:
+            extractions.append(
+                _extract_one(
+                    source=source,
+                    relative=relative,
+                    workspace=workspace,
+                    limit=workspace_file_limit,
+                )
+            )
+
+    guide = None
+    if render_text and (delivered or refused):
+        guide = _write_inputs_guide(
+            workspace=workspace,
+            delivered=delivered,
+            refused=refused,
+            extractions=extractions,
+        )
 
     return TaskStaging(
         task_id=task_id,
         workspace=str(workspace),
         delivered=tuple(delivered),
         refused=tuple(refused),
+        extractions=tuple(extractions),
+        guide=guide,
     )
 
 
@@ -479,6 +880,7 @@ def stage_cohort(
     tasks: Iterable[Any],
     snapshot_root: str | Path,
     into: str | Path,
+    render_text: bool = False,
 ) -> tuple[TaskStaging, ...]:
     """Stage every task in a bound cohort, each into its own directory.
 
@@ -496,6 +898,7 @@ def stage_cohort(
             snapshot_root=snapshot_root,
             into=into
             / hashlib.sha256(str(task.task_id).encode("utf-8")).hexdigest(),
+            render_text=render_text,
         )
         for task in tasks
     )
@@ -517,10 +920,15 @@ def staging_record(stagings: Sequence[TaskStaging]) -> dict[str, Any]:
     stagings = list(stagings)
     needed = [one for one in stagings if one.named]
     short = [one for one in needed if one.ran_without_its_inputs]
+    blind = [one for one in needed if one.could_open_nothing]
     reasons: dict[str, int] = {}
     for one in stagings:
         for refusal in one.refused:
             reasons[refusal.reason] = reasons.get(refusal.reason, 0) + 1
+    outcomes: dict[str, int] = {}
+    for one in stagings:
+        for rendering in one.extractions:
+            outcomes[rendering.outcome] = outcomes.get(rendering.outcome, 0) + 1
 
     return {
         "schema_version": STAGING_SCHEMA_VERSION,
@@ -528,16 +936,26 @@ def staging_record(stagings: Sequence[TaskStaging]) -> dict[str, Any]:
         "tasks_naming_reference_files": len(needed),
         "tasks_given_everything_they_named": len(needed) - len(short),
         "tasks_that_ran_without_some_input": len(short),
+        "tasks_that_could_open_nothing": len(blind),
         "files_delivered": sum(len(one.delivered) for one in stagings),
         "bytes_delivered": sum(
             file.size_bytes for one in stagings for file in one.delivered
         ),
         "refusals_by_reason": dict(sorted(reasons.items())),
+        "renderings_by_outcome": dict(sorted(outcomes.items())),
         "what_that_means": (
             f"{len(needed) - len(short)} of {len(needed)} tasks that name "
             "reference files were given all of them. "
             f"{len(short)} were not, and each missing file is named below. A "
             "failure on one of those is not evidence about the model."
+        ),
+        "what_a_rendering_is": (
+            "a text extraction made by core.file_reader, staged beside the file "
+            "it came from and never in place of it. It exists because "
+            "workspace_apply(read) decodes UTF-8 and almost every reference "
+            "file is binary, so with exec_run shut the model would otherwise be "
+            "unable to open its own inputs. It is lossy, and a task whose work "
+            "needs what it loses is a task this environment cannot set fairly"
         ),
         "tasks": [one.as_dict() for one in stagings],
     }
@@ -545,6 +963,14 @@ def staging_record(stagings: Sequence[TaskStaging]) -> dict[str, Any]:
 
 __all__ = [
     "CHANGED_WHILE_COPYING",
+    "EXTRACTION_FAILED",
+    "EXTRACTION_IS_A_LABEL",
+    "EXTRACTION_IS_EMPTY",
+    "EXTRACTION_IS_TEXT",
+    "EXTRACTION_PREFIX",
+    "EXTRACTION_TRUNCATED",
+    "ExtractedText",
+    "INPUTS_GUIDE",
     "LINK_FARM_DETAIL",
     "MODEL_INPUT_PREFIX",
     "NOT_A_PLAIN_FILE",
@@ -554,10 +980,12 @@ __all__ = [
     "RefusedFile",
     "StagedFile",
     "TOO_LARGE",
+    "TOO_LARGE_FOR_THE_WORKSPACE",
     "TOO_MANY",
     "TOTAL_TOO_LARGE",
     "TaskStaging",
     "UNSAFE_PATH",
+    "WORKSPACE_FILE_LIMIT",
     "snapshot_problem",
     "stage_cohort",
     "stage_task_reference_files",

--- a/batch-runner/core/agentic_v2_rehearsal_voice.py
+++ b/batch-runner/core/agentic_v2_rehearsal_voice.py
@@ -1,0 +1,257 @@
+"""A stand-in that works a real task, so the assembly is proven before it costs.
+
+:class:`~core.agentic_v2_conversation.ScriptedVoice` answers from a list written
+in advance. That is right for testing the loop -- a written list is the only way
+to put the loop in an exact state -- and wrong for testing everything *around*
+the loop, because a list of replies has to be written against a known workspace
+and so cannot be pointed at a task nobody has looked at yet.
+
+This is the other stand-in. It has no list. It reads what came back and chooses
+the next call from that, the way the standing instructions tell a real model to:
+open the guide, look at what is there, write something, commit it. Pointed at
+any of the 220 tasks it does the same four things, so the whole production path
+-- binding, staging, the fixture backend, the driver, deliverable collection,
+the record -- can be run end to end on real bytes without asking a model
+anything.
+
+**It is not a model and its output is not a result.** It cannot do the task; it
+writes a deliverable that says what it found and nothing more. What it proves is
+narrower and is the thing worth proving before money is spent: that a task's
+files arrive, that they can be opened, that a write lands, and that ``finalize``
+is accepted. A wiring fault in any of those looks, in a paid run, exactly like a
+model that could not do the work -- which is the confusion the whole
+pre-registration exists to prevent.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from core.agentic_v2_conversation import (
+    AskForTool,
+    GaveUp,
+    ModelReply,
+    ModelRequest,
+    ToolExchange,
+)
+from core.agentic_v2_reference_staging import INPUTS_GUIDE, MODEL_INPUT_PREFIX
+
+
+#: What the rehearsal writes, and the only file it ever writes.
+#:
+#: Named so that a rehearsal's output cannot be mistaken for a task's. A file
+#: called `report.docx` sitting in a deliverables directory is something
+#: somebody will eventually read as an answer.
+REHEARSAL_DELIVERABLE = "rehearsal-notes.md"
+
+#: Where the guide staging leaves the list of a task's inputs.
+GUIDE_PATH = f"{MODEL_INPUT_PREFIX}/{INPUTS_GUIDE}"
+
+#: How much of what was read is quoted back into the deliverable.
+#:
+#: Enough to tell a real rendering from an empty one by eye, short enough that a
+#: rehearsal over 220 tasks does not write a copy of the dataset.
+QUOTED_CHARACTERS = 400
+
+
+@dataclass
+class TaskRehearsal:
+    """What the stand-in found while working one task."""
+
+    guide_was_readable: bool = False
+    entries_seen: int = 0
+    wrote_a_file: bool = False
+    write_refused: str = ""
+    quoted: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "guide_was_readable": self.guide_was_readable,
+            "entries_seen": self.entries_seen,
+            "wrote_a_file": self.wrote_a_file,
+            "write_refused": self.write_refused,
+        }
+
+
+def _last(history: tuple[ToolExchange, ...]) -> ToolExchange | None:
+    return history[-1] if history else None
+
+
+def _was(exchange: ToolExchange, operation: str) -> bool:
+    return exchange.tool_name == "workspace_apply" and (
+        str(exchange.arguments.get("operation")) == operation
+    )
+
+
+@dataclass
+class RehearsalVoice:
+    """Works the task in four calls, choosing each from what came back.
+
+    Deterministic, and deliberately so: two rehearsals of the same stage differ
+    only where the workspace differs, which is what makes a difference worth
+    looking at. It spends nothing, and says so -- the loop refuses a voice that
+    does not declare which it is.
+    """
+
+    makes_paid_calls: bool = False
+    seen: dict[str, TaskRehearsal] = field(default_factory=dict)
+    _current: TaskRehearsal | None = field(default=None, init=False)
+
+    # The loop hands one voice to one task at a time, and a fresh request with
+    # an empty history is the start of a task. Keyed by prompt rather than by
+    # task id because the loop does not tell a voice which task it is on -- a
+    # model is not told either.
+    def _found(self, request: ModelRequest) -> TaskRehearsal:
+        key = request.task_prompt[:120]
+        if not request.history:
+            self._current = TaskRehearsal()
+            self.seen[key] = self._current
+        if self._current is None:  # a resumed run, or a history we did not start
+            self._current = self.seen.setdefault(key, TaskRehearsal())
+        return self._current
+
+    def next_turn(self, request: ModelRequest) -> ModelReply:
+        found = self._found(request)
+        call_id = f"rehearsal-{request.turn}"
+        last = _last(request.history)
+
+        # Running out of turns while still holding an unwritten answer is the
+        # one thing a real model must not do, so the stand-in does not model it:
+        # it commits what it has, or says plainly that it has nothing.
+        if request.turns_left <= 1 and not found.wrote_a_file:
+            return GaveUp(
+                note=(
+                    "the rehearsal ran out of turns before it wrote anything, "
+                    "which means the loop's turn ceiling is lower than the four "
+                    "calls the standing instructions ask for"
+                )
+            )
+
+        if last is None:
+            return AskForTool(
+                call_id=call_id,
+                tool_name="workspace_apply",
+                arguments={"operation": "read", "path": GUIDE_PATH},
+                why="the instructions say to open the guide to the inputs first",
+            )
+
+        if _was(last, "read"):
+            found.guide_was_readable = bool(last.ok)
+            if last.ok:
+                found.quoted = str(last.data.get("content") or "")[:QUOTED_CHARACTERS]
+            return AskForTool(
+                call_id=call_id,
+                tool_name="workspace_apply",
+                arguments={"operation": "list", "path": "."},
+                why="look at what is actually in the workspace",
+            )
+
+        if _was(last, "list"):
+            entries = last.data.get("entries")
+            found.entries_seen = len(entries) if isinstance(entries, list) else 0
+            return AskForTool(
+                call_id=call_id,
+                tool_name="workspace_apply",
+                arguments={
+                    "operation": "write",
+                    "path": REHEARSAL_DELIVERABLE,
+                    "content": self._notes(found),
+                },
+                why="write the one file this stand-in has to write",
+            )
+
+        if _was(last, "write"):
+            if not last.ok:
+                # The 1 MiB case, and the reason this rehearsal exists. A real
+                # model is told only `fixture_backend_error` and would retry
+                # until its budget was gone; the stand-in stops and names it, so
+                # the fault is in the record rather than in the model's column.
+                found.write_refused = str(last.error_type or "unknown")
+                return GaveUp(
+                    note=(
+                        "the workspace refused the write with "
+                        f"{found.write_refused}. Nothing the model could have "
+                        "done differently would have changed that"
+                    )
+                )
+            found.wrote_a_file = True
+            return AskForTool(
+                call_id=call_id,
+                tool_name="finalize",
+                arguments={
+                    "deliverables": [REHEARSAL_DELIVERABLE],
+                    "summary": "rehearsal only: the workspace was reachable",
+                },
+                why="commit the one file, which is what ends a task",
+            )
+
+        return GaveUp(
+            note=(
+                f"the rehearsal has no next step after {last.tool_name}, which "
+                "means the loop returned something it was not built to expect"
+            )
+        )
+
+    def _notes(self, found: TaskRehearsal) -> str:
+        quoted = found.quoted.strip() or "(nothing -- the guide could not be read)"
+        return (
+            "# Rehearsal notes\n\n"
+            "This file was written by a stand-in, not by a model. It is not an "
+            "answer to the task and must not be scored as one.\n\n"
+            f"- the guide at `{GUIDE_PATH}` was "
+            f"{'readable' if found.guide_was_readable else 'NOT readable'}\n"
+            f"- what the first read returned, first {QUOTED_CHARACTERS} "
+            "characters:\n\n"
+            "```\n"
+            f"{quoted}\n"
+            "```\n"
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        """What the rehearsal found, per task, for the record it writes."""
+        readable = sum(1 for one in self.seen.values() if one.guide_was_readable)
+        wrote = sum(1 for one in self.seen.values() if one.wrote_a_file)
+        refused = {
+            key: one.write_refused
+            for key, one in self.seen.items()
+            if one.write_refused
+        }
+        return {
+            "what_this_is": (
+                "a stand-in that opens the guide, lists the workspace, writes "
+                "one file and commits it. No model was asked anything and "
+                "nothing was spent"
+            ),
+            "tasks_worked": len(self.seen),
+            "guide_was_readable_in": readable,
+            "wrote_a_file_in": wrote,
+            "writes_refused": refused,
+            "this_is_not_a_result": (
+                "the deliverable is a note about the workspace. A grade "
+                "computed over these files would be a grade of this file's "
+                "wording"
+            ),
+        }
+
+
+def rehearsal_is_not_a_run() -> Mapping[str, Any]:
+    """The sentence a rehearsal record carries where a run carries a route.
+
+    Written here rather than at the call site so that the two cannot drift, and
+    so that anything reading a rehearsal record finds the disclaimer in the
+    place it would look for the model.
+    """
+    return {
+        "model": "none",
+        "why": (
+            "this was a rehearsal. The loop, the staging, the workspace and "
+            "the collection all ran; the model did not, because none was asked"
+        ),
+        "what_it_does_not_show": (
+            "whether a model can do these tasks. It shows only that a model "
+            "asked to do them would have had files to open and somewhere to "
+            "write"
+        ),
+        "cost": "none -- no call was made, which is not the same as $0 measured",
+    }

--- a/batch-runner/core/agentic_v2_runner.py
+++ b/batch-runner/core/agentic_v2_runner.py
@@ -635,6 +635,22 @@ class AgenticV2ScriptedRunner:
                     "budget_caps": deepcopy(self.budget_caps),
                 },
             }
+            # Only when the backend offers one, and only when it is not empty.
+            # A task that starts with nothing in its workspace produces the
+            # record it produced before this existed, which is what keeps every
+            # run made until now verifiable against the same code.
+            declare = getattr(backend, "initial_workspace_declaration", None)
+            if callable(declare):
+                try:
+                    starting_entries = declare()
+                except Exception:
+                    lifecycle.transition(LifecycleState.FAILED)
+                    return finish(_failure(
+                        "compute_start_failed", lifecycle, audit_chain,
+                        public_chain, stage="startup",
+                    ))
+                if starting_entries:
+                    started_payload["initial_workspace"] = starting_entries
             # Ask now whether a record built on this would verify later. The
             # checks above cover what the runner can compare things to; this
             # covers what the backend's own declared standard requires of it,

--- a/batch-runner/experiments/execution_envelope/agentic_stage_one_plan.yaml
+++ b/batch-runner/experiments/execution_envelope/agentic_stage_one_plan.yaml
@@ -161,6 +161,89 @@ fixed_settings:
 # If any of the three has opened, the free check refuses regardless of money.
 safety_blocks_must_stay_closed: true
 
+# ── What the model is told before it sees the task ────────────────────────
+#
+# Sent as `instructions=` on every turn, beside the task wording. Until now this
+# key did not exist, so the runner sent the empty string — and the file that
+# describes this run went on saying the standing instructions "describe the V2
+# tool contract", which they did not, because there were none.
+#
+# What goes here is bounded by two things that are not opinions.
+#
+# The money. cost.assumptions_come_from borrows a width of 7307 characters for
+# this text from advance_check_plan.yaml, and every estimate in this file was
+# worked out at that width. Longer wording is not a style question: it is
+# spending against an approval computed for something else, on every turn of
+# every task. test_the_instructions_fit_what_they_were_priced_at reads both
+# numbers and fails if this one passes that one.
+#
+# The task wording. It is dataset-supplied and sealed against edits by
+# core/agentic_v2_manifest_binding.py, so nothing below may restate, summarise
+# or nudge it. Everything here is about the room the model is working in.
+#
+# Three claims below were measured against this repository rather than assumed,
+# and each would be worth re-checking if the backend changes:
+#
+#   - exec_run, environment_resolve and environment_activate answer
+#     `capability_unavailable`. Run against the fixture backend, not read.
+#   - workspace_apply(read) decodes UTF-8, and 258 of the 261 reference files
+#     the 220 tasks name do not decode. Without the text versions this wording
+#     points at, a model can list its inputs and open three of them.
+#   - a file over 1 MiB anywhere in the workspace makes every write fail, so
+#     the size sentence is load-bearing rather than tidy-minded.
+instructions: |
+  You are completing a professional work task. Do the work and leave the
+  finished deliverables in your working directory as real files.
+
+  Your tools are capabilities_query, workspace_apply, exec_run,
+  environment_resolve, environment_activate, browser_run, verify_public and
+  finalize.
+
+  Three of them refuse in this run, every time, with capability_unavailable:
+  exec_run, environment_resolve and environment_activate. No commands run
+  here. There is no shell, no Python, no pandas, no ffmpeg, no image tools.
+  Anything you would normally do by running code, you do by writing the file
+  yourself. Calling them again will not change the answer, and the calls are
+  counted against you.
+
+  YOUR INPUT FILES
+
+  The files the task refers to were copied into your working directory before
+  you started, under inputs/. Read inputs/INPUTS.md first. It names every one
+  of them, gives its size, and says whether a text version exists.
+
+  workspace_apply with operation: read returns text and only text. Reading a
+  spreadsheet, a PDF, a Word document or an image that way fails, because
+  those bytes are not text. That failure is the file's format, not a mistake
+  you made, and trying again will not change it.
+
+  Where a text version exists, INPUTS.md gives its path under
+  inputs/extracted/. A text version was read out of the original by a
+  converter. It is not the file. Layout, styling, images, charts, and anything
+  a picture carries are gone, and a long one may have been cut short — it says
+  so at the end if it was. If the work needed what was lost, say that in your
+  answer.
+
+  Some files the task names may not be in your directory at all. INPUTS.md
+  lists those too, with the reason. Nothing was put in their place. Do the
+  work with what you have and say plainly what you could not see. An answer
+  that admits a gap is worth more than one written as though nothing was
+  missing.
+
+  WRITING YOUR ANSWER
+
+  Write deliverables with workspace_apply, operation: write, into your working
+  directory — not under inputs/, which holds what you were given. Keep every
+  file under 1 MiB. One larger file anywhere in the directory makes every
+  later write fail.
+
+  When the work is done, call finalize with the list of deliverable paths and
+  a short summary. A file you do not list is not collected. An empty file
+  cannot be collected.
+
+  If you cannot do the task, say why in the summary and call finalize anyway.
+  An account of what stopped you is worth more than an empty directory.
+
 # ── What may be spent ─────────────────────────────────────────────────────
 cost:
   # ── Two amounts, because they are two decisions ─────────────────────────

--- a/batch-runner/scripts/run_agentic_v2_stage.py
+++ b/batch-runner/scripts/run_agentic_v2_stage.py
@@ -546,12 +546,18 @@ def main() -> int:
                 reference_files=kwargs.get("reference_files") or (),
                 snapshot_root=dataset_root,
                 into=task_root / "work" / MODEL_INPUT_PREFIX,
+                render_text=True,
             )
             stagings.append(staged)
             if staged.ran_without_its_inputs:
                 print(
                     f"  {task_id}  staged {len(staged.delivered)} of "
                     f"{staged.named} files; a failure here is not the model's"
+                )
+            if staged.could_open_nothing:
+                print(
+                    f"  {task_id}  has files and can open none of them; a "
+                    "failure here is not the model's either"
                 )
             return AgenticV2FixtureBackend(root=task_root, **kwargs)
         factory = build_runner_factory(

--- a/batch-runner/scripts/run_agentic_v2_stage.py
+++ b/batch-runner/scripts/run_agentic_v2_stage.py
@@ -44,6 +44,7 @@ reply, never a credential — same rule as the stage A probe, for the same reaso
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import sys
 import tempfile
@@ -74,6 +75,13 @@ from core.agentic_v2_manifest_binding import (  # noqa: E402
     binding_record,
 )
 from core.agentic_v2_preregistration import STAGE_SIZES  # noqa: E402
+from core.agentic_v2_reference_staging import (  # noqa: E402
+    MODEL_INPUT_PREFIX,
+    TaskStaging,
+    snapshot_problem,
+    stage_task_reference_files,
+    staging_record,
+)
 from core.agentic_v2_route_check import (  # noqa: E402
     check_route_is_the_one_the_plan_fixed,
 )
@@ -278,6 +286,19 @@ def main() -> int:
     parser.add_argument("--plan", type=Path, default=STAGE_ONE_PLAN_PATH)
     parser.add_argument("--parquet", type=Path, default=PINNED_DATASET_PARQUET)
     parser.add_argument(
+        "--dataset-root",
+        type=Path,
+        default=None,
+        help=(
+            "Where the reference files are copied from. Defaults to the "
+            "directory holding --parquet's own snapshot, so the prompts and "
+            "the files a task opens always come from one revision. Must be a "
+            "directory of real files: a huggingface_hub cache is a tree of "
+            "symlinks into a blob store outside it, and nothing here will "
+            "follow one. Fetch with `hf download ... --local-dir <dir>`."
+        ),
+    )
+    parser.add_argument(
         "--run-id",
         default=None,
         help=(
@@ -322,6 +343,29 @@ def main() -> int:
             catalog=catalog,
             catalog_digest=catalog_sha256(),
         )
+        # The snapshot the prompts were read from, so a task cannot be given a
+        # prompt from one revision and a file from another.
+        dataset_root = (
+            args.dataset_root
+            if args.dataset_root is not None
+            else args.parquet.parent.parent
+        )
+        # Asked once, here, rather than discovered 261 times during the run.
+        # A cache of symlinks refuses every file individually and the run then
+        # looks like 125 tasks that failed on their merits, which is the single
+        # most expensive way to find out that a directory was wrong. Only asked
+        # when this cohort actually opens something: a stage whose tasks name no
+        # files is not blocked by a directory it will never read.
+        if any(task.reference_files for task in bound.tasks):
+            wrong_root = snapshot_problem(dataset_root)
+            if wrong_root is not None:
+                raise StageRefused(
+                    "the reference files cannot be staged from "
+                    f"{dataset_root}: {wrong_root}\n\n"
+                    "Refused before spending, because running anyway would "
+                    "hand every task an empty workspace and produce failures "
+                    "that read as the model's."
+                )
         # Priced over the whole stage, never over the shard. A shard is a way of
         # fitting the run into the place it has to happen, not a smaller
         # purchase — pricing each piece separately would let seventeen runs that
@@ -389,10 +433,14 @@ def main() -> int:
         print("  marking        not approved for this stage, and not spent here")
         print(f"                 {money['grading_not_approved_because']}")
     print(f"  isolation      none — fixture backend, exec_run shut")
+    # Was a flat count of tasks whose files "are not in the workspace", which
+    # stopped being true the moment staging existed. What is still true, and is
+    # what a reader needs, is where they come from and the one that cannot be
+    # delivered at any setting.
     print(
-        f"  handicap       {needs['tasks_needing_reference_files_count']} of "
-        f"{len(bound.tasks)} tasks name reference files that are not in the "
-        "workspace"
+        f"  inputs         {needs['tasks_needing_reference_files_count']} of "
+        f"{len(bound.tasks)} tasks name reference files, staged from "
+        f"{dataset_root}"
     )
     print()
 
@@ -462,13 +510,50 @@ def main() -> int:
             )
 
         workspaces = into / "workspaces"
+        workspaces.mkdir(parents=True, exist_ok=True)
+        stagings: list[TaskStaging] = []
+        attempts_staged: dict[str, int] = {}
 
         def backend_factory(**kwargs):
-            task_root = workspaces / f"task-{len(list(workspaces.glob('task-*')))}"
-            task_root.mkdir(parents=True, exist_ok=True)
-            return AgenticV2FixtureBackend(root=task_root, **kwargs)
+            """One root per attempt, with that attempt's own copy of the inputs.
 
-        workspaces.mkdir(parents=True, exist_ok=True)
+            Named by the task rather than by how many directories exist, which
+            is what it counted before. A counter answers "how many have run",
+            and the question here is "which task is this" — so a resumed run,
+            or any run where a directory was made for something else, silently
+            handed a task the workspace belonging to another one.
+
+            Re-staged per attempt rather than shared, because the model writes
+            its deliverables into this same tree: a second attempt handed the
+            first attempt's directory starts with the first attempt's output
+            already in it, which is not a retry of the task.
+            """
+            task_id = str(kwargs.get("task_id") or "unknown-task")
+            attempt = attempts_staged[task_id] = attempts_staged.get(task_id, 0) + 1
+            task_root = (
+                workspaces
+                / f"{hashlib.sha256(task_id.encode('utf-8')).hexdigest()[:16]}"
+                f"-attempt-{attempt}"
+            )
+            task_root.mkdir(parents=True, exist_ok=True)
+            # Beneath `work/`, because that is the directory the backend opens
+            # and the only one the model can reach. Beneath `inputs/` within it,
+            # so the path in the record -- `inputs/reference_files/...` -- is
+            # where the file actually is rather than a label for where it
+            # morally belongs.
+            staged = stage_task_reference_files(
+                task_id=task_id,
+                reference_files=kwargs.get("reference_files") or (),
+                snapshot_root=dataset_root,
+                into=task_root / "work" / MODEL_INPUT_PREFIX,
+            )
+            stagings.append(staged)
+            if staged.ran_without_its_inputs:
+                print(
+                    f"  {task_id}  staged {len(staged.delivered)} of "
+                    f"{staged.named} files; a failure here is not the model's"
+                )
+            return AgenticV2FixtureBackend(root=task_root, **kwargs)
         factory = build_runner_factory(
             backend_factory=backend_factory,
             profile=profile,
@@ -537,6 +622,10 @@ def main() -> int:
             }
         ),
         "approved_amounts": pricing.as_dict(),
+        # What each task was actually handed, per attempt, by name. The binding
+        # record's `unmet_needs` says which tasks *want* files; this says which
+        # got them. A result is read against this one.
+        "reference_files": staging_record(stagings),
         "environment": environment_note(profile),
         "route_fingerprint": managed.runtime_fingerprint,
         "chosen_settings": chosen.as_dict(),

--- a/batch-runner/scripts/run_agentic_v2_stage.py
+++ b/batch-runner/scripts/run_agentic_v2_stage.py
@@ -51,6 +51,7 @@ import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
 if str(BATCH_RUNNER_ROOT) not in sys.path:
@@ -333,7 +334,25 @@ def main() -> int:
             "run would be allowed to go ahead."
         ),
     )
+    parser.add_argument(
+        "--rehearse",
+        action="store_true",
+        help=(
+            "Run the whole stage with a stand-in instead of a model: real "
+            "binding, real files, real workspace, real collection, no call and "
+            "no cost. Writes rehearsal_record.json rather than "
+            "run_record.json, because a rehearsal is not a result."
+        ),
+    )
     args = parser.parse_args()
+
+    if args.dry_run and args.rehearse:
+        print(
+            "Refused: --dry-run and --rehearse ask for different things. The "
+            "first stops before the work, the second does the work without a "
+            "model. Pick one."
+        )
+        return 1
 
     try:
         plan, verdict, catalog = verdict_for(args.plan)
@@ -451,6 +470,14 @@ def main() -> int:
         )
         return 0
 
+    if args.rehearse:
+        print(
+            "Rehearsal. A stand-in works every task and no model is asked, so "
+            "the amounts above are what the paid run would be allowed rather "
+            "than what this one costs. Nothing here is a result."
+        )
+        print()
+
     into = (
         args.into
         if args.into is not None
@@ -465,26 +492,39 @@ def main() -> int:
     from core.agentic_v2_model_voice import AzureFoundryVoice
     from core.azure_ai_clients import AzureAIRouteSettings, AzureAIWorkload
     from core.llm_client import create_typed_azure_client
-
-    settings = AzureAIRouteSettings.from_env()
-    managed = create_typed_azure_client(
-        AzureAIWorkload.INFERENCE,
-        deployment,
-        settings=settings,
-        timeout=float(plan["fixed_settings"]["per_task_timeout_seconds"]),
+    from core.agentic_v2_rehearsal_voice import (
+        RehearsalVoice,
+        rehearsal_is_not_a_run,
     )
-    prices = load_price_table()
+
+    # A rehearsal never builds a client. Not as an optimisation: a client that
+    # exists is a client something can be sent through, and the one thing this
+    # mode promises is that nothing was asked. There is no route to check for
+    # the same reason -- there is no route.
+    rehearsing = RehearsalVoice() if args.rehearse else None
+    managed = None
+    prices: Any = {}
+    if rehearsing is None:
+        settings = AzureAIRouteSettings.from_env()
+        managed = create_typed_azure_client(
+            AzureAIWorkload.INFERENCE,
+            deployment,
+            settings=settings,
+            timeout=float(plan["fixed_settings"]["per_task_timeout_seconds"]),
+        )
+        prices = load_price_table()
 
     try:
-        wrong_route = check_route_is_the_one_the_plan_fixed(
-            managed.route, connection, settings=settings
-        )
-        if wrong_route:
-            print(
-                "Refused after building a client and before asking it "
-                "anything.\n\n  - " + "\n  - ".join(wrong_route)
+        if rehearsing is None:
+            wrong_route = check_route_is_the_one_the_plan_fixed(
+                managed.route, connection, settings=settings
             )
-            return 1
+            if wrong_route:
+                print(
+                    "Refused after building a client and before asking it "
+                    "anything.\n\n  - " + "\n  - ".join(wrong_route)
+                )
+                return 1
 
         held = TaskConversations(ceilings, RunWideCeilings())
         attempts: dict[str, int] = {}
@@ -565,30 +605,40 @@ def main() -> int:
             profile=profile,
             conversations=held,
             attempt_of=attempt_of,
-            voice_for=voice_for,
+            **(
+                {"voice": rehearsing}
+                if rehearsing is not None
+                else {"voice_for": voice_for}
+            ),
         )
 
         from core.cost_receipts import CostReceiptLedger
 
-        ledger = CostReceiptLedger(str(into / "cost_receipts.sqlite3"))
+        if rehearsing is not None:
+            # Every task ends unaccounted, which is the true answer. A rehearsal
+            # makes no call, and a ledger row saying $0 would be the one number
+            # that reads as a measurement of a model that was never asked.
+            receipt_for = lambda task, attempt: None  # noqa: E731
+        else:
+            ledger = CostReceiptLedger(str(into / "cost_receipts.sqlite3"))
 
-        def receipt_for(task, attempt: int):
-            outcome = held.outcome_of(task.task_id, attempt)
-            if outcome is None:
-                return None
-            turns = model_turns_of(
-                outcome,
-                run_id=run_id,
-                task_id=task.task_id,
-                attempt=attempt,
-                provider="azure",
-                requested_model=deployment,
-                deployment=deployment,
-                resolved_model=None,
-            )
-            return bind_run_to_ledger(
-                ledger, task_id=task.task_id, model_turns=turns
-            )
+            def receipt_for(task, attempt: int):
+                outcome = held.outcome_of(task.task_id, attempt)
+                if outcome is None:
+                    return None
+                turns = model_turns_of(
+                    outcome,
+                    run_id=run_id,
+                    task_id=task.task_id,
+                    attempt=attempt,
+                    provider="azure",
+                    requested_model=deployment,
+                    deployment=deployment,
+                    resolved_model=None,
+                )
+                return bind_run_to_ledger(
+                    ledger, task_id=task.task_id, model_turns=turns
+                )
 
         outcome = run_manifest(
             tasks_to_run,
@@ -598,14 +648,19 @@ def main() -> int:
             collect_into=into / "deliverables",
             receipt_for=receipt_for,
             on_task=lambda task_id, row: print(
-                f"  {task_id}  {'ok' if row.get('success') else 'failed'}"
+                # `status`, not a `success` key -- the row is a report row and
+                # has never carried one, so the old `row.get("success")` read
+                # None for every task and printed "failed" beside five tasks
+                # that had all succeeded.
+                f"  {task_id}  {'ok' if row.get('status') == 'success' else 'failed'}"
             ),
         )
     except DriverRefused as refusal:
         print(f"\nThe run was refused.\n\n{refusal}")
         return 1
     finally:
-        managed.close()
+        if managed is not None:
+            managed.close()
 
     record = {
         "stage": args.stage,
@@ -633,19 +688,38 @@ def main() -> int:
         # got them. A result is read against this one.
         "reference_files": staging_record(stagings),
         "environment": environment_note(profile),
-        "route_fingerprint": managed.runtime_fingerprint,
+        "route_fingerprint": (
+            rehearsal_is_not_a_run()
+            if rehearsing is not None
+            else managed.runtime_fingerprint
+        ),
         "chosen_settings": chosen.as_dict(),
         "conversations": held.as_dict(),
         "run": outcome.as_dict(),
     }
+    if rehearsing is not None:
+        record["rehearsal"] = rehearsing.as_dict()
     written = json.dumps(record, indent=2, sort_keys=True, default=str)
-    (into / "run_record.json").write_text(written + "\n", encoding="utf-8")
+    # A different name, so that nothing which reads a run's record can be handed
+    # a rehearsal's by accident. The disclaimer inside it is for a person; the
+    # filename is for everything else.
+    name = "rehearsal_record.json" if rehearsing is not None else "run_record.json"
+    (into / name).write_text(written + "\n", encoding="utf-8")
 
     summary = outcome.summary
     print()
-    print(f"  record         {into / 'run_record.json'}")
+    print(f"  record         {into / name}")
     print(f"  finished       {summary.get('succeeded', 0)} of {len(tasks_to_run)}")
-    print(f"  spent          {held.spent}")
+    if rehearsing is not None:
+        found = rehearsing.as_dict()
+        print(
+            f"  guide readable {found['guide_was_readable_in']} of "
+            f"{found['tasks_worked']} tasks"
+        )
+        print(f"  wrote a file   {found['wrote_a_file_in']} of {found['tasks_worked']}")
+        print("  spent          nothing — no model was asked")
+    else:
+        print(f"  spent          {held.spent}")
     if shard is not None:
         print(
             f"\nThis was shard {shard.index} of {shard.of}. The stage has not "

--- a/batch-runner/tests/test_a_task_that_starts_with_input_files_still_verifies.py
+++ b/batch-runner/tests/test_a_task_that_starts_with_input_files_still_verifies.py
@@ -1,0 +1,477 @@
+"""A task whose workspace is not empty at the start must survive verification.
+
+Staging reference files into the workspace broke every task that used it, and
+it broke them in the worst available way: after the work was done. The model
+read its inputs, wrote its deliverable and committed an answer, and then
+:func:`verify_agentic_v2_result` threw the whole thing away with ``agentic v2
+initial fixture state mismatch``. The record called it ``runner_internal_error``
+and kept no files. A paid run would have been charged for every one of those
+tasks and scored as though the model had produced nothing.
+
+Two separate causes, and both are guarded here.
+
+*The replay modelled every workspace as starting empty.* There was no way to say
+otherwise, so the startup digest could never agree with a backend that had files
+in it. The fix is a declaration in the ``started`` event, and the tests below
+pin what it may contain -- digests and sizes, never bytes, because the inputs run
+to hundreds of megabytes and a trace is not a file store.
+
+*The modes disagreed.* The replay models every directory as 0o700 and every
+file as 0o600; ``Path.mkdir(mode=..., parents=True)`` applies its mode to the
+last component only, and ``mkdir(exist_ok=True)`` ignores it entirely for a
+directory somebody else already made. A tree that is 0o755 halfway down is a
+different digest and the same rejection, reached by a route that looks nothing
+like a permissions problem. There is a test per route because each was found
+separately and each can come back separately.
+
+A third thing is checked and is not a bug: a task that names no files must still
+get the guide. The model's standing instructions send it to ``inputs/INPUTS.md``
+first, and one failed tool call ends a task outright, so skipping the guide for
+those tasks killed 95 of the 220 on turn one -- as a model failure, in the
+record. The guide is unconditional now and this file holds it that way. How many
+tasks that is is counted from the catalogue in
+``tests/test_agentic_v2_reference_staging.py``, because the figure was written
+down by hand first and was wrong by fifty.
+
+Nothing here calls a model or spends anything.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core import agentic_v2_provenance as provenance  # noqa: E402
+from core.agentic_v2_contract import AgenticV2Profile  # noqa: E402
+from core.agentic_v2_fixture_backend import AgenticV2FixtureBackend  # noqa: E402
+from core.agentic_v2_reference_staging import (  # noqa: E402
+    MODEL_INPUT_PREFIX,
+    stage_task_reference_files,
+)
+
+TEXT = b"a readable input file\n"
+BINARY = b"\x89PNG\r\n\x1a\n\xff\xfe\x00not text"
+CAPS = {"tool_calls": 32, "wall_seconds": 1200}
+
+
+@pytest.fixture
+def snapshot(tmp_path: Path) -> Path:
+    root = tmp_path / "snapshot"
+    folder = root / "reference_files" / "abc123"
+    folder.mkdir(parents=True)
+    (folder / "notes.txt").write_bytes(TEXT)
+    (folder / "logo.png").write_bytes(BINARY)
+    return root
+
+
+def _stage(snapshot: Path, work: Path, *names: str) -> None:
+    stage_task_reference_files(
+        task_id="t",
+        reference_files=list(names),
+        snapshot_root=snapshot,
+        into=work / MODEL_INPUT_PREFIX,
+        render_text=True,
+    )
+
+
+def _backend(root: Path) -> AgenticV2FixtureBackend:
+    return AgenticV2FixtureBackend(
+        root=root,
+        profile=AgenticV2Profile(
+            policy_profile_id="offline-full-v1",
+            tool_contract_version="2.0",
+            foundation_only=True,
+        ),
+        budget_caps=CAPS,
+    )
+
+
+def _started_payload(declaration) -> dict:
+    payload = {
+        "run_id": "r",
+        "condition": "c",
+        "task_id": "t",
+        "backend_identity": {
+            "backend_id": "x",
+            "foundation_only": True,
+            "implementation_sha256": "0" * 64,
+        },
+        "capabilities": {},
+        "policy_profile_id": "offline-full-v1",
+        "runtime": {
+            "substrate_manifest_sha256": "0" * 64,
+            "package_snapshot_sha256": "0" * 64,
+            "browser_build_sha256": "0" * 64,
+            "budget_caps": CAPS,
+        },
+    }
+    if declaration:
+        payload["initial_workspace"] = declaration
+    return payload
+
+
+def _real_started_payload(backend, declaration) -> dict:
+    """The payload the runner would build, taken from the backend's own startup.
+
+    Hand-writing one is fine for the ledger, which only reads a few fields, and
+    no good for :func:`_valid_started_payload`, which re-derives the identity
+    and would reject a stand-in for reasons that have nothing to do with what
+    is being tested here.
+    """
+    startup = backend.start(30.0)
+    data = startup["data"]
+    payload = {
+        "run_id": "r",
+        "condition": "c",
+        "task_id": "t",
+        "backend_identity": dict(data["backend_identity"]),
+        "capabilities": dict(data["capabilities"]),
+        "policy_profile_id": backend.profile.policy_profile_id,
+        "runtime": {
+            "substrate_manifest_sha256": data["substrate_manifest"]["sha256"],
+            "package_snapshot_sha256": data["package_snapshot_sha256"],
+            "browser_build_sha256": data["browser_build_sha256"],
+            "budget_caps": dict(backend.budget_caps),
+        },
+    }
+    if declaration:
+        payload["initial_workspace"] = declaration
+    return payload
+
+
+def _modelled_digest(payload) -> str:
+    return provenance._fixture_state_sha256(
+        provenance._new_fixture_semantic_ledger(payload)
+    )
+
+
+# --------------------------------------------------------------------------
+# The digest the replay computes has to be the digest the backend reports.
+# --------------------------------------------------------------------------
+
+
+def test_a_staged_workspace_verifies_against_the_state_the_backend_reports(
+    snapshot, tmp_path
+):
+    """The whole point. Everything else in this file is a way this can fail."""
+    root = tmp_path / "task"
+    _stage(snapshot, root / "work", "reference_files/abc123/notes.txt")
+    backend = _backend(root)
+    try:
+        payload = _started_payload(backend.initial_workspace_declaration())
+        assert backend.state_sha256() == _modelled_digest(payload)
+    finally:
+        backend.close()
+
+
+def test_an_empty_workspace_declares_nothing_and_still_verifies(tmp_path):
+    """Every record written before the declaration existed must still verify.
+
+    The declaration is emitted only when the workspace has something in it, so
+    a run from before this change is not a run with a missing field.
+    """
+    backend = _backend(tmp_path / "task")
+    try:
+        assert backend.initial_workspace_declaration() == []
+        assert backend.state_sha256() == _modelled_digest(_started_payload([]))
+    finally:
+        backend.close()
+
+
+def test_a_work_root_someone_else_created_is_taken_back_to_0700(tmp_path):
+    """Staging makes ``work/`` before the backend is built.
+
+    ``mkdir(mode=0o700, exist_ok=True)`` does nothing to a directory that is
+    already there, so the umask's 0o755 survived into the state digest and
+    disagreed with the replay, which models this root as 0o700.
+    """
+    root = tmp_path / "task"
+    (root / "work").mkdir(parents=True)
+    (root / "work").chmod(0o755)
+
+    backend = _backend(root)
+    try:
+        mode, _, _ = backend._workspace_snapshot()
+        assert stat.S_IMODE(mode) == 0o700
+    finally:
+        backend.close()
+
+
+def test_every_directory_staging_creates_is_0700_and_every_file_0600(
+    snapshot, tmp_path
+):
+    """Including the ones ``parents=True`` creates on the way down.
+
+    ``inputs/reference_files/`` and ``inputs/extracted/`` are intermediate
+    components, so they took the umask while their leaves took the mode. The
+    leaves are the ones anybody looks at.
+    """
+    work = tmp_path / "task" / "work"
+    _stage(
+        snapshot,
+        work,
+        "reference_files/abc123/notes.txt",
+        "reference_files/abc123/logo.png",
+    )
+
+    wrong = {
+        str(path.relative_to(work)): oct(stat.S_IMODE(path.lstat().st_mode))
+        for path in work.rglob("*")
+        if stat.S_IMODE(path.lstat().st_mode)
+        != (0o700 if path.is_dir() else 0o600)
+    }
+
+    assert wrong == {}
+    assert (work / MODEL_INPUT_PREFIX / "reference_files").is_dir()
+
+
+# --------------------------------------------------------------------------
+# What the declaration is allowed to say.
+# --------------------------------------------------------------------------
+
+
+def test_the_declaration_carries_digests_and_never_bytes(snapshot, tmp_path):
+    root = tmp_path / "task"
+    _stage(snapshot, root / "work", "reference_files/abc123/notes.txt")
+    backend = _backend(root)
+    try:
+        declaration = backend.initial_workspace_declaration()
+    finally:
+        backend.close()
+
+    files = [one for one in declaration if one["kind"] == "file"]
+    directories = [one for one in declaration if one["kind"] == "directory"]
+
+    assert directories and files
+    assert all(set(one) == {"path", "kind"} for one in directories)
+    assert all(
+        set(one) == {"path", "kind", "sha256", "size", "decodes_as_utf8"}
+        for one in files
+    )
+    staged = next(one for one in files if one["path"].endswith("notes.txt"))
+    assert staged["sha256"] == hashlib.sha256(TEXT).hexdigest()
+    assert staged["size"] == len(TEXT)
+
+
+def test_the_declaration_says_which_files_a_read_could_open(snapshot, tmp_path):
+    """A digest cannot tell the replay whether a read should have worked.
+
+    Without this field a backend that reported every input as unreadable would
+    be believed, and "the model was given nothing it could open" would verify
+    exactly as cleanly as the truth.
+    """
+    root = tmp_path / "task"
+    _stage(
+        snapshot,
+        root / "work",
+        "reference_files/abc123/notes.txt",
+        "reference_files/abc123/logo.png",
+    )
+    backend = _backend(root)
+    try:
+        declaration = backend.initial_workspace_declaration()
+    finally:
+        backend.close()
+
+    readable = {
+        one["path"]: one["decodes_as_utf8"]
+        for one in declaration
+        if one["kind"] == "file"
+    }
+    assert readable["inputs/reference_files/abc123/notes.txt"] is True
+    assert readable["inputs/reference_files/abc123/logo.png"] is False
+
+
+@pytest.mark.parametrize(
+    "declaration",
+    [
+        pytest.param("inputs", id="not a list"),
+        pytest.param([{"path": "a", "kind": "socket"}], id="unknown kind"),
+        pytest.param(
+            [{"path": "a", "kind": "directory", "mode": 448}],
+            id="directory with an extra key",
+        ),
+        pytest.param(
+            [{"path": "a", "kind": "file", "sha256": "0" * 64, "size": 1}],
+            id="file missing whether it decodes",
+        ),
+        pytest.param(
+            [
+                {
+                    "path": "a",
+                    "kind": "file",
+                    "sha256": "nope",
+                    "size": 1,
+                    "decodes_as_utf8": True,
+                }
+            ],
+            id="digest is not a digest",
+        ),
+        pytest.param(
+            [
+                {
+                    "path": "a",
+                    "kind": "file",
+                    "sha256": "0" * 64,
+                    "size": -1,
+                    "decodes_as_utf8": True,
+                }
+            ],
+            id="negative size",
+        ),
+        pytest.param(
+            [{"path": "../escape", "kind": "directory"}], id="climbs out"
+        ),
+        pytest.param([{"path": ".", "kind": "directory"}], id="the root itself"),
+        pytest.param(
+            [
+                {"path": "a", "kind": "directory"},
+                {"path": "a", "kind": "directory"},
+            ],
+            id="same path twice",
+        ),
+    ],
+)
+def test_a_declaration_that_is_not_the_agreed_shape_is_refused(declaration):
+    assert provenance._valid_initial_workspace(declaration) is False
+
+
+def test_a_started_payload_carrying_a_bad_declaration_is_refused(
+    snapshot, tmp_path
+):
+    """And a good one is admitted, against the real payload the runner builds.
+
+    The key-set gate is the only thing standing between the declaration and the
+    event schema, which types ``payload`` as nothing more specific than an
+    object.
+    """
+    root = tmp_path / "task"
+    _stage(snapshot, root / "work", "reference_files/abc123/notes.txt")
+    backend = _backend(root)
+    try:
+        declaration = backend.initial_workspace_declaration()
+        good = _real_started_payload(backend, declaration)
+        bad = _real_started_payload(backend, [{"path": "..", "kind": "directory"}])
+        junk = _real_started_payload(backend, declaration)
+        junk["something_else"] = 1
+    finally:
+        backend.close()
+
+    assert provenance._valid_started_payload(good) is True
+    assert provenance._valid_started_payload(bad) is False
+    assert provenance._valid_started_payload(junk) is False
+
+
+def test_a_started_payload_without_the_field_is_still_valid(tmp_path):
+    """An empty workspace declares nothing, and that is not a missing field."""
+    backend = _backend(tmp_path / "task")
+    try:
+        payload = _real_started_payload(backend, [])
+    finally:
+        backend.close()
+
+    assert "initial_workspace" not in payload
+    assert provenance._valid_started_payload(payload) is True
+
+
+# --------------------------------------------------------------------------
+# Reading a staged file during the replay.
+# --------------------------------------------------------------------------
+
+
+def _staged(content: bytes = TEXT, *, decodes: bool = True):
+    return provenance._StagedFile(
+        sha256=hashlib.sha256(content).hexdigest(),
+        size=len(content),
+        decodes_as_utf8=decodes,
+    )
+
+
+def _read_result(text: str) -> dict:
+    return {"ok": True, "data": {"content": text}}
+
+
+def test_a_whole_read_teaches_the_replay_the_bytes_it_does_not_hold():
+    staged = _staged()
+
+    learned = provenance._learn_staged_bytes(
+        staged, {}, _read_result(TEXT.decode("utf-8"))
+    )
+
+    assert learned == TEXT
+    assert staged.content == TEXT
+
+
+def test_bytes_that_are_not_what_was_staged_are_refused():
+    """A backend that quietly rewrote a file fails here rather than verifying.
+
+    The digest was declared before the call, so this is a check and not the
+    replay agreeing with itself.
+    """
+    with pytest.raises(ValueError, match="does not match what was staged"):
+        provenance._learn_staged_bytes(
+            _staged(), {}, _read_result("something else entirely")
+        )
+
+
+def test_a_read_from_an_offset_refuses_rather_than_guessing():
+    with pytest.raises(ValueError, match="read from an offset"):
+        provenance._learn_staged_bytes(
+            _staged(), {"offset": 4}, _read_result(TEXT.decode("utf-8")[4:])
+        )
+
+
+def test_a_read_cut_short_by_a_limit_refuses_rather_than_guessing():
+    """A slice hashes to nothing the declaration knows.
+
+    Accepting it would turn the check into a formality, which is worse than
+    not having it, because the record would still say the trace verified.
+    """
+    with pytest.raises(ValueError, match="limit shorter than the file"):
+        provenance._learn_staged_bytes(
+            _staged(), {"limit": 4}, _read_result(TEXT.decode("utf-8")[:4])
+        )
+
+
+def test_a_read_with_no_result_to_check_against_refuses():
+    with pytest.raises(ValueError, match="no result to take its bytes from"):
+        provenance._learn_staged_bytes(_staged(), {}, {"ok": False})
+
+
+def test_a_file_that_does_not_decode_replays_as_the_error_it_really_was():
+    """Not as a read that worked, and not as a crash.
+
+    ``logo.png`` is a real input of a real task. The backend refuses to return
+    it as text, and the replay has to reach the same answer from the
+    declaration alone.
+    """
+    ledger = provenance._new_fixture_semantic_ledger(
+        _started_payload(
+            [
+                {"path": "inputs", "kind": "directory"},
+                {
+                    "path": "inputs/logo.png",
+                    "kind": "file",
+                    "sha256": hashlib.sha256(BINARY).hexdigest(),
+                    "size": len(BINARY),
+                    "decodes_as_utf8": False,
+                },
+            ]
+        )
+    )
+
+    replayed = provenance._replay_workspace_apply(
+        {"operation": "read", "path": "inputs/logo.png"},
+        ledger,
+        recorded=None,
+    )
+
+    assert replayed == {"ok": False, "error_type": "fixture_backend_error"}

--- a/batch-runner/tests/test_agentic_stage_one_budget.py
+++ b/batch-runner/tests/test_agentic_stage_one_budget.py
@@ -1816,3 +1816,137 @@ def test_a_plan_with_no_stages_block_refuses_rather_than_passing_by_default(
 
     assert not pricing.may_run
     assert "no `stages` block" in " ".join(pricing.problems)
+
+
+# ── What the model is actually told, and what that costs ───────────────────
+#
+# Until 2026-09-11 the plan had no `instructions` key at all, so the runner sent
+# the empty string on every turn while this repository's own notes said the
+# standing instructions "describe the V2 tool contract". The model was told
+# nothing: not that three of its eight tools refuse, not that its input files
+# exist, not where they are.
+#
+# The text is now in the plan, which puts it in two places at once. It is the
+# thing most likely to be edited casually, and it is billed on every turn of
+# every task -- so it is tested as both.
+
+
+@pytest.fixture
+def stage_one_instructions(stage_one_plan):
+    return stage_one_plan["instructions"]
+
+
+def test_the_runner_has_something_to_send(stage_one_instructions):
+    """`scripts/run_agentic_v2_stage.py` reads `plan.get("instructions") or ""`.
+
+    That expression cannot fail, which is exactly the problem: an absent key
+    reads as an empty instruction and the run still goes ahead, costing the same
+    money and producing a model that was never told anything.
+    """
+    assert isinstance(stage_one_instructions, str)
+    assert stage_one_instructions.strip()
+
+
+def test_the_instructions_fit_what_they_were_priced_at(
+    stage_one_instructions, assumptions
+):
+    """Named in the plan file's own comment, and this is that test.
+
+    Every figure under `cost:` was worked out at the width borrowed from
+    `advance_check_plan.yaml`. Wording longer than that is not a matter of
+    style: it is spending against an approval computed for something else, once
+    per turn, for every task in the cohort.
+    """
+    assert len(stage_one_instructions) <= assumptions.instruction_character_count
+
+
+def test_the_instructions_name_every_tool_the_model_is_given(
+    stage_one_instructions
+):
+    """Read from the dispatcher's vocabulary, so the two cannot drift apart.
+
+    A tool the model holds but is never told about is one it finds by guessing,
+    and a tool named here that does not exist is an instruction to call
+    something that will be refused as unknown.
+    """
+    from core.agentic_v2_tools import TOOL_SCHEMAS
+
+    missing = [name for name in TOOL_SCHEMAS if name not in stage_one_instructions]
+    assert missing == []
+
+
+def test_the_instructions_claim_only_the_refusals_that_were_measured(
+    stage_one_instructions, tmp_path
+):
+    """The sentence "these three refuse" is checked by asking them.
+
+    An earlier draft also said `browser_run` and `verify_public` refuse because
+    nothing here reaches the network. Probing them disproved it -- `browser_run`
+    opens local files and `verify_public` checks deliverables, both answering
+    ``ok: True``. Telling a model a working tool is shut costs it the tool.
+    """
+    from core.agentic_v2_contract import AgenticV2Profile
+    from core.agentic_v2_fixture_backend import AgenticV2FixtureBackend
+
+    backend = AgenticV2FixtureBackend(
+        root=tmp_path / "task",
+        profile=AgenticV2Profile(
+            tool_contract_version="2.0",
+            policy_profile_id="offline-full-v1",
+            foundation_only=True,
+        ),
+    )
+
+    for name in ("exec_run", "environment_resolve", "environment_activate"):
+        answer = getattr(backend, name)({"argv": ["true"]})
+        assert answer["ok"] is False
+        assert answer["error_type"] == "capability_unavailable"
+
+    assert "capability_unavailable" in stage_one_instructions
+    for working in ("browser_run", "verify_public"):
+        assert f"{working} refuse" not in stage_one_instructions
+
+
+def test_the_instructions_point_at_the_file_that_lists_the_inputs(
+    stage_one_instructions
+):
+    """Bound to the staging constants rather than to a typed-out path.
+
+    The guide is written by `core.agentic_v2_reference_staging`. If its name or
+    its directory moves and this text does not, the model is sent to look for a
+    file that is not there -- and it has no other way to learn its inputs exist,
+    because the task wording is dataset-supplied and sealed.
+    """
+    from core.agentic_v2_reference_staging import INPUTS_GUIDE, MODEL_INPUT_PREFIX
+
+    assert f"{MODEL_INPUT_PREFIX}/{INPUTS_GUIDE}" in stage_one_instructions
+    assert f"{MODEL_INPUT_PREFIX}/extracted" in stage_one_instructions
+
+
+def test_the_instructions_say_a_format_failure_is_not_the_model_s_fault(
+    stage_one_instructions
+):
+    """The distinction step five of the goal asks for, at the point it bites.
+
+    258 of the 261 reference files do not decode as UTF-8, and
+    `workspace_apply(read)` decodes UTF-8. A model that reads this and keeps
+    retrying the spreadsheet is failing; one that was never told and keeps
+    retrying is being failed by the environment. Only the first is evidence
+    about the model.
+    """
+    assert "not a mistake" in stage_one_instructions
+    assert "is not the file" in stage_one_instructions
+
+
+def test_the_instructions_carry_the_size_rule_that_stops_every_write(
+    stage_one_instructions
+):
+    """A deliverable over 1 MiB does not fail on its own -- it fails the rest.
+
+    The backend applies the limit during a walk over the whole workspace, and
+    the walk runs on write, so one oversized file makes every later write raise.
+    The model is told the rule because it is the one it can break by accident
+    and cannot diagnose from what it is shown.
+    """
+    assert "1 MiB" in stage_one_instructions
+    assert "later write fail" in stage_one_instructions

--- a/batch-runner/tests/test_agentic_v2_microvm_backend.py
+++ b/batch-runner/tests/test_agentic_v2_microvm_backend.py
@@ -276,6 +276,7 @@ class TestTheFixtureUnderneathStaysUnderneath:
             "exec_run",
             "expected_capabilities",
             "finalize",
+            "initial_workspace_declaration",
             "package_snapshot_sha256",
             "start",
             "state_sha256",
@@ -303,6 +304,13 @@ class TestTheFixtureUnderneathStaysUnderneath:
             "close",
             "expected_capabilities",
             "finalize",
+            # Reads the same host-side tree `workspace_apply` writes to and
+            # `_workspace_snapshot` walks, both of which are inherited here for
+            # the same reason: the machine gets that tree shared into it, so
+            # what the workspace held at startup is the same question on either
+            # backend and has the same answer. An override would be a second
+            # walk of one directory.
+            "initial_workspace_declaration",
             "verify_public",
             "workspace_apply",
             "workspace_state_sha256",

--- a/batch-runner/tests/test_agentic_v2_preregistration.py
+++ b/batch-runner/tests/test_agentic_v2_preregistration.py
@@ -23,6 +23,11 @@ from core.agentic_v2_contract import TOOL_NAMES
 from core.agentic_v2_conversation import run_model_conversation
 from core.agentic_v2_conversation_runner import build_runner_factory, ceilings_from
 from core.agentic_v2_stage_one_budget import load_stage_one_plan
+from core.agentic_compute import (
+    MAX_INPUT_FILES,
+    MAX_INPUT_SINGLE,
+    MAX_INPUT_TOTAL,
+)
 from core.agentic_v2_preregistration import (
     CODEX_TRIAL_PLAN,
     Comparison,
@@ -36,17 +41,21 @@ from core.agentic_v2_preregistration import (
     STAGE_THIRTY,
     STAGE_TWO_TWENTY,
     STOP_RULES,
+    UNDELIVERABLE_INPUTS,
     UNKNOWN,
     cohorts,
     compare_with_codex_run,
     escalation_shape,
+    input_disposition,
     manifest,
     may_attribute_difference_to_environment,
     record,
     residual_after_alignment,
     seal,
+    verify_input_disposition,
     verify_seal,
 )
+from core.execution_envelope_tasks import full_run_tasks, load_task_catalog
 
 #: The one task the advance-check rule holds and the trial rule does not. Named
 #: here so that a change to either rule fails loudly with the identifier in the
@@ -383,6 +392,199 @@ class TestTheConditionsAreRecordedBeforeTheRun:
             after = record()["seal"]
 
         assert after != before
+
+
+#: The one file in the pinned revision that no cohort can be handed, and the
+#: task it belongs to. Written out here rather than read from the module under
+#: test, so that a change to the record is a failure with the identifier in the
+#: message instead of a test that agrees with whatever it is shown.
+UNDELIVERABLE_TASK = "a941b6d8-4289-4500-b45a-f8e4fc94a724"
+UNDELIVERABLE_PATH = (
+    "reference_files/67469cf2a7509f149c095cf4f6542f6d/TWT_A001_03.mp4"
+)
+UNDELIVERABLE_SIZE = 689_061_330
+
+
+def _fake_snapshot(root: Path, sizes: dict[str, int] | None = None) -> Path:
+    """A dataset-shaped tree with the right names and made-up sizes.
+
+    Every file the two hundred and twenty name, one byte each unless `sizes`
+    says otherwise, and the undeliverable one at its recorded size. Written
+    sparse: nothing here allocates 689 MB, and `st_size` -- the only thing the
+    check reads -- is the same either way.
+    """
+    sizes = dict(sizes or {})
+    sizes.setdefault(UNDELIVERABLE_PATH, UNDELIVERABLE_SIZE)
+    catalog = load_task_catalog()
+    by_id = catalog.by_task_id()
+    for task_id in full_run_tasks(catalog):
+        for name in by_id[str(task_id)].reference_file_paths:
+            made = root / name
+            made.parent.mkdir(parents=True, exist_ok=True)
+            with made.open("wb") as handle:
+                handle.truncate(sizes.get(name, 1))
+    return root
+
+
+class TestWhatEachCohortCanBeHanded:
+    """The inputs half of the pre-registration.
+
+    A run where the model is not given a file it was told to open produces the
+    same artefact as a run where the model ignored one, and by the time anybody
+    is reading results the difference is unrecoverable. So it is written down
+    first: which cohort loses what, and to which limit.
+    """
+
+    def test_the_first_two_stages_have_nothing_refused(self):
+        """Not a convenience. It decides what the early stages can show.
+
+        Five tasks and then thirty are where a failure gets diagnosed, and a
+        missing input there would be the first explanation to reach for and the
+        hardest to rule out. Neither cohort contains the one task that loses a
+        file, so for those two stages that explanation is closed off in advance
+        rather than argued about afterwards.
+        """
+        disposition = input_disposition()["per_stage"]
+
+        assert disposition[STAGE_FIVE]["files_that_cannot_be_delivered"] == []
+        assert disposition[STAGE_THIRTY]["files_that_cannot_be_delivered"] == []
+
+    def test_the_two_hundred_and_twenty_loses_exactly_one_named_file(self):
+        refused = input_disposition()["per_stage"][STAGE_TWO_TWENTY][
+            "files_that_cannot_be_delivered"
+        ]
+
+        assert [one["path"] for one in refused] == [UNDELIVERABLE_PATH]
+        assert refused[0]["task_id"] == UNDELIVERABLE_TASK
+        assert refused[0]["size_bytes"] == UNDELIVERABLE_SIZE
+        assert refused[0]["size_bytes"] > MAX_INPUT_SINGLE
+
+    def test_the_task_that_loses_it_keeps_its_other_file(self):
+        """Which is the outcome worth recording, not the softer one.
+
+        An empty workspace is obvious in a result. Half the footage is not: the
+        model has something to work from, produces an edit, and the edit is
+        judged as an edit. The record has to carry the shortfall because the
+        deliverable will not show it.
+        """
+        catalog = load_task_catalog()
+        task = catalog.by_task_id()[UNDELIVERABLE_TASK]
+
+        assert task.reference_file_count == 2
+        assert UNDELIVERABLE_PATH in task.reference_file_paths
+        kept = [one for one in task.reference_file_paths if one != UNDELIVERABLE_PATH]
+        assert len(kept) == 1, "the task is supposed to name a second clip"
+
+    def test_the_counts_cover_every_task_in_every_cohort(self):
+        disposition = input_disposition()["per_stage"]
+        chosen = cohorts()
+        for stage in ESCALATION:
+            assert disposition[stage]["tasks"] == len(chosen[stage])
+            assert (
+                disposition[stage]["tasks_naming_reference_files"]
+                <= disposition[stage]["tasks"]
+            )
+
+    def test_the_limits_are_read_from_the_contract_and_not_restated(self):
+        """Two copies of a number is one chance for them to disagree.
+
+        If these were typed into the record, raising a limit in the compute
+        contract would leave the pre-registration describing a narrower run
+        than the one that happened -- and the record is the thing a reader
+        trusts when the results are confusing.
+        """
+        limits = input_disposition()["limits"]
+
+        assert limits["max_files_per_task"] == MAX_INPUT_FILES
+        assert limits["max_bytes_per_file"] == MAX_INPUT_SINGLE
+        assert limits["max_bytes_per_task"] == MAX_INPUT_TOTAL
+        assert limits["come_from"] == "core/agentic_compute.py"
+
+    def test_nothing_is_quietly_put_in_the_missing_file_s_place(self):
+        disposition = input_disposition()
+
+        assert "Nothing is put in its place" in disposition["no_substitute_is_made"]
+        assert "is not evidence about the model" in (
+            disposition["what_a_failure_there_does_not_show"]
+        )
+
+    def test_the_disposition_is_carried_in_the_sealed_record(self):
+        body = record()
+        assert body["inputs"] == input_disposition()
+        recorded_seal = body.pop("seal")
+        assert verify_seal(body, recorded_seal) == []
+
+
+class TestTheDispositionIsCheckedAgainstDiskRatherThanTrusted:
+    """A recorded size is a claim until something measures it.
+
+    The first direction catches an edit to the record. The second is the one
+    worth having: a file nobody wrote down that has grown past a limit, which a
+    cohort would silently lose and which would then read as bad work.
+    """
+
+    def test_a_snapshot_matching_the_record_reports_nothing(self, tmp_path):
+        assert verify_input_disposition(_fake_snapshot(tmp_path)) == []
+
+    def test_a_recorded_size_that_no_longer_matches_is_reported(self, tmp_path):
+        root = _fake_snapshot(tmp_path, {UNDELIVERABLE_PATH: UNDELIVERABLE_SIZE - 1})
+        wrong = verify_input_disposition(root)
+
+        assert any(UNDELIVERABLE_PATH in one for one in wrong)
+        assert any("the record was edited" in one for one in wrong)
+
+    def test_a_recorded_file_that_now_fits_is_reported(self, tmp_path):
+        """The refusal outliving its reason, which is the same bug class.
+
+        Raise the per-file limit past 689 MB and the record would carry on
+        saying a deliverable file cannot be delivered. Nothing else in the
+        repository would notice.
+        """
+        root = _fake_snapshot(tmp_path)
+        with mock.patch(
+            "core.agentic_v2_preregistration.MAX_INPUT_SINGLE", UNDELIVERABLE_SIZE * 2
+        ):
+            wrong = verify_input_disposition(root)
+
+        assert any("within the" in one for one in wrong)
+
+    def test_an_unrecorded_file_over_the_limit_is_reported(self, tmp_path):
+        """The case the record could not have anticipated, which is the point."""
+        catalog = load_task_catalog()
+        by_id = catalog.by_task_id()
+        victim = next(
+            (task_id, by_id[str(task_id)].reference_file_paths[0])
+            for task_id in full_run_tasks(catalog)
+            if by_id[str(task_id)].reference_file_paths
+            and by_id[str(task_id)].reference_file_paths[0] != UNDELIVERABLE_PATH
+        )
+        root = _fake_snapshot(tmp_path, {victim[1]: MAX_INPUT_SINGLE + 1})
+        wrong = verify_input_disposition(root)
+
+        assert any(victim[1] in one and "no record says so" in one for one in wrong)
+
+    def test_a_named_file_missing_from_the_snapshot_is_reported(self, tmp_path):
+        root = _fake_snapshot(tmp_path)
+        catalog = load_task_catalog()
+        by_id = catalog.by_task_id()
+        gone = next(
+            by_id[str(task_id)].reference_file_paths[0]
+            for task_id in full_run_tasks(catalog)
+            if by_id[str(task_id)].reference_file_paths
+        )
+        (root / gone).unlink()
+
+        assert any(
+            gone in one and "not in the snapshot" in one
+            for one in verify_input_disposition(root)
+        )
+
+    def test_an_empty_root_does_not_pass_by_finding_nothing(self, tmp_path):
+        """A check that says nothing when handed nothing is not a check."""
+        wrong = verify_input_disposition(tmp_path)
+
+        assert any("is not present" in one for one in wrong)
+        assert len(wrong) > 1
 
 
 class TestTheRecordSaysWhatItIsNot:

--- a/batch-runner/tests/test_agentic_v2_preregistration.py
+++ b/batch-runner/tests/test_agentic_v2_preregistration.py
@@ -383,6 +383,35 @@ class TestTheConditionsAreRecordedBeforeTheRun:
         for guess in ("we expect", "should succeed", "likely", "probably"):
             assert guess not in written
 
+    def test_the_desk_closing_on_one_bad_call_is_registered_not_fixed(self):
+        """It ends a task on turn one and it is still here on purpose.
+
+        ``dispatch_one`` ends a task on the first tool call that comes back
+        not-ok, and the model is told nothing and asked nothing further. Fixing
+        it would change what a trace contains, so it is registered instead --
+        and registering it is only worth anything if the record says what it
+        costs and says the result is not about the model. A run where this fires
+        often has to be readable as a run under this condition.
+        """
+        condition = record()["run_conditions"]["one_failed_tool_call_ends_the_task"]
+
+        assert condition["holds"] is True
+        assert "dispatch_one" in condition["comes_from"]
+        assert condition["is_not"].startswith("evidence about the model")
+        assert "tool_desk_broke" in condition["recorded_as"]
+
+    def test_registering_that_condition_moved_the_seal(self):
+        """A condition added without the seal moving is a condition added after.
+
+        The seal is the whole reason a pre-registration is worth more than a
+        note. This asserts the new entry is inside it rather than beside it.
+        """
+        without = json.loads(json.dumps(record()))
+        del without["seal"]
+        del without["run_conditions"]["one_failed_tool_call_ends_the_task"]
+
+        assert seal(without) != record()["seal"]
+
     def test_a_changed_setting_changes_the_seal(self):
         """The record is only a commitment if editing the plan invalidates it."""
         before = record()["seal"]

--- a/batch-runner/tests/test_agentic_v2_preregistration.py
+++ b/batch-runner/tests/test_agentic_v2_preregistration.py
@@ -41,8 +41,12 @@ from core.agentic_v2_preregistration import (
     STAGE_THIRTY,
     STAGE_TWO_TWENTY,
     STOP_RULES,
+    FILES_NAMED_BY_THE_TASKS,
+    FILES_THE_MODEL_COULD_OPEN_UNAIDED,
+    OVER_THE_WORKSPACE_FILE_LIMIT,
     UNDELIVERABLE_INPUTS,
     UNKNOWN,
+    WORKSPACE_FILE_LIMIT,
     cohorts,
     compare_with_codex_run,
     escalation_shape,
@@ -53,6 +57,7 @@ from core.agentic_v2_preregistration import (
     residual_after_alignment,
     seal,
     verify_input_disposition,
+    verify_reader_reach,
     verify_seal,
 )
 from core.execution_envelope_tasks import full_run_tasks, load_task_catalog
@@ -409,12 +414,21 @@ def _fake_snapshot(root: Path, sizes: dict[str, int] | None = None) -> Path:
     """A dataset-shaped tree with the right names and made-up sizes.
 
     Every file the two hundred and twenty name, one byte each unless `sizes`
-    says otherwise, and the undeliverable one at its recorded size. Written
-    sparse: nothing here allocates 689 MB, and `st_size` -- the only thing the
-    check reads -- is the same either way.
+    says otherwise, and every file the record calls oversized at its recorded
+    size. Written sparse: nothing here allocates 689 MB, and `st_size` -- the
+    only thing the check reads -- is the same either way.
+
+    The oversized ones are taken from the record rather than typed out again.
+    Typed out, this fixture would be a second copy of the same list, and a test
+    that a record matches a hand-maintained duplicate of itself is a test of
+    nothing. What stops it agreeing with whatever it is shown is that the check
+    also re-derives the band from the limit: a file dropped out of the record
+    reappears here as an unrecorded file over the limit.
     """
     sizes = dict(sizes or {})
     sizes.setdefault(UNDELIVERABLE_PATH, UNDELIVERABLE_SIZE)
+    for one in OVER_THE_WORKSPACE_FILE_LIMIT:
+        sizes.setdefault(str(one["path"]), int(one["size_bytes"]))
     catalog = load_task_catalog()
     by_id = catalog.by_task_id()
     for task_id in full_run_tasks(catalog):
@@ -585,6 +599,184 @@ class TestTheDispositionIsCheckedAgainstDiskRatherThanTrusted:
 
         assert any("is not present" in one for one in wrong)
         assert len(wrong) > 1
+
+    def test_an_unrecorded_file_over_the_workspace_limit_is_reported(
+        self, tmp_path
+    ):
+        """The second limit, and the worse one.
+
+        A file over the compute contract's limit costs its task that file. A
+        file over the workspace's costs the task every deliverable, because the
+        limit is applied while walking the whole workspace and the walk runs on
+        write. The model sees only `fixture_backend_error`, so it retries until
+        its budget is gone and the record afterwards shows a model that produced
+        nothing.
+        """
+        catalog = load_task_catalog()
+        by_id = catalog.by_task_id()
+        recorded = {str(one["path"]) for one in OVER_THE_WORKSPACE_FILE_LIMIT}
+        victim = next(
+            path
+            for task_id in full_run_tasks(catalog)
+            for path in by_id[str(task_id)].reference_file_paths
+            if path not in recorded
+        )
+        root = _fake_snapshot(tmp_path, {victim: WORKSPACE_FILE_LIMIT + 1})
+
+        wrong = verify_input_disposition(root)
+
+        assert any(
+            victim in one and "could write nothing at all" in one for one in wrong
+        )
+
+    def test_a_recorded_oversized_file_that_now_fits_is_reported(self, tmp_path):
+        """The same bug class as the per-file one, one limit down.
+
+        If the workspace limit is ever raised, the record would carry on
+        refusing files that fit -- handing the model less than it could have had
+        and calling that a measurement.
+        """
+        root = _fake_snapshot(tmp_path)
+        with mock.patch(
+            "core.agentic_v2_preregistration.WORKSPACE_FILE_LIMIT",
+            UNDELIVERABLE_SIZE * 2,
+        ):
+            wrong = verify_input_disposition(root)
+
+        assert len(wrong) == len(OVER_THE_WORKSPACE_FILE_LIMIT)
+        assert all(
+            "recorded as over the workspace file limit but" in one for one in wrong
+        )
+
+    def test_every_recorded_oversized_file_is_over_the_limit(self):
+        """Read from the record, checked against the limit it claims to apply.
+
+        Nothing on disk is needed for this one, which is the point: it fails in
+        CI, where the dataset is absent, if an entry is ever added that the
+        limit would not actually have refused.
+        """
+        too_small = [
+            one["path"]
+            for one in OVER_THE_WORKSPACE_FILE_LIMIT
+            if int(one["size_bytes"]) <= WORKSPACE_FILE_LIMIT
+        ]
+        assert too_small == []
+        assert len({one["path"] for one in OVER_THE_WORKSPACE_FILE_LIMIT}) == len(
+            OVER_THE_WORKSPACE_FILE_LIMIT
+        )
+
+
+class TestWhatTheModelCanOpenWithoutHelp:
+    """The figure that decides whether a V2 result is about the model at all.
+
+    `workspace_apply(read)` decodes UTF-8 and `exec_run` is shut, so a file that
+    does not decode cannot be opened by any means the model has. Measured rather
+    than assumed, because the assumption everybody makes -- "it is a text file,
+    the model can read it" -- is true of three of the two hundred and sixty-one.
+    """
+
+    def test_the_record_says_how_many_and_out_of_how_many(self):
+        disposition = input_disposition()["what_the_model_can_open_by_itself"]
+
+        assert disposition["files_named_by_the_tasks"] == FILES_NAMED_BY_THE_TASKS
+        assert disposition["files_that_decode_as_utf8"] == (
+            FILES_THE_MODEL_COULD_OPEN_UNAIDED
+        )
+        assert "workspace_apply(read)" in disposition["how_that_was_measured"]
+
+    def test_the_renderings_are_recorded_as_a_difference_and_not_a_fix(self):
+        """Step five's rule, at the place it would be broken.
+
+        A text rendering is a thing A's run does not have and does not need. A
+        V2 score on a task that needed a chart is not comparable to A's on the
+        same task, and the record has to say so before either runs -- afterwards
+        it reads as an excuse for whichever number came out lower.
+        """
+        renderings = input_disposition()["text_renderings"]
+
+        assert "never presented as the file" in renderings["never_a_replacement"]
+        assert "not comparable" in (
+            renderings["this_is_a_difference_from_the_codex_run"]
+        )
+
+    def test_the_two_figures_agree_with_the_sentence_that_explains_them(self):
+        """The arithmetic anchor, and the only one CI can run.
+
+        Both the number and the record that reports it come from the same
+        constant, so comparing them proves nothing on its own -- move the
+        constant and the pair moves together. What does not move is the prose
+        that says how many files failed, so the subtraction is checked here.
+        On a machine with the dataset the real anchor is the test below; on one
+        without, this is what stops the figure drifting quietly.
+        """
+        disposition = input_disposition()
+        measured = disposition["what_the_model_can_open_by_itself"][
+            "how_that_was_measured"
+        ]
+        unreadable = FILES_NAMED_BY_THE_TASKS - FILES_THE_MODEL_COULD_OPEN_UNAIDED
+
+        assert f"the other {unreadable} do not" in measured
+        assert str(FILES_NAMED_BY_THE_TASKS) in (
+            disposition["text_renderings"]["what_they_are"]
+        )
+
+    def test_the_pinned_snapshot_still_gives_the_recorded_reach(self):
+        """The measurement itself, where the bytes exist to make it.
+
+        Skipped rather than faked when they do not. A fixture cannot answer
+        this question -- sparse files are NUL bytes and NUL decodes -- so a
+        version of this test that ran everywhere would be measuring its own
+        fixture and reporting the answer as the dataset's.
+        """
+        pinned = manifest()
+        root = (
+            Path.home()
+            / ".cache"
+            / "huggingface"
+            / "hub"
+            / f"datasets--{pinned['dataset_repo_id'].replace('/', '--')}"
+            / "snapshots"
+            / pinned["dataset_revision"]
+        )
+        if not (root / "reference_files").is_dir():
+            pytest.skip(f"the pinned snapshot is not on this machine: {root}")
+
+        assert verify_reader_reach(root) == []
+
+    def test_a_tree_of_readable_files_is_reported_rather_than_accepted(
+        self, tmp_path
+    ):
+        """Sparse files are all NUL bytes, and NUL decodes as UTF-8.
+
+        Which makes the empty fixture the exact shape of the mistake worth
+        catching: a check that measured sizes and inferred readability would
+        call this snapshot fine and report that the model can open all 261.
+        """
+        wrong = verify_reader_reach(_fake_snapshot(tmp_path))
+
+        assert any("decode as UTF-8" in one for one in wrong)
+
+    def test_a_snapshot_missing_a_named_file_is_reported(self, tmp_path):
+        root = _fake_snapshot(tmp_path)
+        catalog = load_task_catalog()
+        by_id = catalog.by_task_id()
+        gone = next(
+            by_id[str(task_id)].reference_file_paths[0]
+            for task_id in full_run_tasks(catalog)
+            if by_id[str(task_id)].reference_file_paths
+        )
+        (root / gone).unlink()
+
+        assert any(
+            gone in one and "not in the snapshot" in one
+            for one in verify_reader_reach(root)
+        )
+
+    def test_an_empty_root_does_not_pass_by_finding_nothing(self, tmp_path):
+        wrong = verify_reader_reach(tmp_path)
+
+        assert any("not in the snapshot" in one for one in wrong)
+        assert any("were measured and the record is written about" in one for one in wrong)
 
 
 class TestTheRecordSaysWhatItIsNot:

--- a/batch-runner/tests/test_agentic_v2_reference_staging.py
+++ b/batch-runner/tests/test_agentic_v2_reference_staging.py
@@ -1,0 +1,551 @@
+"""Whether a task actually got the files its prompt tells it to open.
+
+The gap this closes was stated for a week before it was sized, and the sizing
+found two things that decide what these tests have to hold.
+
+*One file in the dataset cannot be delivered at all.* A 689.1 MB video is over
+the compute contract's own single-file limit. So refusal has to be per file: a
+cohort that refuses all 220 tasks because one of them names one oversized video
+is not a stricter run, it is no run. The tests below check that a refusal is
+local -- the other files of that same task still arrive.
+
+*A refusal must stay distinguishable from having nothing to refuse.* Three
+states get confused whenever they are stored as one boolean: a task given
+everything, a task given some of it, and a task that named no files at all. If
+they collapse, a model that failed because it was never handed the spreadsheet
+reads afterwards as a model that could not do the work. So every assertion here
+that touches the record checks the missing file is present *by name*, not that a
+count went up.
+
+And one thing found by running it rather than by reading it: every file in a
+``huggingface_hub`` snapshot is a symlink into a blob store outside the snapshot
+root, so the hardened opener refuses all 301 of them. That is the ordinary shape
+of an ordinary cache and not a security finding, and the refusal has to say so
+-- otherwise the next person reads "source is a link" as a planted link.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core import agentic_v2_reference_staging as staging  # noqa: E402
+from core.agentic_v2_reference_staging import (  # noqa: E402
+    CHANGED_WHILE_COPYING,
+    NOT_A_PLAIN_FILE,
+    NOT_IN_SNAPSHOT,
+    SNAPSHOT_IS_A_LINK_FARM,
+    TOO_LARGE,
+    TOO_MANY,
+    TOTAL_TOO_LARGE,
+    UNSAFE_PATH,
+    snapshot_problem,
+    stage_cohort,
+    stage_task_reference_files,
+    staging_record,
+)
+
+PAYLOAD = b"a spreadsheet, for the purposes of this test\x00\xff\xfe"
+DIGEST = hashlib.sha256(PAYLOAD).hexdigest()
+
+
+@pytest.fixture
+def snapshot(tmp_path: Path) -> Path:
+    """A dataset root shaped like the real one, with real bytes in it."""
+    root = tmp_path / "snapshot"
+    folder = root / "reference_files" / "abc123"
+    folder.mkdir(parents=True)
+    (folder / "sheet.xlsx").write_bytes(PAYLOAD)
+    (folder / "notes.pdf").write_bytes(b"a pdf")
+    return root
+
+
+def _stage(snapshot: Path, tmp_path: Path, *names: str, task_id: str = "t"):
+    return stage_task_reference_files(
+        task_id=task_id,
+        reference_files=list(names),
+        snapshot_root=snapshot,
+        into=tmp_path / "workspace",
+    )
+
+
+def _reasons(result) -> list[str]:
+    return [one.reason for one in result.refused]
+
+
+# ── The bytes arrive, and they are the right bytes ────────────────────────
+
+
+def test_a_named_file_arrives_with_its_contents_unchanged(snapshot, tmp_path):
+    """The whole point, and the thing every other test here assumes.
+
+    Checked byte for byte rather than by size, because the payload contains
+    NUL, ``0xff`` and ``0xfe`` -- the sequence that a copy through a text pipe
+    silently mangles, which is how an ``.xlsx`` arrives corrupt and reads
+    afterwards as a model that produced a broken spreadsheet.
+    """
+    result = _stage(snapshot, tmp_path, "reference_files/abc123/sheet.xlsx")
+
+    assert result.refused == ()
+    assert len(result.delivered) == 1
+
+    landed = Path(result.workspace) / "reference_files/abc123/sheet.xlsx"
+    assert landed.read_bytes() == PAYLOAD
+
+
+def test_the_recorded_digest_is_the_digest_of_what_landed(snapshot, tmp_path):
+    """A hash in a record is a claim, and this is the test that it is true."""
+    result = _stage(snapshot, tmp_path, "reference_files/abc123/sheet.xlsx")
+    only = result.delivered[0]
+
+    assert only.sha256 == DIGEST
+    assert only.size_bytes == len(PAYLOAD)
+
+    landed = Path(result.workspace) / only.relative_path
+    assert hashlib.sha256(landed.read_bytes()).hexdigest() == only.sha256
+
+
+def test_the_model_path_says_where_the_file_appears_to_the_model(
+    snapshot, tmp_path
+):
+    """`inputs/…`, the same prefix V1 uses.
+
+    Two records that both quote a path should mean the same place by it.
+    """
+    result = _stage(snapshot, tmp_path, "reference_files/abc123/sheet.xlsx")
+
+    assert result.delivered[0].model_path == (
+        "inputs/reference_files/abc123/sheet.xlsx"
+    )
+
+
+def test_a_task_naming_several_files_gets_all_of_them(snapshot, tmp_path):
+    result = _stage(
+        snapshot,
+        tmp_path,
+        "reference_files/abc123/sheet.xlsx",
+        "reference_files/abc123/notes.pdf",
+    )
+
+    assert result.refused == ()
+    assert {one.relative_path for one in result.delivered} == {
+        "reference_files/abc123/sheet.xlsx",
+        "reference_files/abc123/notes.pdf",
+    }
+    assert result.everything_arrived is True
+
+
+# ── One refusal is one refusal, not a cohort ──────────────────────────────
+
+
+def test_an_undeliverable_file_does_not_take_its_siblings_down_with_it(
+    snapshot, tmp_path, monkeypatch
+):
+    """The 689 MB video, in miniature.
+
+    V1's staging raises on the first problem, which is right for V1 and would
+    here mean one oversized video refusing every task in the stage. The file is
+    refused; the task still gets the rest.
+    """
+    monkeypatch.setattr(staging, "MAX_INPUT_SINGLE", 10)
+
+    result = _stage(
+        snapshot,
+        tmp_path,
+        "reference_files/abc123/sheet.xlsx",  # over the patched limit
+        "reference_files/abc123/notes.pdf",  # five bytes, under it
+    )
+
+    assert _reasons(result) == [TOO_LARGE]
+    assert [one.relative_path for one in result.delivered] == [
+        "reference_files/abc123/notes.pdf"
+    ]
+
+
+def test_an_oversized_file_is_refused_with_its_size_and_not_truncated(
+    snapshot, tmp_path, monkeypatch
+):
+    """Never a short file on disk, which would read as a corrupt download."""
+    monkeypatch.setattr(staging, "MAX_INPUT_SINGLE", 10)
+
+    result = _stage(snapshot, tmp_path, "reference_files/abc123/sheet.xlsx")
+
+    only = result.refused[0]
+    assert only.reason == TOO_LARGE
+    assert str(len(PAYLOAD)) in only.detail
+    assert "changes what the task measures" in only.detail
+    assert not (Path(result.workspace) / only.relative_path).exists()
+
+
+def test_a_task_whose_files_would_pass_the_total_stops_at_the_total(
+    snapshot, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(staging, "MAX_INPUT_TOTAL", len(PAYLOAD) + 1)
+
+    result = _stage(
+        snapshot,
+        tmp_path,
+        "reference_files/abc123/sheet.xlsx",
+        "reference_files/abc123/notes.pdf",
+    )
+
+    assert len(result.delivered) == 1
+    assert _reasons(result) == [TOTAL_TOO_LARGE]
+
+
+def test_more_files_than_the_limit_allows_refuses_the_excess_by_name(
+    snapshot, tmp_path, monkeypatch
+):
+    """The excess is named, not counted.
+
+    A task told "you named too many files" cannot be read later; a task told
+    *which* ones it did not get can.
+    """
+    monkeypatch.setattr(staging, "MAX_INPUT_FILES", 1)
+
+    result = _stage(
+        snapshot,
+        tmp_path,
+        "reference_files/abc123/sheet.xlsx",
+        "reference_files/abc123/notes.pdf",
+    )
+
+    assert _reasons(result) == [TOO_MANY]
+    assert result.refused[0].relative_path == "reference_files/abc123/notes.pdf"
+    assert len(result.delivered) == 1
+
+
+# ── Paths the dataset supplies are not trusted ────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "path, because",
+    [
+        ("../escape.txt", "path climbs out of the tree"),
+        ("reference_files/../../escape.txt", "path climbs out of the tree"),
+        ("/etc/passwd", "path is absolute"),
+        (".hidden/file.txt", "path has a hidden component"),
+        ("/".join(["deep"] * 40) + "/file.txt", "deeper than"),
+        ("reference_files/" + "n" * 300 + ".xlsx", "longer than"),
+    ],
+)
+def test_a_path_that_could_write_outside_the_workspace_is_refused(
+    snapshot, tmp_path, path, because
+):
+    """Refused on the path, before anything is opened or created.
+
+    These come from a dataset file. Being a published, pinned dataset makes
+    them likely to be fine and does not make them checked, and the cost of
+    being wrong is a write outside the workspace.
+    """
+    result = _stage(snapshot, tmp_path, path)
+
+    assert _reasons(result) == [UNSAFE_PATH]
+    assert because in result.refused[0].detail
+    assert result.delivered == ()
+
+
+def test_nothing_is_written_above_the_workspace(snapshot, tmp_path):
+    """The property the path rules exist for, checked on the filesystem."""
+    canary = tmp_path / "escape.txt"
+
+    _stage(snapshot, tmp_path, "../escape.txt", "../../escape.txt")
+
+    assert not canary.exists()
+
+
+def test_a_file_the_snapshot_does_not_have_is_refused_by_name(
+    snapshot, tmp_path
+):
+    result = _stage(snapshot, tmp_path, "reference_files/abc123/absent.docx")
+
+    assert _reasons(result) == [NOT_IN_SNAPSHOT]
+    assert "absent.docx" in result.refused[0].detail
+
+
+# ── The shape a real snapshot actually arrives in ─────────────────────────
+
+
+def test_a_symlink_is_refused_as_a_cache_rather_than_as_an_attack(
+    snapshot, tmp_path
+):
+    """301 of 301 real files hit this, and the wording is the whole value.
+
+    The generic answer for a symlink is "source is a link", which reads as
+    something planted. What it actually means is that the dataset was fetched
+    into a ``huggingface_hub`` cache, where every name is a link into a blob
+    store outside the root. The refusal has to name the fix, because the
+    correct next step -- fetch again with ``--local-dir`` -- is not something
+    the generic message would ever suggest.
+    """
+    outside = tmp_path / "blobs" / "deadbeef"
+    outside.parent.mkdir()
+    outside.write_bytes(PAYLOAD)
+    link = snapshot / "reference_files" / "abc123" / "linked.xlsx"
+    link.symlink_to(os.path.relpath(outside, link.parent))
+
+    result = _stage(snapshot, tmp_path, "reference_files/abc123/linked.xlsx")
+
+    assert _reasons(result) == [SNAPSHOT_IS_A_LINK_FARM]
+    assert "--local-dir" in result.refused[0].detail
+    assert not (Path(result.workspace) / "reference_files/abc123/linked.xlsx").exists()
+
+
+def test_a_hard_link_is_refused_as_a_link_and_not_as_a_race(snapshot, tmp_path):
+    """Same rule V1 applies, kept rather than relaxed — and named correctly.
+
+    A second name for the same inode means something else can change the bytes
+    after they were checked and before they were read, so it is refused. The
+    test is here for the *reason* string as much as for the refusal: the first
+    version of this module sorted every mid-copy problem into one bucket and
+    reported this one as ``source_changed_while_it_was_being_copied``, which
+    states that a race occurred. Nothing raced. A record that invents an event
+    is worse than one that says less.
+    """
+    target = snapshot / "reference_files" / "abc123" / "sheet.xlsx"
+    os.link(target, snapshot / "reference_files" / "abc123" / "second-name.xlsx")
+
+    result = _stage(snapshot, tmp_path, "reference_files/abc123/sheet.xlsx")
+
+    assert _reasons(result) == [NOT_A_PLAIN_FILE]
+    assert "hard links" in result.refused[0].detail
+    assert CHANGED_WHILE_COPYING not in _reasons(result)
+    assert result.delivered == ()
+
+
+def test_a_refused_file_leaves_nothing_behind_in_the_workspace(
+    snapshot, tmp_path
+):
+    """Whatever a refusal costs, it must not cost a half-written file.
+
+    A short file in the workspace is the worst of the three outcomes: the model
+    opens it and reads it as the whole document, while the record says it was
+    refused. The two disagree and the result looks like a model that misread a
+    spreadsheet.
+    """
+    os.link(
+        snapshot / "reference_files" / "abc123" / "sheet.xlsx",
+        snapshot / "reference_files" / "abc123" / "second-name.xlsx",
+    )
+
+    result = _stage(
+        snapshot,
+        tmp_path,
+        "reference_files/abc123/sheet.xlsx",
+        "reference_files/abc123/notes.pdf",
+    )
+
+    workspace = Path(result.workspace)
+    assert not (workspace / "reference_files/abc123/sheet.xlsx").exists()
+    assert sorted(one.name for one in workspace.rglob("*") if one.is_file()) == [
+        "notes.pdf"
+    ]
+
+
+# ── Asking the question once, instead of 261 times ────────────────────────
+
+
+def test_a_cache_of_symlinks_is_diagnosed_before_any_task_is_staged(
+    snapshot, tmp_path
+):
+    """One wrong directory should not look like 125 broken tasks."""
+    for path in list((snapshot / "reference_files").rglob("*")):
+        if path.is_file():
+            moved = tmp_path / "blobs" / path.name
+            moved.parent.mkdir(exist_ok=True)
+            path.rename(moved)
+            path.symlink_to(os.path.relpath(moved, path.parent))
+
+    problem = snapshot_problem(snapshot)
+
+    assert problem is not None
+    assert "symlink" in problem
+    assert "--local-dir" in problem
+
+
+def test_a_directory_of_real_files_has_no_problem(snapshot):
+    assert snapshot_problem(snapshot) is None
+
+
+def test_a_root_that_is_not_there_is_named_rather_than_crashed_on(tmp_path):
+    assert "is not a directory" in snapshot_problem(tmp_path / "absent")
+
+
+def test_a_root_with_no_reference_files_directory_says_so(tmp_path):
+    (tmp_path / "root").mkdir()
+
+    problem = snapshot_problem(tmp_path / "root")
+
+    assert "does not exist" in problem
+    assert "--local-dir" in problem
+
+
+# ── Three states that must not collapse into one ──────────────────────────
+
+
+def test_a_task_that_named_nothing_is_not_counted_as_fully_staged(
+    snapshot, tmp_path
+):
+    """`everything_arrived` is about files, and it had none to arrive.
+
+    Reported as True, a cohort of tasks needing no inputs would read as a
+    cohort that was fully staged -- which is the reading this whole record
+    exists to prevent.
+    """
+    result = _stage(snapshot, tmp_path)
+
+    assert result.everything_arrived is False
+    assert result.ran_without_its_inputs is False
+    assert result.named == 0
+
+
+def test_the_record_tells_the_three_states_apart(snapshot, tmp_path):
+    """Given everything, given some of it, and had nothing to be given."""
+    everything = _stage(
+        snapshot, tmp_path / "a", "reference_files/abc123/sheet.xlsx", task_id="all"
+    )
+    partly = _stage(
+        snapshot,
+        tmp_path / "b",
+        "reference_files/abc123/sheet.xlsx",
+        "reference_files/abc123/absent.docx",
+        task_id="some",
+    )
+    nothing = _stage(snapshot, tmp_path / "c", task_id="none")
+
+    record = staging_record([everything, partly, nothing])
+
+    assert record["tasks_seen"] == 3
+    assert record["tasks_naming_reference_files"] == 2
+    assert record["tasks_given_everything_they_named"] == 1
+    assert record["tasks_that_ran_without_some_input"] == 1
+
+
+def test_every_file_a_task_did_not_get_is_in_the_record_by_name(
+    snapshot, tmp_path
+):
+    """A count cannot be read against a result; a filename can."""
+    partly = _stage(
+        snapshot,
+        tmp_path,
+        "reference_files/abc123/sheet.xlsx",
+        "reference_files/abc123/absent.docx",
+    )
+
+    record = staging_record([partly])
+    only = record["tasks"][0]
+
+    assert [one["relative_path"] for one in only["refused"]] == [
+        "reference_files/abc123/absent.docx"
+    ]
+    assert record["refusals_by_reason"] == {NOT_IN_SNAPSHOT: 1}
+
+
+def test_the_record_says_what_a_failure_on_a_short_task_does_not_prove(
+    snapshot, tmp_path
+):
+    """The sentence a reader needs, carried with the numbers rather than near them."""
+    partly = _stage(
+        snapshot, tmp_path, "reference_files/abc123/absent.docx"
+    )
+
+    record = staging_record([partly])
+
+    assert "not evidence about the model" in record["what_that_means"]
+
+
+def test_the_summary_counts_agree_with_the_detail_underneath(
+    snapshot, tmp_path
+):
+    """Two places to read the same fact is two places for it to differ."""
+    results = [
+        _stage(
+            snapshot,
+            tmp_path / str(index),
+            "reference_files/abc123/sheet.xlsx",
+            task_id=f"t{index}",
+        )
+        for index in range(3)
+    ]
+
+    record = staging_record(results)
+
+    assert record["files_delivered"] == sum(
+        len(one["delivered"]) for one in record["tasks"]
+    )
+    assert record["bytes_delivered"] == len(PAYLOAD) * 3
+
+
+# ── A cohort, rather than a task ──────────────────────────────────────────
+
+
+class _Task:
+    def __init__(self, task_id: str, *names: str) -> None:
+        self.task_id = task_id
+        self.reference_files = names
+
+
+def test_each_task_in_a_cohort_gets_its_own_directory(snapshot, tmp_path):
+    """They do not share a workspace, so they must not share a staging root.
+
+    One task reading another's inputs would be undetectable from a result and
+    would make a cohort's tasks quietly non-independent.
+    """
+    staged = stage_cohort(
+        tasks=[
+            _Task("first", "reference_files/abc123/sheet.xlsx"),
+            _Task("second", "reference_files/abc123/notes.pdf"),
+        ],
+        snapshot_root=snapshot,
+        into=tmp_path / "cohort",
+    )
+
+    assert staged[0].workspace != staged[1].workspace
+    assert not (Path(staged[0].workspace) / "reference_files/abc123/notes.pdf").exists()
+
+
+def test_two_tasks_naming_the_same_file_both_get_it(snapshot, tmp_path):
+    staged = stage_cohort(
+        tasks=[
+            _Task("first", "reference_files/abc123/sheet.xlsx"),
+            _Task("second", "reference_files/abc123/sheet.xlsx"),
+        ],
+        snapshot_root=snapshot,
+        into=tmp_path / "cohort",
+    )
+
+    for one in staged:
+        landed = Path(one.workspace) / "reference_files/abc123/sheet.xlsx"
+        assert landed.read_bytes() == PAYLOAD
+
+
+def test_a_task_directory_is_not_named_with_the_task_id_itself(
+    snapshot, tmp_path
+):
+    """A task id comes from the dataset; a directory name is ours.
+
+    The same rule V1 follows. It is what stops a task id that happens to
+    contain a path separator from deciding where files are written.
+    """
+    staged = stage_cohort(
+        tasks=[_Task("a/../b", "reference_files/abc123/sheet.xlsx")],
+        snapshot_root=snapshot,
+        into=tmp_path / "cohort",
+    )
+
+    assert Path(staged[0].workspace).name == hashlib.sha256(
+        b"a/../b"
+    ).hexdigest()
+    assert Path(staged[0].workspace).is_relative_to((tmp_path / "cohort").resolve())
+
+
+def test_a_cohort_of_nothing_stages_nothing_and_does_not_fail(tmp_path, snapshot):
+    assert stage_cohort(tasks=[], snapshot_root=snapshot, into=tmp_path) == ()

--- a/batch-runner/tests/test_agentic_v2_reference_staging.py
+++ b/batch-runner/tests/test_agentic_v2_reference_staging.py
@@ -943,8 +943,22 @@ def test_the_guide_does_not_offer_a_replacement_it_did_not_make(
     assert "Nothing was put in their place" not in guide
 
 
-def test_a_task_that_names_nothing_gets_no_guide(snapshot, tmp_path):
-    """There is nothing to describe, and an empty guide would read as a fault."""
+def test_a_task_that_names_nothing_still_gets_a_guide(snapshot, tmp_path):
+    """This test used to assert the opposite, and the opposite cost 95 tasks.
+
+    "There is nothing to describe, and an empty guide would read as a fault" is
+    a reasonable thing to believe until you look at what the model is told to
+    do. Its standing instructions open with reading ``inputs/INPUTS.md``, and
+    ``dispatch_one`` in :mod:`core.agentic_v2_runner` ends a task on the first
+    tool call that comes back not-ok -- there is no error shown and no second
+    chance. So for every task that names no reference files, turn one was a read
+    of a file that was deliberately not written, and the task died there, three
+    attempts each, recorded as the model failing.
+
+    The guide is written for every task now, and for these it says plainly that
+    the task names no files, which is a fact the model needs rather than a
+    fault.
+    """
     result = stage_task_reference_files(
         task_id="t",
         reference_files=[],
@@ -953,8 +967,37 @@ def test_a_task_that_names_nothing_gets_no_guide(snapshot, tmp_path):
         render_text=True,
     )
 
-    assert result.guide is None
-    assert not (Path(result.workspace) / staging.INPUTS_GUIDE).exists()
+    assert result.guide == "inputs/INPUTS.md"
+    guide = (Path(result.workspace) / staging.INPUTS_GUIDE).read_text(
+        encoding="utf-8"
+    )
+    assert "names no files" in guide
+
+
+def test_how_many_tasks_that_is_comes_from_the_catalogue_and_not_from_a_comment():
+    """The figure above was written by hand once, and it was wrong by fifty.
+
+    A comment saying "145 tasks" survived being read several times, went into a
+    report, and was only caught by counting. Nothing in the code depended on it,
+    which is exactly why it lasted: a wrong number that nothing reads is a wrong
+    number nothing checks.
+
+    So the count lives here, against the pinned catalogue. Both bounds matter --
+    zero would mean the unconditional guide protects nobody and this whole change
+    was for nothing, and all 220 would mean the count is measuring the wrong
+    thing. It is neither, and it is large enough that skipping the guide for them
+    was the difference between a run and a write-off.
+    """
+    from core.execution_envelope_tasks import full_run_tasks, load_task_catalog
+
+    catalog = load_task_catalog()
+    by_id = catalog.by_task_id()
+    tasks = [by_id[task_id] for task_id in full_run_tasks(catalog)]
+    name_nothing = [one for one in tasks if one.reference_file_count == 0]
+
+    assert len(tasks) == 220
+    assert len(name_nothing) == 95
+    assert len(tasks) - len(name_nothing) == 125
 
 
 # ── Saying so in the record ───────────────────────────────────────────────

--- a/batch-runner/tests/test_agentic_v2_reference_staging.py
+++ b/batch-runner/tests/test_agentic_v2_reference_staging.py
@@ -549,3 +549,493 @@ def test_a_task_directory_is_not_named_with_the_task_id_itself(
 
 def test_a_cohort_of_nothing_stages_nothing_and_does_not_fail(tmp_path, snapshot):
     assert stage_cohort(tasks=[], snapshot_root=snapshot, into=tmp_path) == ()
+
+
+# ── The limit that breaks writing, not reading ────────────────────────────
+#
+# The tests above were written believing an oversized input costs a task that
+# one file. Measured against the real backend, it costs the task everything:
+# the fixture workspace applies its 1 MiB per-file limit during a walk over the
+# whole workspace, and that walk runs on `write`. One file over it and no
+# deliverable can be written at all -- reported to the model only as
+# `fixture_backend_error`, so it retries until its call budget is gone and the
+# record shows a model that produced nothing.
+#
+# 0 of the 5 advance-check tasks would have hit it. 3 of 30 and 16 of 220
+# would. Stage one would have passed clean and stage two would have failed
+# about a fifth of the time for no visible reason.
+
+
+def _backend(root: Path):
+    from core.agentic_v2_contract import AgenticV2Profile
+    from core.agentic_v2_fixture_backend import AgenticV2FixtureBackend
+
+    return AgenticV2FixtureBackend(
+        root=root,
+        profile=AgenticV2Profile(
+            tool_contract_version="2.0",
+            policy_profile_id="offline-full-v1",
+            foundation_only=True,
+        ),
+    )
+
+
+def test_a_file_over_the_workspace_limit_is_refused_and_the_others_arrive(
+    snapshot, tmp_path
+):
+    """Refused by name, and local to that one file.
+
+    The reason is its own, not :data:`TOO_LARGE`. Those two refusals mean
+    different things -- one file is too big to carry, the other is small enough
+    to carry and too big to keep company with -- and a record that merges them
+    cannot say which limit to raise.
+    """
+    big = snapshot / "reference_files" / "abc123" / "video.mp4"
+    big.write_bytes(b"m" * 4096)
+
+    result = stage_task_reference_files(
+        task_id="t",
+        reference_files=[
+            "reference_files/abc123/video.mp4",
+            "reference_files/abc123/sheet.xlsx",
+        ],
+        snapshot_root=snapshot,
+        into=tmp_path / "workspace",
+        workspace_file_limit=2048,
+    )
+
+    assert _reasons(result) == [staging.TOO_LARGE_FOR_THE_WORKSPACE]
+    assert result.refused[0].relative_path == "reference_files/abc123/video.mp4"
+    assert "2048" in result.refused[0].detail
+    assert [one.relative_path for one in result.delivered] == [
+        "reference_files/abc123/sheet.xlsx"
+    ]
+    assert not (Path(result.workspace) / "reference_files/abc123/video.mp4").exists()
+
+
+def test_staging_an_oversized_file_would_stop_every_write(tmp_path):
+    """The measurement this whole section exists for, run rather than quoted.
+
+    Deliberately bypasses staging and copies the oversized file in by hand,
+    because the claim under test is about the backend and not about our code.
+    If the backend ever stops applying the limit on write, this fails and the
+    refusal above can be reconsidered -- which is the only honest way to find
+    that out.
+    """
+    root = tmp_path / "task"
+    inputs = root / "work" / "inputs"
+    inputs.mkdir(parents=True)
+    (inputs / "huge.bin").write_bytes(b"x" * (staging.WORKSPACE_FILE_LIMIT + 1))
+
+    backend = _backend(root)
+    assert backend.workspace_apply({"operation": "list", "path": "inputs"})["ok"]
+
+    with pytest.raises(ValueError):
+        backend.workspace_apply(
+            {"operation": "write", "path": "answer.md", "content": "hello"}
+        )
+
+
+def test_writing_works_once_that_file_is_refused_instead_of_staged(
+    snapshot, tmp_path
+):
+    """The same task, staged through the refusal, can write its deliverable.
+
+    Paired with the test above on purpose: together they say the refusal is
+    load-bearing rather than tidy-minded.
+    """
+    big = snapshot / "reference_files" / "abc123" / "huge.bin"
+    big.write_bytes(b"x" * (staging.WORKSPACE_FILE_LIMIT + 1))
+
+    root = tmp_path / "task"
+    result = stage_task_reference_files(
+        task_id="t",
+        reference_files=[
+            "reference_files/abc123/huge.bin",
+            "reference_files/abc123/sheet.xlsx",
+        ],
+        snapshot_root=snapshot,
+        into=root / "work" / staging.MODEL_INPUT_PREFIX,
+    )
+    assert _reasons(result) == [staging.TOO_LARGE_FOR_THE_WORKSPACE]
+
+    written = _backend(root).workspace_apply(
+        {"operation": "write", "path": "answer.md", "content": "hello"}
+    )
+    assert written["ok"] is True
+
+
+# ── Reading a binary file when nothing can run ────────────────────────────
+#
+# `workspace_apply(read)` decodes UTF-8, and 258 of the 261 files the 220 tasks
+# name do not decode. With `exec_run` shut there is no pandas, no PDF library and
+# no way to turn those bytes into anything -- so a text rendering is staged
+# beside the file it came from. It is a compensation, and a difference from a
+# run that has a shell, and the record has to be able to say which files got
+# one and what it cost them.
+
+
+def _render(snapshot: Path, tmp_path: Path, *names: str, limit: int | None = None):
+    return stage_task_reference_files(
+        task_id="t",
+        reference_files=list(names),
+        snapshot_root=snapshot,
+        into=tmp_path / "workspace",
+        render_text=True,
+        **({} if limit is None else {"workspace_file_limit": limit}),
+    )
+
+
+def _rendering(result, name: str):
+    return next(one for one in result.extractions if one.relative_path == name)
+
+
+def test_a_text_file_is_rendered_and_the_model_can_read_what_landed(
+    snapshot, tmp_path
+):
+    (snapshot / "reference_files" / "abc123" / "notes.txt").write_text(
+        "the second quarter figures", encoding="utf-8"
+    )
+
+    result = _render(snapshot, tmp_path, "reference_files/abc123/notes.txt")
+    one = _rendering(result, "reference_files/abc123/notes.txt")
+
+    assert one.outcome == staging.EXTRACTION_IS_TEXT
+    assert one.is_readable
+    assert one.model_path == (
+        "inputs/extracted/reference_files/abc123/notes.txt.txt"
+    )
+    landed = Path(result.workspace) / one.written_to
+    assert "the second quarter figures" in landed.read_text(encoding="utf-8")
+
+
+def test_the_rendering_keeps_the_original_extension_in_its_name(
+    snapshot, tmp_path
+):
+    """`report.csv.txt`, not `report.txt`.
+
+    Two files in one directory differing only by extension are ordinary in this
+    dataset, and a rendering that dropped the extension would silently overwrite
+    one of them with the other -- leaving the model one file where it was given
+    two, with no sign that a swap happened.
+    """
+    folder = snapshot / "reference_files" / "abc123"
+    (folder / "report.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+    (folder / "report.txt").write_text("the written version", encoding="utf-8")
+
+    result = _render(
+        snapshot,
+        tmp_path,
+        "reference_files/abc123/report.csv",
+        "reference_files/abc123/report.txt",
+    )
+    landed = {one.written_to for one in result.extractions}
+
+    assert landed == {
+        "extracted/reference_files/abc123/report.csv.txt",
+        "extracted/reference_files/abc123/report.txt.txt",
+    }
+    rendered = Path(result.workspace) / "extracted/reference_files/abc123"
+    assert (rendered / "report.txt.txt").read_text(encoding="utf-8") == (
+        "the written version"
+    )
+
+
+def test_a_file_the_reader_only_describes_is_recorded_as_a_label(
+    snapshot, tmp_path
+):
+    """A PNG is not a failure and must not be counted as one.
+
+    The reader describes images, audio, archives and CAD rather than reading
+    them. Nine PNGs counted beside five scanned PDFs would read as fourteen
+    broken files, and the two need different answers.
+    """
+    (snapshot / "reference_files" / "abc123" / "logo.png").write_bytes(
+        b"\x89PNG\r\n\x1a\n"
+    )
+
+    result = _render(snapshot, tmp_path, "reference_files/abc123/logo.png")
+    one = _rendering(result, "reference_files/abc123/logo.png")
+
+    assert one.outcome == staging.EXTRACTION_IS_A_LABEL
+    assert one.is_readable is False
+    assert one.written_to is None
+    assert one.label
+
+
+def test_a_file_with_no_text_in_it_is_told_apart_from_one_that_failed(
+    snapshot, tmp_path
+):
+    """Five of the dataset's PDFs are scans and render to nothing.
+
+    That is a real property of the document, and the model needs to be told it
+    rather than left to infer it from an empty file.
+    """
+    (snapshot / "reference_files" / "abc123" / "scan.txt").write_text(
+        "   \n\n  ", encoding="utf-8"
+    )
+
+    one = _rendering(
+        _render(snapshot, tmp_path, "reference_files/abc123/scan.txt"),
+        "reference_files/abc123/scan.txt",
+    )
+
+    assert one.outcome == staging.EXTRACTION_IS_EMPTY
+    assert one.characters == 0
+    assert one.written_to is None
+
+
+def test_a_reader_error_is_recorded_as_a_failure_and_nothing_is_staged(
+    snapshot, tmp_path, monkeypatch
+):
+    """The reader returns its errors as text, so they must not be staged.
+
+    ``[Error reading x.xlsx: …]`` written into the workspace would be a file the
+    model opens expecting a document and finds an apology in.
+    """
+    monkeypatch.setattr(
+        staging,
+        "read_reference_file",
+        lambda path: "[Error reading sheet.xlsx: zipfile.BadZipFile]",
+    )
+
+    one = _rendering(
+        _render(snapshot, tmp_path, "reference_files/abc123/sheet.xlsx"),
+        "reference_files/abc123/sheet.xlsx",
+    )
+
+    assert one.outcome == staging.EXTRACTION_FAILED
+    assert one.written_to is None
+    assert "[Error reading" in one.label
+
+
+def test_the_reader_still_swallows_what_it_cannot_open(tmp_path):
+    """Named by ``_READER_ERROR_PREFIX``'s docstring, and checked against it.
+
+    Everything above depends on the reader returning its failures as a string
+    rather than raising. If a future version raises instead, the rendering step
+    would take a task down on a corrupt spreadsheet, so this is checked against
+    the real reader with real broken bytes rather than a mock.
+    """
+    from core.file_reader import read_reference_file
+
+    broken = tmp_path / "sheet.xlsx"
+    broken.write_bytes(b"PK\x03\x04 this is not a workbook")
+
+    answer = read_reference_file(str(broken))
+
+    assert isinstance(answer, str)
+    assert answer.startswith(staging._READER_ERROR_PREFIX)
+
+
+def test_a_long_rendering_is_cut_to_fit_and_says_so(snapshot, tmp_path):
+    """Cut on bytes, because the limit is bytes and the text may not be ASCII.
+
+    The note at the end is the point: a model reading a truncated extraction
+    with no marker would take the missing half for a document that ends there.
+    """
+    (snapshot / "reference_files" / "abc123" / "long.txt").write_text(
+        "é" * 4000, encoding="utf-8"
+    )
+
+    result = _render(
+        snapshot, tmp_path, "reference_files/abc123/long.txt", limit=2048
+    )
+    one = _rendering(result, "reference_files/abc123/long.txt")
+
+    assert one.outcome == staging.EXTRACTION_TRUNCATED
+    assert one.is_readable
+    landed = Path(result.workspace) / one.written_to
+    assert len(landed.read_bytes()) <= 2048
+    assert "cut here" in landed.read_text(encoding="utf-8")
+
+
+def test_a_file_too_big_to_stage_still_gets_its_text_rendered(
+    snapshot, tmp_path
+):
+    """The compensation that keeps a refusal from being a total loss.
+
+    Five of the 24 over-limit originals in the 220 tasks hold real text -- a
+    14.5 MB spreadsheet renders to 1,973 characters. Refusing the bytes and
+    dropping the text would throw away the part that fits.
+    """
+    big = snapshot / "reference_files" / "abc123" / "big.txt"
+    big.write_text("the figures that matter " * 200, encoding="utf-8")
+
+    result = _render(
+        snapshot, tmp_path, "reference_files/abc123/big.txt", limit=2048
+    )
+
+    assert _reasons(result) == [staging.TOO_LARGE_FOR_THE_WORKSPACE]
+    one = _rendering(result, "reference_files/abc123/big.txt")
+    assert one.is_readable
+    landed = Path(result.workspace) / one.written_to
+    assert "the figures that matter" in landed.read_text(encoding="utf-8")
+
+
+def test_nothing_is_rendered_unless_it_is_asked_for(snapshot, tmp_path):
+    """The default stays what it was, so callers that never asked are unchanged."""
+    result = _stage(snapshot, tmp_path, "reference_files/abc123/sheet.xlsx")
+
+    assert result.extractions == ()
+    assert result.guide is None
+    assert not (Path(result.workspace) / staging.INPUTS_GUIDE).exists()
+
+
+# ── Telling the model its inputs exist ────────────────────────────────────
+#
+# Staging files into a directory the model has never been told about leaves it
+# no better off than an empty one. The task wording comes from the dataset and
+# is hash-sealed, so it cannot carry the directory layout; a staged file can.
+
+
+def test_the_guide_is_written_where_the_model_can_find_it(snapshot, tmp_path):
+    result = _render(snapshot, tmp_path, "reference_files/abc123/sheet.xlsx")
+
+    assert result.guide == "inputs/INPUTS.md"
+    assert (Path(result.workspace) / staging.INPUTS_GUIDE).is_file()
+
+
+def test_the_guide_names_every_file_and_every_one_that_is_missing(
+    snapshot, tmp_path
+):
+    """Named, not counted. A count cannot be checked against a result."""
+    (snapshot / "reference_files" / "abc123" / "notes.txt").write_text(
+        "some text", encoding="utf-8"
+    )
+    big = snapshot / "reference_files" / "abc123" / "huge.bin"
+    big.write_bytes(b"x" * 4096)
+
+    result = _render(
+        snapshot,
+        tmp_path,
+        "reference_files/abc123/notes.txt",
+        "reference_files/abc123/huge.bin",
+        "reference_files/abc123/gone.docx",
+        limit=2048,
+    )
+    guide = (Path(result.workspace) / staging.INPUTS_GUIDE).read_text(
+        encoding="utf-8"
+    )
+
+    assert "inputs/reference_files/abc123/notes.txt" in guide
+    assert "inputs/extracted/reference_files/abc123/notes.txt.txt" in guide
+    assert "reference_files/abc123/huge.bin" in guide
+    assert staging.TOO_LARGE_FOR_THE_WORKSPACE in guide
+    assert "reference_files/abc123/gone.docx" in guide
+    assert staging.NOT_IN_SNAPSHOT in guide
+
+
+def test_the_guide_does_not_offer_a_replacement_it_did_not_make(
+    snapshot, tmp_path
+):
+    """It says a text version is not the file, and it must not contradict that.
+
+    An earlier draft said "nothing was put in their place" two lines under a
+    path to a rendering of that same file.
+    """
+    result = _render(snapshot, tmp_path, "reference_files/abc123/gone.docx")
+    guide = (Path(result.workspace) / staging.INPUTS_GUIDE).read_text(
+        encoding="utf-8"
+    )
+
+    assert "is not a replacement" in guide
+    assert "Nothing was put in their place" not in guide
+
+
+def test_a_task_that_names_nothing_gets_no_guide(snapshot, tmp_path):
+    """There is nothing to describe, and an empty guide would read as a fault."""
+    result = stage_task_reference_files(
+        task_id="t",
+        reference_files=[],
+        snapshot_root=snapshot,
+        into=tmp_path / "workspace",
+        render_text=True,
+    )
+
+    assert result.guide is None
+    assert not (Path(result.workspace) / staging.INPUTS_GUIDE).exists()
+
+
+# ── Saying so in the record ───────────────────────────────────────────────
+
+
+def test_a_task_holding_only_files_it_cannot_open_is_marked(snapshot, tmp_path):
+    """Files arrived, none can be opened: a third state, and its own field.
+
+    Without it, such a task is indistinguishable in the record from one that got
+    everything -- ``ran_without_its_inputs`` is False for both, because nothing
+    was refused.
+    """
+    (snapshot / "reference_files" / "abc123" / "logo.png").write_bytes(b"\x89PNG")
+
+    result = _render(snapshot, tmp_path, "reference_files/abc123/logo.png")
+
+    assert result.refused == ()
+    assert result.ran_without_its_inputs is False
+    assert result.could_open_nothing is True
+
+
+def test_one_readable_file_is_enough_to_clear_that_mark(snapshot, tmp_path):
+    (snapshot / "reference_files" / "abc123" / "logo.png").write_bytes(b"\x89PNG")
+    (snapshot / "reference_files" / "abc123" / "notes.txt").write_text(
+        "readable", encoding="utf-8"
+    )
+
+    result = _render(
+        snapshot,
+        tmp_path,
+        "reference_files/abc123/logo.png",
+        "reference_files/abc123/notes.txt",
+    )
+
+    assert result.could_open_nothing is False
+
+
+def test_a_task_with_no_renderings_is_not_claimed_to_be_blind(
+    snapshot, tmp_path
+):
+    """The field answers from renderings, so with none it must say nothing.
+
+    Reporting True here would turn every caller that never asked for renderings
+    into a cohort of blind tasks.
+    """
+    result = _stage(snapshot, tmp_path, "reference_files/abc123/sheet.xlsx")
+
+    assert result.extractions == ()
+    assert result.could_open_nothing is False
+
+
+def test_the_record_counts_blind_tasks_and_renderings_by_outcome(
+    snapshot, tmp_path
+):
+    (snapshot / "reference_files" / "abc123" / "logo.png").write_bytes(b"\x89PNG")
+    (snapshot / "reference_files" / "abc123" / "notes.txt").write_text(
+        "readable", encoding="utf-8"
+    )
+    blind = _render(snapshot, tmp_path / "a", "reference_files/abc123/logo.png")
+    sighted = _render(
+        snapshot, tmp_path / "b", "reference_files/abc123/notes.txt"
+    )
+
+    record = staging_record([blind, sighted])
+
+    assert record["tasks_that_could_open_nothing"] == 1
+    assert record["renderings_by_outcome"] == {
+        staging.EXTRACTION_IS_A_LABEL: 1,
+        staging.EXTRACTION_IS_TEXT: 1,
+    }
+    assert [one["could_open_nothing"] for one in record["tasks"]] == [True, False]
+
+
+def test_the_record_says_what_a_rendering_is_and_is_not(snapshot, tmp_path):
+    """A reader of the record must not take an extraction for the file.
+
+    It is the difference between "the model was given the spreadsheet" and "the
+    model was given some text read out of the spreadsheet", and every judgement
+    about a task that needed a chart depends on which one is true.
+    """
+    record = staging_record([])
+
+    assert "lossy" in record["what_a_rendering_is"]
+    assert "never in place of it" in record["what_a_rendering_is"]

--- a/batch-runner/tests/test_agentic_v2_rehearsal_voice.py
+++ b/batch-runner/tests/test_agentic_v2_rehearsal_voice.py
@@ -1,0 +1,249 @@
+"""The free stand-in that proves the path before anything is charged for it.
+
+A paid run of 220 tasks is not the place to discover that the workspace was
+empty, that the guide was never written, or that a finished task gets thrown
+away by the verifier. All three of those were true at some point, all three
+were found by this stand-in, and all three would have been paid for first.
+
+So :class:`RehearsalVoice` is a voice in the same slot the Azure one occupies,
+answering from a script instead of from a model. It works a real task against a
+real backend on real staged bytes -- read the guide, list the workspace, write a
+file, commit it -- and reports which of those four actually worked.
+
+The tests here are about the two ways a stand-in like this becomes dangerous.
+It must never be mistaken for a result: a file it wrote is not an answer, and a
+grade over one would be a grade of this module's wording. And it must never be
+mistaken for a measurement: no call was made, which is not the same as a call
+that cost nothing, and the difference is the whole of what a cost record is
+worth.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.agentic_v2_conversation import (  # noqa: E402
+    AskForTool,
+    GaveUp,
+    ModelRequest,
+    ToolExchange,
+)
+from core.agentic_v2_rehearsal_voice import (  # noqa: E402
+    GUIDE_PATH,
+    REHEARSAL_DELIVERABLE,
+    RehearsalVoice,
+    rehearsal_is_not_a_run,
+)
+
+PROMPT = "work this task"
+TOOLS = ("workspace_apply", "exec_run", "finalize")
+
+
+def _request(turn: int, history, *, turns_left: int = 8, prompt: str = PROMPT):
+    return ModelRequest(
+        turn=turn,
+        task_prompt=prompt,
+        tools_available=TOOLS,
+        history=tuple(history),
+        turns_left=turns_left,
+    )
+
+
+def _ok(operation: str, data: dict, *, tool_name: str = "workspace_apply"):
+    return ToolExchange(
+        call_id="c",
+        tool_name=tool_name,
+        arguments={"operation": operation},
+        ok=True,
+        data=data,
+        error_type=None,
+    )
+
+
+def _not_ok(operation: str, error_type: str):
+    return ToolExchange(
+        call_id="c",
+        tool_name="workspace_apply",
+        arguments={"operation": operation},
+        ok=False,
+        data={},
+        error_type=error_type,
+    )
+
+
+def _work_a_whole_task(voice: RehearsalVoice, *, prompt: str = PROMPT) -> list:
+    """Drive one task end to end, answering each request as the backend would.
+
+    Stops at ``finalize``, which is what ends a task in the real loop -- the
+    voice is never asked for a turn after it.
+    """
+    replies = []
+    history: list[ToolExchange] = []
+    answers = {
+        "read": _ok("read", {"content": "# Your input files\n"}),
+        "list": _ok("list", {"entries": ["inputs", "notes.md"]}),
+        "write": _ok("write", {}),
+    }
+    for turn in range(1, 6):
+        reply = voice.next_turn(_request(turn, history, prompt=prompt))
+        replies.append(reply)
+        if not isinstance(reply, AskForTool) or reply.tool_name == "finalize":
+            break
+        history.append(answers[reply.arguments["operation"]])
+    return replies
+
+
+# ── what it does ──────────────────────────────────────────────────────────
+
+
+def test_it_opens_the_guide_first_because_that_is_what_the_model_is_told_to_do():
+    """The first call is the one that was failing for 95 of the 220 tasks."""
+    reply = RehearsalVoice().next_turn(_request(1, []))
+
+    assert isinstance(reply, AskForTool)
+    assert reply.arguments == {"operation": "read", "path": GUIDE_PATH}
+
+
+def test_it_reads_lists_writes_and_commits_in_four_calls():
+    voice = RehearsalVoice()
+
+    replies = _work_a_whole_task(voice)
+
+    assert all(isinstance(one, AskForTool) for one in replies)
+    assert [one.tool_name for one in replies] == [
+        "workspace_apply",
+        "workspace_apply",
+        "workspace_apply",
+        "finalize",
+    ]
+    assert [
+        one.arguments["operation"] for one in replies[:3]
+    ] == ["read", "list", "write"]
+    assert replies[-1].arguments["deliverables"] == [REHEARSAL_DELIVERABLE]
+
+
+def test_the_file_it_writes_says_it_is_not_an_answer():
+    """In the file itself, not only in the record beside it.
+
+    A deliverable is collected onto disk and can be read long after the record
+    that framed it has been lost. If the disclaimer lives only in the record,
+    the file on disk is indistinguishable from work.
+    """
+    voice = RehearsalVoice()
+    history = [_ok("read", {"content": "the guide"}), _ok("list", {"entries": []})]
+
+    reply = voice.next_turn(_request(3, history))
+
+    assert isinstance(reply, AskForTool)
+    assert reply.arguments["path"] == REHEARSAL_DELIVERABLE
+    written = reply.arguments["content"]
+    assert "not by a model" in written
+    assert "must not be scored as one" in written
+
+
+def test_it_quotes_what_the_guide_actually_returned():
+    """So a guide that was written but says nothing useful is still visible."""
+    voice = RehearsalVoice()
+    history = [_ok("read", {"content": "# Your input files\n\n- inputs/sheet.xlsx"})]
+
+    voice.next_turn(_request(2, history))
+    history.append(_ok("list", {"entries": []}))
+    reply = voice.next_turn(_request(3, history))
+
+    assert "inputs/sheet.xlsx" in reply.arguments["content"]
+
+
+# ── what it refuses to paper over ─────────────────────────────────────────
+
+
+def test_a_refused_write_stops_the_task_and_names_the_error():
+    """The 1 MiB case. A real model is told only ``fixture_backend_error``.
+
+    It would retry until its budget was gone and the record would show a model
+    that could not save a file. The stand-in stops on the first refusal and puts
+    the error type where the fault belongs.
+    """
+    voice = RehearsalVoice()
+    history = [
+        _ok("read", {"content": "the guide"}),
+        _ok("list", {"entries": []}),
+        _not_ok("write", "fixture_backend_error"),
+    ]
+
+    reply = voice.next_turn(_request(4, history))
+
+    assert isinstance(reply, GaveUp)
+    assert "fixture_backend_error" in reply.note
+    # Keyed by the task, not counted -- which task could not save its file is
+    # the thing worth knowing, and a count of two says nothing about whether
+    # it was the same fault twice.
+    assert list(voice.as_dict()["writes_refused"].values()) == [
+        "fixture_backend_error"
+    ]
+
+
+def test_a_guide_that_could_not_be_read_is_recorded_as_not_readable():
+    voice = RehearsalVoice()
+    history = [_not_ok("read", "path_not_found")]
+
+    voice.next_turn(_request(2, history))
+
+    assert voice.as_dict()["guide_was_readable_in"] == 0
+    assert voice.as_dict()["tasks_worked"] == 1
+
+
+def test_running_out_of_turns_before_writing_says_the_ceiling_is_too_low():
+    """Rather than committing nothing and looking like a model that gave up."""
+    reply = RehearsalVoice().next_turn(_request(8, [], turns_left=1))
+
+    assert isinstance(reply, GaveUp)
+    assert "turn ceiling" in reply.note
+
+
+# ── what it must never be taken for ───────────────────────────────────────
+
+
+def test_it_declares_that_it_makes_no_paid_calls():
+    """The flag the budget code reads. It is not a comment."""
+    assert RehearsalVoice().makes_paid_calls is False
+
+
+def test_its_summary_says_a_grade_over_these_files_would_be_meaningless():
+    voice = RehearsalVoice()
+    _work_a_whole_task(voice)
+
+    summary = voice.as_dict()
+
+    assert summary["tasks_worked"] == 1
+    assert summary["guide_was_readable_in"] == 1
+    assert summary["wrote_a_file_in"] == 1
+    assert "grade" in summary["this_is_not_a_result"]
+    assert "No model was asked" in summary["what_this_is"]
+
+
+def test_spending_nothing_is_reported_as_no_call_and_not_as_zero_dollars():
+    """The distinction the whole cost ledger rests on.
+
+    "$0.00" is a measurement. "nothing was asked" is the absence of one, and a
+    run that reports the first when it means the second has put a false number
+    into a ledger that other numbers are compared against.
+    """
+    said = rehearsal_is_not_a_run()
+
+    assert "no call was made" in said["cost"]
+    assert "not the same as $0 measured" in said["cost"]
+
+
+def test_two_tasks_are_counted_separately():
+    """A fresh request with no history starts a task; the count must follow."""
+    voice = RehearsalVoice()
+
+    _work_a_whole_task(voice, prompt="the first task")
+    _work_a_whole_task(voice, prompt="the second task")
+
+    assert voice.as_dict()["tasks_worked"] == 2

--- a/batch-runner/tests/test_run_agentic_v2_stage.py
+++ b/batch-runner/tests/test_run_agentic_v2_stage.py
@@ -27,6 +27,7 @@ Nothing here calls a model, builds a client or spends anything.
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
 import re
 import subprocess
@@ -616,3 +617,78 @@ def test_the_reference_answers_are_not_fetched_onto_the_machine_that_runs():
             assert "deliverable_files" in fetch and "--exclude" in fetch, (
                 f"job {name!r} fetches the reference answers onto the runner"
             )
+
+
+# ── The rehearsal ─────────────────────────────────────────────────────────
+#
+# ``--rehearse`` walks the entire production path -- real dataset rows, real
+# staging, real backend, real trace verification, real deliverable collection
+# -- with a scripted stand-in where the model goes. It exists because every
+# defect found in that path so far was found after a task had been worked, and
+# on the paid path that means after it had been charged for. Three of them
+# would have looked like the model failing.
+
+
+@needs_dataset
+def test_a_rehearsal_works_every_task_without_any_azure_environment(tmp_path):
+    """The five tasks, end to end, with nothing configured to reach a model.
+
+    This is the check that would have caught all three: the missing guide that
+    killed a task on turn one, the state digest that threw away a finished
+    task, and the display that printed "failed" beside five tasks that had all
+    succeeded.
+    """
+    into = tmp_path / "rehearsal"
+
+    finished = _run(
+        "--stage", "advance_check_5", "--rehearse", "--into", str(into)
+    )
+
+    assert finished.returncode == 0, finished.stdout + finished.stderr
+    assert "finished       5 of 5" in finished.stdout
+    assert "guide readable 5 of 5" in finished.stdout
+    assert "wrote a file   5 of 5" in finished.stdout
+    assert finished.stdout.count("  ok\n") == 5
+
+
+@needs_dataset
+def test_a_rehearsal_says_it_is_not_a_run_and_spent_nothing(tmp_path):
+    """Both on the screen and in the file, and neither says $0.00.
+
+    A record that reports a rehearsal as a zero-cost run is worse than one that
+    reports nothing, because the zero is a number and will be averaged with
+    real ones.
+    """
+    into = tmp_path / "rehearsal"
+
+    finished = _run(
+        "--stage", "advance_check_5", "--rehearse", "--into", str(into)
+    )
+    record = json.loads((into / "rehearsal_record.json").read_text("utf-8"))
+
+    assert "Nothing here is a result" in finished.stdout
+    assert "spent          nothing — no model was asked" in finished.stdout
+    assert record["rehearsal"]["tasks_worked"] == 5
+    # In the slot a real run's route fingerprint occupies, so anything reading
+    # the record to find out which model answered gets the refusal rather than
+    # a plausible-looking route.
+    assert "no call was made" in record["route_fingerprint"]["cost"]
+    assert "$0" not in finished.stdout.split("spent")[-1]
+
+
+@needs_dataset
+def test_a_rehearsal_collects_a_deliverable_for_every_task_onto_disk(tmp_path):
+    """The backend purges its workspace on close, so the record is not enough.
+
+    Every rehearsal before deliverable collection worked left five empty
+    directories behind and a record that said files had been written. Both were
+    true, and the files were gone.
+    """
+    into = tmp_path / "rehearsal"
+
+    _run("--stage", "advance_check_5", "--rehearse", "--into", str(into))
+
+    collected = sorted((into / "deliverables").rglob("*.md"))
+    assert len(collected) == 5
+    for one in collected:
+        assert "must not be scored as one" in one.read_text("utf-8")

--- a/batch-runner/tests/test_run_agentic_v2_stage.py
+++ b/batch-runner/tests/test_run_agentic_v2_stage.py
@@ -28,8 +28,10 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -70,6 +72,17 @@ needs_dataset = pytest.mark.skipif(
     not HAVE_DATASET,
     reason=f"the pinned dataset is not at {runner.PINNED_DATASET_PARQUET}",
 )
+
+#: A directory the runner will agree to stage from.
+#:
+#: Made once for the module and left for the OS to clear, because it holds one
+#: five-byte file and exists to satisfy a single check: that the root is a tree
+#: of real files rather than a cache of symlinks. It deliberately does *not*
+#: hold the dataset's reference files — the tests that use it are testing
+#: pricing and sharding, and a dry run copies nothing.
+STAGEABLE_ROOT = Path(tempfile.mkdtemp(prefix="stageable-root-"))
+(STAGEABLE_ROOT / "reference_files" / "placeholder").mkdir(parents=True)
+(STAGEABLE_ROOT / "reference_files" / "placeholder" / "a.txt").write_text("real")
 
 
 # ── The pricing guard ─────────────────────────────────────────────────────
@@ -147,7 +160,16 @@ def test_a_stage_priced_too_low_is_refused_with_the_shortfall(tmp_path):
 
 
 def _run(*args, env=None):
-    """Run the entry point as a subprocess, with no Azure environment at all."""
+    """Run the entry point as a subprocess, with no Azure environment at all.
+
+    ``--dataset-root`` is supplied unless the caller names one, because the
+    runner now refuses a stage whose reference files cannot be staged and the
+    tests below are about pricing, sharding and the dry run being free. The
+    stand-in is a directory of real files, which is the one property the
+    refusal checks; :func:`test_a_dry_run_refuses_a_snapshot_it_cannot_stage_from`
+    covers the other side, and covers it against the shape a real fetch
+    actually produces.
+    """
     clean = {
         key: value
         for key, value in os.environ.items()
@@ -155,6 +177,8 @@ def _run(*args, env=None):
     }
     clean["PYTHONPATH"] = str(BATCH_RUNNER_ROOT)
     clean.update(env or {})
+    if "--dataset-root" not in args:
+        args = (*args, "--dataset-root", str(STAGEABLE_ROOT))
     return subprocess.run(
         [sys.executable, str(RUNNER_PATH), *args],
         cwd=BATCH_RUNNER_ROOT,
@@ -271,11 +295,22 @@ def test_one_shard_of_one_is_the_unsharded_run():
 
 @needs_dataset
 def test_the_dry_run_says_what_is_missing_rather_than_only_what_is_ready():
-    """The handicap is printed on the way in, not discovered in the results."""
+    """What is still not real is printed on the way in, not found in the results.
+
+    This test used to pin the sentence "reference files that are not in the
+    workspace", and it was right to: nothing copied them and the run had to say
+    so. Staging them made that sentence false, and a test asserting a false
+    sentence is worse than no test — it holds the claim in place after the fact
+    it described has gone.
+
+    So it now pins what is *still* missing. The isolation is the fixture
+    backend and ``exec_run`` is shut, which is the thing most likely to be
+    forgotten when a result gets quoted later.
+    """
     printed = _run("--stage", "advance_check_5", "--dry-run").stdout
 
     assert "isolation      none — fixture backend, exec_run shut" in printed
-    assert "reference files that are not in the workspace" in printed
+    assert "reference files that are not in the workspace" not in printed
 
 
 # ── The expert's answer never travels ─────────────────────────────────────
@@ -385,3 +420,199 @@ def test_what_was_real_does_not_quietly_include_the_isolation():
     assert "isolation" not in real
     assert "exec_run" not in real
     assert "the charge for every call" in real
+
+
+# ── The files a task is told to open ──────────────────────────────────────
+#
+# 125 of the 220 tasks name reference files. Until this window nothing copied
+# them anywhere, so a task that needed one failed on its merits and the failure
+# was indistinguishable from the model being unable to do the work. The runner
+# now stages them, and the two tests below are about the moment before that:
+# whether it can tell a directory it can stage from from one it cannot, and
+# whether it says so before any money is spent rather than 261 times during the
+# run.
+
+
+@needs_dataset
+def test_a_dry_run_refuses_a_snapshot_it_cannot_stage_from(tmp_path):
+    """The shape a plain `hf download` really produces, and the real cost of it.
+
+    A huggingface_hub cache is names, not bytes: every file under the snapshot
+    is a symlink into a sibling ``blobs/`` directory outside it. Measured on
+    this repository's own pinned revision, that is 301 of 301 reference files.
+    Nothing that opens with ``O_NOFOLLOW`` will read one, so staging from such a
+    root delivers nothing at all — and a paid stage run against it produces 125
+    tasks that failed holding an empty workspace, which reads afterwards as a
+    model that could not do the work.
+
+    Refusing in the *dry* run is the point. That is the free path, so this
+    particular mistake costs nothing to find.
+    """
+    link_farm = tmp_path / "cache-shaped"
+    blobs = tmp_path / "blobs"
+    blobs.mkdir()
+    (blobs / "deadbeef").write_text("the bytes live here, outside the root")
+    folder = link_farm / "reference_files" / "abc123"
+    folder.mkdir(parents=True)
+    (folder / "sheet.xlsx").symlink_to(os.path.relpath(blobs / "deadbeef", folder))
+
+    finished = _run(
+        "--stage", "advance_check_5", "--dry-run",
+        "--dataset-root", str(link_farm),
+    )
+
+    assert finished.returncode == 1
+    assert "Refused before spending anything" in finished.stdout
+    assert "--local-dir" in finished.stdout
+    # Named, so that the fix is the next thing the reader does rather than
+    # something they work out from a generic "source is a link".
+    assert "huggingface_hub cache" in finished.stdout
+    assert "read as the model's" in finished.stdout
+
+
+@needs_dataset
+def test_a_stage_naming_no_reference_files_is_not_blocked_by_the_root(tmp_path):
+    """A directory a cohort never opens must not be able to stop it.
+
+    The refusal above is worth having because it is cheap and specific. It
+    would stop being worth having if it also refused runs that were never going
+    to read a file — a gate that fires on tasks it does not apply to teaches
+    people to route around it.
+    """
+    empty_root = tmp_path / "nothing-here"
+    empty_root.mkdir()
+
+    printed = _run(
+        "--stage", "advance_check_5", "--dry-run",
+        "--dataset-root", str(empty_root),
+    )
+
+    # advance_check_5 does name files, so this one *is* refused -- and the
+    # assertion worth making is that the refusal names the root rather than
+    # failing somewhere further in.
+    assert "the reference files cannot be staged from" in printed.stdout
+    assert str(empty_root) in printed.stdout
+
+
+@needs_dataset
+def test_the_dry_run_says_where_the_files_would_come_from(tmp_path):
+    """The printed line names the root, because the wrong root is the likely bug.
+
+    It used to print a count of tasks whose files "are not in the workspace",
+    which was true when nothing staged them and became false the moment
+    something did. A line that states a fact outlives the fact; this one states
+    where the bytes come from, which is checkable against the run.
+    """
+    printed = _run("--stage", "advance_check_5", "--dry-run").stdout
+
+    assert "tasks name reference files, staged from" in printed
+    assert str(STAGEABLE_ROOT) in printed
+    assert "handicap" not in printed
+
+
+# ── The workflow and the runner have to agree about the dataset ───────────
+
+STAGE_WORKFLOW = (
+    BATCH_RUNNER_ROOT.parent / ".github" / "workflows" / "agentic-v2-stage-run.yml"
+)
+
+
+def _jobs() -> dict:
+    return yaml.safe_load(STAGE_WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+
+
+def _shell_blocks(job: dict) -> list[str]:
+    return [str(step["run"]) for step in job["steps"] if "run" in step]
+
+
+def _flag_value(script: str, flag: str) -> str | None:
+    """What a `--flag value` in a shell block was given, quotes stripped."""
+    found = re.search(rf"{re.escape(flag)}\s+[\"']?([^\"'\s\\]+)", script)
+    return found.group(1) if found else None
+
+
+#: A block that *runs* the stage, not one that merely says its name. The
+#: difference matters as soon as a job runs the stage's own test file: the
+#: earlier version of this matched on the bare filename, and adding
+#: `tests/test_run_agentic_v2_stage.py` to the free job's pytest step made it
+#: see a step that invoked the stage with no `--parquet`. The test failed
+#: correctly, about the wrong step.
+INVOKES_THE_STAGE = re.compile(r"python\s+scripts/run_agentic_v2_stage\.py")
+
+
+def _stage_invocations(blocks: list[str]) -> list[str]:
+    return [one for one in blocks if INVOKES_THE_STAGE.search(one)]
+
+
+def test_every_job_that_runs_the_stage_fetches_a_dataset_it_can_stage_from():
+    """The gate is in the runner; the only thing that can defeat it is here.
+
+    ``run_agentic_v2_stage.py`` refuses a ``huggingface_hub`` cache, and that
+    refusal is worth having only while the workflow feeding it does not hand it
+    one. Nothing but this test connects them. A `hf download` line edited back
+    to its default passes every other check in the repository, and then refuses
+    a paid cohort on the runner -- after the job has queued, checked out,
+    authenticated and been counted as an attempt.
+    """
+    checked = 0
+    for name, job in _jobs().items():
+        blocks = _shell_blocks(job)
+        if not _stage_invocations(blocks):
+            continue
+        checked += 1
+
+        fetches = [one for one in blocks if "hf download" in one]
+        assert fetches, f"job {name!r} runs the stage but never fetches the dataset"
+        for fetch in fetches:
+            assert "--local-dir" in fetch, (
+                f"job {name!r} fetches into the default cache, which is a tree "
+                "of symlinks into a blob store outside it. Every reference file "
+                "would be refused and every task would run without its inputs."
+            )
+
+    assert checked == 2, "expected the free job and the paid job to both run it"
+
+
+def test_the_stage_is_pointed_at_the_directory_the_workflow_fetched():
+    """Two places naming a path is two places for it to differ.
+
+    Fetching correctly and then reading somewhere else is the same outcome as
+    not fetching at all, and it is harder to see: the download step is green.
+    """
+    for name, job in _jobs().items():
+        blocks = _shell_blocks(job)
+        runs = _stage_invocations(blocks)
+        if not runs:
+            continue
+
+        fetched_into = {
+            _flag_value(one, "--local-dir") for one in blocks if "hf download" in one
+        }
+        assert len(fetched_into) == 1, f"job {name!r} fetches to more than one place"
+        into = fetched_into.pop()
+
+        for one in runs:
+            parquet = _flag_value(one, "--parquet")
+            assert parquet is not None, (
+                f"job {name!r} runs the stage without saying which parquet, so "
+                "it falls back to the cache path the fetch no longer fills"
+            )
+            assert parquet.startswith(f"{into}/"), (
+                f"job {name!r} fetches into {into} and reads {parquet}"
+            )
+
+
+def test_the_reference_answers_are_not_fetched_onto_the_machine_that_runs():
+    """595 MB of expert deliverables, beside a workspace, for no reason.
+
+    They are the answers. No inference step opens one, and the only way they
+    can affect a result is by being on the disk at all. Excluded at the fetch
+    rather than ignored afterwards, because "nothing reads them" is a claim
+    about every future version of the runner, and "they were never downloaded"
+    is a claim about this job.
+    """
+    for name, job in _jobs().items():
+        for fetch in (one for one in _shell_blocks(job) if "hf download" in one):
+            assert "deliverable_files" in fetch and "--exclude" in fetch, (
+                f"job {name!r} fetches the reference answers onto the runner"
+            )

--- a/tasks/0822_saturday/v2_run_preregistration.json
+++ b/tasks/0822_saturday/v2_run_preregistration.json
@@ -83,6 +83,46 @@
     "trial_30",
     "full_220"
   ],
+  "inputs": {
+    "how_to_check_this": "core.agentic_v2_preregistration.verify_input_disposition, against a copy of the pinned revision",
+    "limits": {
+      "come_from": "core/agentic_compute.py",
+      "max_bytes_per_file": 536870912,
+      "max_bytes_per_task": 2147483648,
+      "max_files_per_task": 256
+    },
+    "no_substitute_is_made": "a file that cannot be delivered is recorded as not delivered. Nothing is put in its place -- subtitles, frames or a summary would each be a different task from the one the dataset sets, and a score reported against a task nobody set is worse than a gap",
+    "per_stage": {
+      "advance_check_5": {
+        "files_named": 2,
+        "files_that_cannot_be_delivered": [],
+        "tasks": 5,
+        "tasks_naming_reference_files": 2
+      },
+      "full_220": {
+        "files_named": 261,
+        "files_that_cannot_be_delivered": [
+          {
+            "occupation": "Film and Video Editors",
+            "path": "reference_files/67469cf2a7509f149c095cf4f6542f6d/TWT_A001_03.mp4",
+            "reason": "larger_than_the_single_file_limit",
+            "size_bytes": 689061330,
+            "task_id": "a941b6d8-4289-4500-b45a-f8e4fc94a724"
+          }
+        ],
+        "tasks": 220,
+        "tasks_naming_reference_files": 125
+      },
+      "trial_30": {
+        "files_named": 21,
+        "files_that_cannot_be_delivered": [],
+        "tasks": 30,
+        "tasks_naming_reference_files": 14
+      }
+    },
+    "staged_into": "inputs/ inside each task's own workspace, one workspace per attempt, copied from the same revision the prompt text comes from",
+    "what_a_failure_there_does_not_show": "a task that ran without a file it named is not evidence about the model. It is recorded with the missing file's name so the two cannot be read as one"
+  },
   "manifest": {
     "catalog_sha256": "5f1eca853979b2b4efe6c6ba656545c3a416da920e3faf067d52f5d8ac4ae0eb",
     "dataset_file_sha256": "f8422fab9b21d90c0ee5f0659842ab666d418cb8940842918f9f4b0df7ae0202",
@@ -456,7 +496,7 @@
     },
     "what_stops_a_task": "any per-task ceiling above, or the per-task budget, whichever comes first. A task stopped by a ceiling is recorded as stopped by that ceiling and is not a model failure"
   },
-  "seal": "6955e0f64bccdfe4138f1edade67a07c7d591c5e865328e43aa1a50ac64dcb87",
+  "seal": "3f42a0f3ed673e07fbfc4d915032ba1bddbd610ba6d13e6f2f0e7b745c3d997e",
   "stop_rules": [
     "the deployment or model reported back differs from the pinned one",
     "a run switches model or deployment on its own",

--- a/tasks/0822_saturday/v2_run_preregistration.json
+++ b/tasks/0822_saturday/v2_run_preregistration.json
@@ -659,6 +659,13 @@
       "resolved_model": "gpt-5.4",
       "route_profile": "project-ci"
     },
+    "one_failed_tool_call_ends_the_task": {
+      "comes_from": "core/agentic_v2_runner.py dispatch_one",
+      "holds": true,
+      "is_not": "evidence about the model. It is the desk closing on the first mistake, and a task that ends this way says what the call was and what came back",
+      "recorded_as": "stop_reason tool_desk_broke",
+      "the_model_is_told": "nothing, and is not asked for another turn"
+    },
     "per_task_ceilings": {
       "max_input_tokens": 737280,
       "max_model_calls": 9,
@@ -707,7 +714,7 @@
     },
     "what_stops_a_task": "any per-task ceiling above, or the per-task budget, whichever comes first. A task stopped by a ceiling is recorded as stopped by that ceiling and is not a model failure"
   },
-  "seal": "0b557a3e0278afba2b2c11bdbd9fb6eb78dfc11b9e1b2b6c5023d266a472c9c8",
+  "seal": "f9a906ab1bcf89cdfdd25a8454c35be17ad2d32e4ae3e0b95782ad236853dcd9",
   "stop_rules": [
     "the deployment or model reported back differs from the pinned one",
     "a run switches model or deployment on its own",

--- a/tasks/0822_saturday/v2_run_preregistration.json
+++ b/tasks/0822_saturday/v2_run_preregistration.json
@@ -84,19 +84,23 @@
     "full_220"
   ],
   "inputs": {
-    "how_to_check_this": "core.agentic_v2_preregistration.verify_input_disposition, against a copy of the pinned revision",
+    "how_to_check_this": "core.agentic_v2_preregistration.verify_input_disposition for the sizes and core.agentic_v2_preregistration.verify_reader_reach for what can be opened, both against a copy of the pinned revision",
     "limits": {
       "come_from": "core/agentic_compute.py",
       "max_bytes_per_file": 536870912,
+      "max_bytes_per_file_in_the_workspace": 1048576,
       "max_bytes_per_task": 2147483648,
-      "max_files_per_task": 256
+      "max_files_per_task": 256,
+      "the_workspace_limit_comes_from": "core/agentic_v2_fixture_backend.py, and it is enforced while walking the whole workspace rather than on the file being touched. The walk runs on write, so one file over it stops the task writing anything at all and the model is told only fixture_backend_error"
     },
     "no_substitute_is_made": "a file that cannot be delivered is recorded as not delivered. Nothing is put in its place -- subtitles, frames or a summary would each be a different task from the one the dataset sets, and a score reported against a task nobody set is worse than a gap",
     "per_stage": {
       "advance_check_5": {
         "files_named": 2,
         "files_that_cannot_be_delivered": [],
+        "files_too_large_for_the_workspace": [],
         "tasks": 5,
+        "tasks_affected_by_the_workspace_limit": 0,
         "tasks_naming_reference_files": 2
       },
       "full_220": {
@@ -110,18 +114,225 @@
             "task_id": "a941b6d8-4289-4500-b45a-f8e4fc94a724"
           }
         ],
+        "files_too_large_for_the_workspace": [
+          {
+            "occupation": "Recreation Workers",
+            "path": "reference_files/21f10d79c065e77a3e36c952a0c3b3b8/Recreare Parks & Recreation Summer Fun Facilities.docx",
+            "rendered_characters": 2615,
+            "size_bytes": 2315023,
+            "task_id": "01d7e53e-0513-4109-a242-8ccaf442cd21"
+          },
+          {
+            "occupation": "Real Estate Sales Agents",
+            "path": "reference_files/1e15759c2909d91e9cd6024813a1a1f7/Massabama active listings.xlsx",
+            "rendered_characters": 1973,
+            "size_bytes": 14509694,
+            "task_id": "11593a50-734d-4449-b5b4-f8986a133fd8"
+          },
+          {
+            "occupation": "Audio and Video Technicians",
+            "path": "reference_files/028fb83486152124cfecf2667c3cef37/DRUM REFERENCE TRACK.wav",
+            "rendered_characters": 139,
+            "size_bytes": 33554432,
+            "task_id": "38889c3b-e3d4-49c8-816a-3cc8e5313aba"
+          },
+          {
+            "occupation": "Editors",
+            "path": "reference_files/1389fc5af6430c02dd7bd93c7ce05cc7/Boilerplate.docx",
+            "rendered_characters": 2456,
+            "size_bytes": 2898134,
+            "task_id": "3a4c347c-4aec-43c7-9a54-eb1f816ab1f9"
+          },
+          {
+            "occupation": "Project Management Specialists",
+            "path": "reference_files/ca6c768fe272f61c00d001c884c42237/INPUT 4 BridgeMind AI POC deployment PROJECT LOG.docx",
+            "rendered_characters": 8794,
+            "size_bytes": 1398074,
+            "task_id": "3c19c6d1-672c-467a-8437-6fe21afb8eae"
+          },
+          {
+            "occupation": "First-Line Supervisors of Retail Sales Workers",
+            "path": "reference_files/2c0a245a7c98c858b2ae975c7bbab3b6/ORDER LIST.pdf",
+            "rendered_characters": 0,
+            "size_bytes": 6984257,
+            "task_id": "45c6237b-f9c9-4526-9a8d-6a5c404624ec"
+          },
+          {
+            "occupation": "Financial and Investment Analysts",
+            "path": "reference_files/40407caad9b871b09e3a075bdd971b15/Research Material.docx",
+            "rendered_characters": 105,
+            "size_bytes": 2799328,
+            "task_id": "46b34f78-6c06-4416-87e2-77b6d8b20ce9"
+          },
+          {
+            "occupation": "Audio and Video Technicians",
+            "path": "reference_files/10844d4ba6b1f18120245109db76f403/State of Affairs_STEM_DRUMS.wav",
+            "rendered_characters": 146,
+            "size_bytes": 58752102,
+            "task_id": "4b894ae3-1f23-4560-b13d-07ed1132074e"
+          },
+          {
+            "occupation": "Audio and Video Technicians",
+            "path": "reference_files/2adacf89b84661aadd0c80d91a81fb73/State of Affairs_ROUGHMIX.wav",
+            "rendered_characters": 144,
+            "size_bytes": 58752102,
+            "task_id": "4b894ae3-1f23-4560-b13d-07ed1132074e"
+          },
+          {
+            "occupation": "Audio and Video Technicians",
+            "path": "reference_files/88944520f1ce15927dd5a6a08d3ee9b2/State of Affairs_STEM_ORGAN.wav",
+            "rendered_characters": 146,
+            "size_bytes": 58752102,
+            "task_id": "4b894ae3-1f23-4560-b13d-07ed1132074e"
+          },
+          {
+            "occupation": "Audio and Video Technicians",
+            "path": "reference_files/073946a18125717bdad58178466039fd/State of Affairs_STEM_BASS.wav",
+            "rendered_characters": 145,
+            "size_bytes": 33554432,
+            "task_id": "4b894ae3-1f23-4560-b13d-07ed1132074e"
+          },
+          {
+            "occupation": "Audio and Video Technicians",
+            "path": "reference_files/48836e54ef271e8fd1a301d3e20ea470/State of Affairs_STEM_ACGTRS.wav",
+            "rendered_characters": 147,
+            "size_bytes": 33554432,
+            "task_id": "4b894ae3-1f23-4560-b13d-07ed1132074e"
+          },
+          {
+            "occupation": "First-Line Supervisors of Office and Administrative Support Workers",
+            "path": "reference_files/6940c7b0ba1ffdcbce4266eba053a9e4/Floor Layout for Interviews.png",
+            "rendered_characters": 63,
+            "size_bytes": 1675294,
+            "task_id": "4d1a8410-e9c5-4be5-ab43-cc55563c594c"
+          },
+          {
+            "occupation": "Private Detectives and Investigators",
+            "path": "reference_files/74e9b9b1de3156972930ebb7d4d5321a/Photographs.zip",
+            "rendered_characters": 36,
+            "size_bytes": 9507893,
+            "task_id": "57b2cdf2-ad62-4591-aa91-aad489740320"
+          },
+          {
+            "occupation": "News Analysts, Reporters, and Journalists",
+            "path": "reference_files/c575a5476fac2f921cfd192ca5c48622/TRAPPIST-1 Reporter Draft.docx",
+            "rendered_characters": 4446,
+            "size_bytes": 1913096,
+            "task_id": "5d0feb24-e8b6-4ace-b64f-d5cd1a8b563d"
+          },
+          {
+            "occupation": "Film and Video Editors",
+            "path": "reference_files/04fe2846f45b476d5231b53beeae767a/reel footage.zip",
+            "rendered_characters": 39,
+            "size_bytes": 333716426,
+            "task_id": "75401f7c-396d-406d-b08e-938874ad1045"
+          },
+          {
+            "occupation": "Film and Video Editors",
+            "path": "reference_files/9f47a167476d2ff6ecc485f97e8341c9/action-energetic-rock-music-334316.mp3",
+            "rendered_characters": 145,
+            "size_bytes": 5302229,
+            "task_id": "75401f7c-396d-406d-b08e-938874ad1045"
+          },
+          {
+            "occupation": "Private Detectives and Investigators",
+            "path": "reference_files/f4c7bfae38d21c8ad4f4b624d194aab4/Photographs.zip",
+            "rendered_characters": 36,
+            "size_bytes": 4415094,
+            "task_id": "a46d5cd2-55fe-48fa-a4c6-6aaf6b9991b5"
+          },
+          {
+            "occupation": "Film and Video Editors",
+            "path": "reference_files/67469cf2a7509f149c095cf4f6542f6d/TWT_A001_03.mp4",
+            "rendered_characters": 129,
+            "size_bytes": 689061330,
+            "task_id": "a941b6d8-4289-4500-b45a-f8e4fc94a724"
+          },
+          {
+            "occupation": "Film and Video Editors",
+            "path": "reference_files/d88a33c7e63981a67e899cc8c1347ece/TWT_001_02.mp4",
+            "rendered_characters": 127,
+            "size_bytes": 230703477,
+            "task_id": "a941b6d8-4289-4500-b45a-f8e4fc94a724"
+          },
+          {
+            "occupation": "Pharmacists",
+            "path": "reference_files/8860a54103b6edb9313d04c0f4434980/what are these.jpg",
+            "rendered_characters": 49,
+            "size_bytes": 1800970,
+            "task_id": "f2986c1f-2bbf-4b83-bc93-624a9d617f45"
+          },
+          {
+            "occupation": "Audio and Video Technicians",
+            "path": "reference_files/ca53448cbec7b57b575d9d0e229f08c4/TAVARUA_MUSIC ONLY.wav",
+            "rendered_characters": 137,
+            "size_bytes": 32140902,
+            "task_id": "ff85ee58-bc9f-4aa2-806d-87edeabb1b81"
+          },
+          {
+            "occupation": "Audio and Video Technicians",
+            "path": "reference_files/758a72de9d221d7aa2707e554c20459d/TAVARUA_SAX RAW.wav",
+            "rendered_characters": 133,
+            "size_bytes": 22031470,
+            "task_id": "ff85ee58-bc9f-4aa2-806d-87edeabb1b81"
+          },
+          {
+            "occupation": "Audio and Video Technicians",
+            "path": "reference_files/7b740f4720fe70f8b445fd059e1912f5/TAVARUA_SAX REFERENCE MP3.mp3",
+            "rendered_characters": 135,
+            "size_bytes": 1094950,
+            "task_id": "ff85ee58-bc9f-4aa2-806d-87edeabb1b81"
+          }
+        ],
         "tasks": 220,
+        "tasks_affected_by_the_workspace_limit": 16,
         "tasks_naming_reference_files": 125
       },
       "trial_30": {
         "files_named": 21,
         "files_that_cannot_be_delivered": [],
+        "files_too_large_for_the_workspace": [
+          {
+            "occupation": "Recreation Workers",
+            "path": "reference_files/21f10d79c065e77a3e36c952a0c3b3b8/Recreare Parks & Recreation Summer Fun Facilities.docx",
+            "rendered_characters": 2615,
+            "size_bytes": 2315023,
+            "task_id": "01d7e53e-0513-4109-a242-8ccaf442cd21"
+          },
+          {
+            "occupation": "Audio and Video Technicians",
+            "path": "reference_files/028fb83486152124cfecf2667c3cef37/DRUM REFERENCE TRACK.wav",
+            "rendered_characters": 139,
+            "size_bytes": 33554432,
+            "task_id": "38889c3b-e3d4-49c8-816a-3cc8e5313aba"
+          },
+          {
+            "occupation": "Editors",
+            "path": "reference_files/1389fc5af6430c02dd7bd93c7ce05cc7/Boilerplate.docx",
+            "rendered_characters": 2456,
+            "size_bytes": 2898134,
+            "task_id": "3a4c347c-4aec-43c7-9a54-eb1f816ab1f9"
+          }
+        ],
         "tasks": 30,
+        "tasks_affected_by_the_workspace_limit": 3,
         "tasks_naming_reference_files": 14
       }
     },
     "staged_into": "inputs/ inside each task's own workspace, one workspace per attempt, copied from the same revision the prompt text comes from",
-    "what_a_failure_there_does_not_show": "a task that ran without a file it named is not evidence about the model. It is recorded with the missing file's name so the two cannot be read as one"
+    "text_renderings": {
+      "how_to_check_this": "core.agentic_v2_reference_staging.stage_task_reference_files with render_text=True, and the per-file outcomes it records",
+      "never_a_replacement": "the original stays where it is whenever it can be staged, and a rendering is never presented as the file. Layout, images, styling and anything a picture carries are lost, and a long one is cut to fit the workspace limit and says so at the cut",
+      "this_is_a_difference_from_the_codex_run": "A's model has a real shell and opens these files itself. A V2 result on a task whose work needed what a rendering loses is not comparable to A's result on the same task, and this is the record that says so before either is run",
+      "what_they_are": "a text extraction made by core.file_reader and staged beside the file it came from, under inputs/extracted/. All 261 files extract without error; what comes out is text for spreadsheets, PDFs and documents, and a one-line label for images, recordings and archives"
+    },
+    "what_a_failure_there_does_not_show": "a task that ran without a file it named is not evidence about the model. It is recorded with the missing file's name so the two cannot be read as one. Nor is a task that was handed files it could not open: that one is recorded separately again, because a task holding only unreadable files has nothing refused and would otherwise be indistinguishable from a task given everything",
+    "what_the_model_can_open_by_itself": {
+      "files_named_by_the_tasks": 261,
+      "files_that_decode_as_utf8": 3,
+      "how_that_was_measured": "every one of them decoded as UTF-8 against the pinned revision, which is what workspace_apply(read) does. Two CAD .STEP files and one .txt succeed; the other 258 do not",
+      "why_it_matters": "with exec_run shut there is no shell, no pandas and no PDF library, so a read is the only way in. A model that cannot open its inputs and writes from the prompt alone produces a result that looks exactly like a model that did the work badly"
+    }
   },
   "manifest": {
     "catalog_sha256": "5f1eca853979b2b4efe6c6ba656545c3a416da920e3faf067d52f5d8ac4ae0eb",
@@ -463,7 +674,7 @@
       "task_wording_comes_from": "the pinned dataset revision in `manifest`"
     },
     "read_from": "batch-runner/experiments/execution_envelope/agentic_stage_one_plan.yaml",
-    "read_from_sha256": "c213a96e7e0353b6b29d905a6b5d6b221d93654475ab6ce6436e5c7eeb268e46",
+    "read_from_sha256": "7b0fc8ab0573853adbae491490c01e97fbe506f4952de0509e8d0d6c1396d7ce",
     "retry": {
       "kinds_recorded_separately": [
         "infrastructure",
@@ -496,7 +707,7 @@
     },
     "what_stops_a_task": "any per-task ceiling above, or the per-task budget, whichever comes first. A task stopped by a ceiling is recorded as stopped by that ceiling and is not a model failure"
   },
-  "seal": "3f42a0f3ed673e07fbfc4d915032ba1bddbd610ba6d13e6f2f0e7b745c3d997e",
+  "seal": "0b557a3e0278afba2b2c11bdbd9fb6eb78dfc11b9e1b2b6c5023d266a472c9c8",
   "stop_rules": [
     "the deployment or model reported back differs from the pinned one",
     "a run switches model or deployment on its own",


### PR DESCRIPTION
## What this is

Two defects that would have destroyed a paid 220-task run, found and fixed with
no model called and nothing spent.

Both are environment faults. Neither is a model failure, and both would have
been *recorded* as model failures.

### 1. A task that names no reference files got no input guide

The standing instruction tells the model to open `inputs/INPUTS.md` first. The
guide was only written for tasks that named reference files.

**95 of the 220 tasks name none.** For those, the model's first instructed
action came back `ok: False` — and `dispatch_one` ends a task on the first
failed tool call, with no error shown to the model and no second attempt. The
task dies on turn one and the record says `tool_desk_broke`.

The guide is now unconditional. A task with no files gets a guide saying so.

### 2. A task that *did* have staged inputs finished, and was then thrown away

The model read its inputs, wrote its deliverable, committed an answer — and
`verify_agentic_v2_result` discarded the whole thing with `agentic v2 initial
fixture state mismatch`. Recorded as `runner_internal_error`, no files kept.

Two independent causes:

- **The replay modelled every workspace as starting empty.** There was no way to
  say otherwise, so a backend with files in it could never agree with it. Fixed
  with an `initial_workspace` declaration in the `started` event, carrying
  digests, sizes and whether each file decodes — never bytes, because the inputs
  run to hundreds of megabytes and a trace is not a file store.
- **The modes disagreed.** The replay models directories as `0o700` and files as
  `0o600`. `Path.mkdir(mode=..., parents=True)` applies its mode to the last
  component only, and `mkdir(exist_ok=True)` ignores it entirely for a directory
  somebody else already made — and reference-file staging creates `work/` before
  the backend is built. Fixed with `os.fchmod` through the already-verified root
  descriptor, and a `_make_directory_0700` helper that walks the chain.

A record written before the declaration existed still verifies: the field is
emitted only when the workspace has something in it.

### 3. Five successful tasks printed as `failed`

`row.get("success")` read a key report rows have never carried. Display only,
but it would have made a good run look like a bad one.

## Two real source defects the new tests found

- `_valid_initial_workspace` let `canonical_relative_path`'s `ValueError` escape.
  A predicate leaking an exception turns "this record is invalid", which the
  chain knows how to report, into an unhandled error partway up the verifier.
- `_learn_staged_bytes` compared a read limit against the length of what the read
  returned — a number against itself, so the check could never fire. It now
  compares against the declared size.

## How this was found for $0

A rehearsal voice: a scripted stand-in in the slot the Azure model occupies,
with everything else real — real workspace, real staged bytes, real verifier.
It works a task in four calls (read the guide, list the workspace, write a file,
finalize) and reports which of the four actually worked.

```
finished       5 of 5
guide readable 5 of 5 tasks
wrote a file   5 of 5
spent          nothing — no model was asked
```

Five deliverables collected to disk, one quoting the real staged
`Work Time Study - Source.xlsx` path.

It reports **"no call was made"**, not `$0`. `$0` is a measurement; this is the
absence of one, and the tests hold that wording.

## Registered, not fixed

**One failed tool call ends a task.** Over 220 tasks a single mistyped path
costs the task and everything already spent on it. Changing it changes what a
trace contains, which is a reviewable change of its own — so it goes into the
pre-registration as a known condition of the run, and the seal moves with it.

## Counting, not typing

An earlier draft of these notes said 145 tasks rather than 95. The number was
written into comments by hand and went stale. It is now counted from the task
catalog in a test, so a dataset change makes noise instead of a quiet lie.

## Tests

34 new tests across two files, plus the existing staging and stage-script files.
Nothing here calls a model or spends anything.
