### PR TITLE
인계 구간이 처음부터 통과할 수 없었습니다 — 검증 단계에 코덱스 게이트 변수 추가

### DIFF
--- a/.github/workflows/batch-run.yml
+++ b/.github/workflows/batch-run.yml
@@ -915,8 +915,9 @@ jobs:
 
       # Reaches `_require_runnable_execution_mode` exactly as step2a does, and
       # so needs the same gate variable. It ran without one until run
-      # 34596408490: leg 1 reached 45 of 220 and uploaded its checkpoint
-      # cleanly, and four minutes later leg 2 died here, before touching it.
+      # 34596408490: leg 0 (run 34571840967) reached 45 of 220 and uploaded
+      # its checkpoint cleanly, and four minutes later leg 1 died here, before
+      # touching it.
       # The defect is invisible on leg 0 because this step only runs on a
       # handover -- so a relay that needs no handover passes, and every relay
       # long enough to need one could never have completed.

--- a/.github/workflows/batch-run.yml
+++ b/.github/workflows/batch-run.yml
@@ -913,10 +913,18 @@ jobs:
           cd batch-runner
           bash step1_prepare_tasks.sh "experiments/${EXPERIMENT_YAML_INPUT}.yaml"
 
+      # Reaches `_require_runnable_execution_mode` exactly as step2a does, and
+      # so needs the same gate variable. It ran without one until run
+      # 34596408490: leg 1 reached 45 of 220 and uploaded its checkpoint
+      # cleanly, and four minutes later leg 2 died here, before touching it.
+      # The defect is invisible on leg 0 because this step only runs on a
+      # handover -- so a relay that needs no handover passes, and every relay
+      # long enough to need one could never have completed.
       - name: 'Validate restored checkpoint identity'
         if: inputs.relay_run > 0
         env:
           GDPVAL_RELAY_LINEAGE_ID: ${{ inputs.relay_lineage_id }}
+          CODEX_FOUNDRY_CONNECTION_CONFIRMED: ${{ steps.read_config.outputs.uses_codex_foundry == 'true' && needs.inspect-mode.outputs.codex_confirmed == 'true' && '1' || '' }}
           AZURE_AI_ROUTE_PROFILE: ${{ steps.read_config.outputs.uses_code_interpreter == 'true' && 'project-ci' || 'direct-v1' }}
           FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.FOUNDRY_PROJECT_ENDPOINT }}
           AZURE_AI_REQUIRE_EXPECTED_IDENTITIES: '1'

--- a/batch-runner/experiments/exp035_codex_foundry_full220.yaml
+++ b/batch-runner/experiments/exp035_codex_foundry_full220.yaml
@@ -169,18 +169,31 @@
 # started by hand. That is the honest bound, written here so that a stall
 # reads as this arithmetic rather than as a fault.
 #
-# One thing the relay does not have
-# ---------------------------------
+# One thing the relay was said not to have, and does
+# -------------------------------------------------
 #
-# There is no no-progress guard. A leg that completes zero tasks still
-# dispatches the next one, and the chain stops only when `relay_run` exceeds
-# `relay_max_runs`. Eleven legs of a deployment refusing everything would
-# spend eleven watchdogs finding that out.
+# This header previously stated that there is no no-progress guard, that a leg
+# completing zero tasks still dispatches the next one, and that eleven legs of
+# a deployment refusing everything would spend eleven watchdogs finding that
+# out. That is wrong, and it is corrected here rather than deleted, because a
+# run planned against it would have been watched by hand for something the
+# workflow already refuses.
 #
-# This is stated rather than fixed, because fixing it means editing
-# `.github/workflows/batch-run.yml`, which is shared and frozen while this
-# stage is in flight. The run is watched instead: if a leg lands with no task
-# advanced, it is stopped by hand rather than by the workflow.
+# `_refuse_a_leg_that_finished_nothing` in `scripts/relay_checkpoint.py` runs
+# on the step that publishes `needs_relay`. It compares the pending count on
+# exit against the count written on entry and raises unless the leg strictly
+# reduced it:
+#
+#   relay leg finished no task: N pending on entry, N pending on exit
+#
+# So the cost of a deployment that refuses everything is one leg, not eleven,
+# and the chain stops red rather than quietly. Leg zero is covered too: with
+# no entry counter on disk the count defaults to the full task set, so a first
+# leg that finished nothing fails the same comparison.
+#
+# What the guard does not cover is a leg that finishes exactly one task, which
+# still reads as progress. Eleven legs at one task each is a possible shape and
+# nothing here stops it; that remains a thing to watch.
 #
 # Resume stays off, for exp034's two reasons
 # ------------------------------------------
@@ -565,9 +578,10 @@ execution:
   # the 290-minute watchdog: 53.2 hours against the 22.8 that exp034's
   # measured rate predicts for 220 tasks. Ten is the ceiling — the workflow's
   # config read refuses anything outside 0..10. This cannot change a result —
-  # a leg picks up the same task list where the last one left it. Note that
-  # the workflow has no no-progress guard, so this number is also the cost of
-  # a deployment that refuses everything.
+  # a leg picks up the same task list where the last one left it. It is not
+  # the cost of a deployment that refuses everything: a leg that completes no
+  # task is refused by `_refuse_a_leg_that_finished_nothing` before it can
+  # dispatch the next one, so that case costs one leg. See the header.
   #
   # Writing this key at all means the dispatch must not pass wall_timeout=0:
   # with the watchdog off nothing ends a leg early enough to hand over, and

--- a/batch-runner/tests/test_a_batch_dispatch_can_open_the_codex_gate.py
+++ b/batch-runner/tests/test_a_batch_dispatch_can_open_the_codex_gate.py
@@ -346,12 +346,13 @@ def test_the_step_that_only_runs_on_a_handover_carries_it_too(workflow):
     ``Validate restored checkpoint identity`` is guarded by ``relay_run > 0``,
     so a run short enough to finish in one leg never executes it and a suite
     that only ever watched leg 0 never saw it. Run ``34596408490`` is what it
-    costs: leg 1 of the 220 reached 45 tasks over five hours and uploaded its
-    checkpoint, and leg 2 raised ``codex_foundry has not been shown to reach
-    its Foundry deployment`` four minutes later, before reading a byte of it.
-    Every retry fails identically, so that lineage cannot be resumed at all.
+    costs: leg 0 (run ``34571840967``) reached 45 tasks over five hours and
+    uploaded its checkpoint, and leg 1 raised ``codex_foundry has not been
+    shown to reach its Foundry deployment`` four minutes later, before reading
+    a byte of it. Every retry fails identically, so that lineage cannot be
+    resumed at all.
 
-    At leg 1's rate -- 45 tasks in 301 minutes -- 220 tasks need roughly five
+    At leg 0's rate -- 45 tasks in 301 minutes -- 220 tasks need roughly five
     legs. This step is therefore not on the path of a long run as an extra
     check on it; it is on the only path a long run has.
     """

--- a/batch-runner/tests/test_a_batch_dispatch_can_open_the_codex_gate.py
+++ b/batch-runner/tests/test_a_batch_dispatch_can_open_the_codex_gate.py
@@ -24,7 +24,10 @@ job with no checkout, no credentials and ``exit 1``.
 is false in two unrelated situations -- the box was ticked, and the
 credential-free parser did not think this was a Codex experiment at all. Only
 one of those means somebody decided. Keying the variable off the second would
-set it with nobody having ticked anything.
+set it with nobody having ticked anything. Checked for every step that starts
+the entrypoint, not for the one that was thought of first: naming ``step2a``
+alone is how the checkpoint validation shipped without the variable and stayed
+green, and the first run long enough to need a handover died on it.
 
 **Every relay leg carries it.** The relay forwards inputs one at a time by
 name, so an input that is added and not forwarded is a run that spends on leg 0
@@ -73,6 +76,27 @@ def _named_step(workflow, name):
         if step.get("name") == name:
             return step
     raise AssertionError(f"no step named {name!r} in the batch-run job")
+
+
+def _steps_that_reach_the_gate(workflow):
+    """Every step whose shell starts the entrypoint that holds the gate.
+
+    Enumerated rather than listed by name, because the omission this checks
+    for is precisely an author adding a place that runs it and not knowing
+    there was a variable to carry. Both spellings count: ``step2a`` goes
+    through ``step2_run_inference.sh``, which is four lines ending in
+    ``python3 step2_run_inference.py``, and the checkpoint validation calls the
+    module directly.
+
+    Matching on the ``run`` body is safe here because YAML comments are gone by
+    the time this sees the document -- the long note above step2a's variable
+    names the module and is not a call.
+    """
+    return [
+        step
+        for step in _batch_steps(workflow)
+        if re.search(r"step2_run_inference\.(py|sh)\b", str(step.get("run", "")))
+    ]
 
 
 def _mode_script(workflow):
@@ -287,16 +311,25 @@ def test_the_variable_is_set_from_the_box_and_never_from_the_block(workflow):
     the expression reads ``codex_confirmed``. If the two parsers ever disagree,
     this stays empty -- and empty is what
     ``_require_runnable_execution_mode`` refuses on.
+
+    Asserted over every step that starts the entrypoint rather than over
+    ``step2a`` alone. Pinning one step by name is what let the checkpoint
+    validation ship without the variable for as long as it did: the assertion
+    passed, because the step it named was correct.
     """
-    step2a = next(
-        step for step in _batch_steps(workflow) if step.get("id") == "step2a"
-    )
-    expression = step2a["env"]["CODEX_FOUNDRY_CONNECTION_CONFIRMED"]
-    assert expression == (
-        "${{ steps.read_config.outputs.uses_codex_foundry == 'true' && "
-        "needs.inspect-mode.outputs.codex_confirmed == 'true' && '1' || '' }}"
-    )
-    assert "codex_blocked" not in expression
+    reaching = _steps_that_reach_the_gate(workflow)
+    assert len(reaching) >= 2, [step.get("name") for step in reaching]
+    for step in reaching:
+        where = step.get("name") or step.get("id")
+        expression = (step.get("env") or {}).get(
+            "CODEX_FOUNDRY_CONNECTION_CONFIRMED"
+        )
+        assert expression is not None, f"{where} can reach the gate and cannot open it"
+        assert expression == (
+            "${{ steps.read_config.outputs.uses_codex_foundry == 'true' && "
+            "needs.inspect-mode.outputs.codex_confirmed == 'true' && '1' || '' }}"
+        ), where
+        assert "codex_blocked" not in expression, where
     # '1' is not decoration: the reader compares against exactly that.
     source = (ROOT / "batch-runner" / "step2_run_inference.py").read_text(
         encoding="utf-8"
@@ -305,6 +338,51 @@ def test_the_variable_is_set_from_the_box_and_never_from_the_block(workflow):
         'os.getenv("CODEX_FOUNDRY_CONNECTION_CONFIRMED", "").strip() == "1"'
         in source
     )
+
+
+def test_the_step_that_only_runs_on_a_handover_carries_it_too(workflow):
+    """The omission above, named, because a generic assertion cannot explain it.
+
+    ``Validate restored checkpoint identity`` is guarded by ``relay_run > 0``,
+    so a run short enough to finish in one leg never executes it and a suite
+    that only ever watched leg 0 never saw it. Run ``34596408490`` is what it
+    costs: leg 1 of the 220 reached 45 tasks over five hours and uploaded its
+    checkpoint, and leg 2 raised ``codex_foundry has not been shown to reach
+    its Foundry deployment`` four minutes later, before reading a byte of it.
+    Every retry fails identically, so that lineage cannot be resumed at all.
+
+    At leg 1's rate -- 45 tasks in 301 minutes -- 220 tasks need roughly five
+    legs. This step is therefore not on the path of a long run as an extra
+    check on it; it is on the only path a long run has.
+    """
+    step = _named_step(workflow, "Validate restored checkpoint identity")
+    assert step["if"] == "inputs.relay_run > 0"
+    assert step in _steps_that_reach_the_gate(workflow)
+    assert "--validate-checkpoint-only" in step["run"]
+    assert "CODEX_FOUNDRY_CONNECTION_CONFIRMED" in step["env"]
+    # It validates; it must not also run. A gate variable on a step that spends
+    # is a different risk from one on a step that only reads.
+    assert "--wall-timeout" not in step["run"]
+
+
+def test_validating_a_checkpoint_goes_through_the_same_refusal_as_running_one(
+    workflow,
+):
+    """Why the variable is needed there at all, checked in the code not the YAML.
+
+    ``validate_restored_checkpoint`` is documented as running "without
+    constructing a model client", which reads like a step that could not
+    possibly need permission to spend. It calls the same guard the spending
+    path calls, one line in. That is deliberate -- a leg that may not run
+    should not be told its checkpoint is fine either -- and it is the reason
+    the env block cannot be trimmed to what the step appears to touch.
+    """
+    source = (ROOT / "batch-runner" / "step2_run_inference.py").read_text(
+        encoding="utf-8"
+    )
+    body = source.split("def validate_restored_checkpoint", 1)[1]
+    body = body.split("\ndef ", 1)[0]
+    assert "_require_runnable_execution_mode(execution_mode)" in body
 
 
 def test_the_config_parser_publishes_the_mode_the_expression_reads(workflow):

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/ai-work/copilot/gdpval-realworks/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/ai-work/copilot/gdpval-realworks/node_modules


### PR DESCRIPTION
## 한 줄로

220문제 릴레이는 **첫 인계에서 반드시 죽습니다.** 인계 구간에만 도는 검증 단계 하나가 코덱스 게이트 변수를 받지 못했습니다.

## 근거 (실행 로그 그대로)

실행 `34571840967`(**leg 0**, 로그에 `RELAY_RUN: 0`)은 정상 종료했습니다 — 45/220 처리, 175 대기, 체크포인트 `79310ab6fd04`을 11:56:04Z에 업로드. 4분 뒤 `34596408490`(**leg 1**, 첫 인계)이 **체크포인트를 읽기도 전에** 죽었습니다.

```
ValueError: codex_foundry has not been shown to reach its Foundry
deployment; run the connection check first and set
CODEX_FOUNDRY_CONNECTION_CONFIRMED=1 once a request has been answered.
```

같은 실행에서 `reject-unconfirmed-codex`는 skipped였고 job 레벨 `CODEX_FOUNDRY_CONFIRMED_INPUT`은 `true`였습니다. **허가는 job까지 도착했고, 이 한 단계까지만 오지 않았습니다.**

`Validate restored checkpoint identity`는 `step2_run_inference.py --validate-checkpoint-only`를 직접 부릅니다. 그 함수는 "모델 클라이언트를 만들지 않는다"고 문서에 적혀 있지만, 첫 줄에서 돈 쓰는 경로와 같은 `_require_runnable_execution_mode`를 부릅니다. 의도된 설계입니다 — 돌 수 없는 구간에게 "체크포인트 괜찮다"고 답해줄 이유가 없으니까요. 그래서 env 블록을 "이 단계가 만지는 것"으로 줄일 수 없습니다.

## 왜 지금까지 초록이었나

이 단계는 `if: inputs.relay_run > 0`이라 **leg 0에서는 아예 실행되지 않습니다.** (이 저장소는 수동 발사를 leg 0이라 부릅니다 — 입력 설명 세 곳이 "leave empty on leg 0".) 한 구간에 끝나는 실험은 전부 통과하고, 인계가 필요할 만큼 긴 실험만 실패합니다. exp033(5문제)·exp034(30문제)가 통과한 이유와 220이 처음 부딪힌 이유가 같은 사실입니다.

leg 0 속도(301분에 45문제)로 220을 채우려면 약 5개 구간, 인계 4번이 필요합니다. 이 수정은 긴 실행을 개선하는 게 아니라 **긴 실행이 끝날 수 있는 유일한 경로**입니다.

## 무엇을 잃고 무엇을 남기나

**그 계보는 못 살립니다.** 재시도해도 같은 자리에서 같게 죽습니다. 이 PR이 살릴 수 있는 작업을 버리는 게 아니라, 앞으로의 실행을 가능하게 합니다.

leg 0의 45문제 성적은 부분 실행으로 보존합니다: 성공 30 / 실패 15(요금 거절 4회 소진 10, `content_filter` 5). **`content_filter`는 정상 벤치마크 실패로 그대로 둡니다.**

## 검사

`step2a`를 이름으로 집던 단언을 **진입점을 실행하는 모든 단계**를 훑도록 일반화했습니다. 한 곳만 지목한 단언은 지목한 곳이 옳았기 때문에 계속 통과했고, 그게 이 결함이 살아남은 방식입니다.

- `test_the_variable_is_set_from_the_box_and_never_from_the_block` — `.py`/`.sh` 양쪽 철자를 훑어 표현식까지 대조
- `test_the_step_that_only_runs_on_a_handover_carries_it_too` — 실행 번호와 5구간 산술을 함께 고정
- `test_validating_a_checkpoint_goes_through_the_same_refusal_as_running_one` — YAML이 아니라 코드에서 확인

**변이 검증:** 워크플로 한 줄을 되돌리면 새 단언 2개가 정확히 빨개지는 것을 확인하고 복원했습니다.

## exp035 헤더 정정

같은 파일 헤더가 "무진척 가드가 없다"고 적어두었는데 **틀렸습니다.** `scripts/relay_checkpoint.py:429`의 `_refuse_a_leg_that_finished_nothing`이 `needs_relay`를 내보내는 단계에서 진입/종료 대기 수를 비교해 줄지 않았으면 거절합니다. 0구간도 덮습니다. 따라서 "전부 거절하는 배포"의 비용은 11구간이 아니라 1구간입니다. 지우지 않고 정정으로 남깁니다. 가드가 못 잡는 것도 적어뒀습니다: 한 문제만 끝낸 구간은 진척으로 읽힙니다.

## 병합 후

exp035를 **0구간부터 새 실행으로** 띄웁니다. `34571840967`은 재개 경로 결함으로 멈춘 부분 실행으로 별도 보존하며 지우지 않습니다.
