### PR TITLE
실행이 말하지 못한 금액을 토큰에서 되살립니다 — exp034 derived_cost.json

### DIFF
--- a/batch-runner/results/exp034_codex_foundry_trial30/report/derived_cost.json
+++ b/batch-runner/results/exp034_codex_foundry_trial30/report/derived_cost.json
@@ -1,0 +1,254 @@
+{
+ "per_task": {
+  "0ed38524-a4ad-405f-9dee-7b2252659aad": {
+   "derived_cost_usd_from_measured_tokens": 0.18461,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 1,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "01d7e53e-0513-4109-a242-8ccaf442cd21": {
+   "derived_cost_usd_from_measured_tokens": 0.439352,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 1,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "0112fc9b-c3b2-4084-8993-5a4abb1f54f1": {
+   "derived_cost_usd_from_measured_tokens": 0.073083,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 1,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "38889c3b-e3d4-49c8-816a-3cc8e5313aba": {
+   "derived_cost_usd_from_measured_tokens": 1.218923,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 2,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "05389f78-589a-473c-a4ae-67c61050bfca": {
+   "derived_cost_usd_from_measured_tokens": 0.411211,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 1,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "02aa1805-c658-4069-8a6a-02dec146063a": {
+   "derived_cost_usd_from_measured_tokens": 0.233196,
+   "derived_cost_basis": "floor_unmeasured_sends_excluded",
+   "derived_cost_calls_measured": 3,
+   "derived_cost_calls_unmeasured": 1,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "0419f1c3-d669-45d0-81cd-f4d5923b06a5": {
+   "derived_cost_usd_from_measured_tokens": 0.246824,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 1,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "105f8ad0-8dd2-422f-9e88-2be5fbd2b215": {
+   "derived_cost_usd_from_measured_tokens": 0.38923,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 4,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "02314fc6-a24e-42f4-a8cd-362cae0f0ec1": {
+   "derived_cost_usd_from_measured_tokens": 0.269366,
+   "derived_cost_basis": "floor_unmeasured_sends_excluded",
+   "derived_cost_calls_measured": 1,
+   "derived_cost_calls_unmeasured": 1,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "1d4672c8-b0a7-488f-905f-9ab4e25a19f7": {
+   "derived_cost_usd_from_measured_tokens": 0.44268,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 4,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "11e1b169-5fb6-4d79-8a83-82ddf4987a85": {
+   "derived_cost_usd_from_measured_tokens": 0.017039,
+   "derived_cost_basis": "floor_unmeasured_sends_excluded",
+   "derived_cost_calls_measured": 1,
+   "derived_cost_calls_unmeasured": 1,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "0353ee0c-18b5-4ad3-88e8-e001d223e1d7": {
+   "derived_cost_usd_from_measured_tokens": 0.277395,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 4,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "3a4c347c-4aec-43c7-9a54-eb1f816ab1f9": {
+   "derived_cost_usd_from_measured_tokens": 0.842841,
+   "derived_cost_basis": "floor_unmeasured_sends_excluded",
+   "derived_cost_calls_measured": 3,
+   "derived_cost_calls_unmeasured": 1,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "11dcc268-cb07-4d3a-a184-c6d7a19349bc": {
+   "derived_cost_usd_from_measured_tokens": 0.174782,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 1,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "0e386e32-df20-4d1f-b536-7159bc409ad5": {
+   "derived_cost_usd_from_measured_tokens": 1.482153,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 2,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "0818571f-5ff7-4d39-9d2c-ced5ae44299e": {
+   "derived_cost_usd_from_measured_tokens": 0.130329,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 2,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "1137e2bb-bdf9-4876-b572-f29b7de5e595": {
+   "derived_cost_usd_from_measured_tokens": 0.229261,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 1,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "045aba2e-4093-42aa-ab7f-159cc538278c": {
+   "derived_cost_usd_from_measured_tokens": 0.702712,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 1,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "3600de06-3f71-4e48-9480-e4828c579924": {
+   "derived_cost_usd_from_measured_tokens": 0.614354,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 3,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "17111c03-aac7-45c2-857d-c06d8223d6ad": {
+   "derived_cost_usd_from_measured_tokens": 0.238727,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 1,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "0ec25916-1b5c-4bfe-93d3-4e103d860f3a": {
+   "derived_cost_usd_from_measured_tokens": 0.342715,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 1,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "3baa0009-5a60-4ae8-ae99-4955cb328ff3": {
+   "derived_cost_usd_from_measured_tokens": 0.462574,
+   "derived_cost_basis": "floor_unmeasured_sends_excluded",
+   "derived_cost_calls_measured": 3,
+   "derived_cost_calls_unmeasured": 1,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "15ddd28d-8445-4baa-ac7f-f41372e1344e": {
+   "derived_cost_usd_from_measured_tokens": 0.2029,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 1,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "2c249e0f-4a8c-4f8e-b4f4-6508ba29b34f": {
+   "derived_cost_usd_from_measured_tokens": 0.263572,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 1,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "0e4fe8cd-16d0-4f41-8247-6385b4762582": {
+   "derived_cost_usd_from_measured_tokens": 0.621604,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 4,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "15d37511-75c5-4c7f-81f1-16e00c0d95f3": {
+   "derived_cost_usd_from_measured_tokens": 0.320137,
+   "derived_cost_basis": "floor_unmeasured_sends_excluded",
+   "derived_cost_calls_measured": 1,
+   "derived_cost_calls_unmeasured": 1,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "0fad6023-767b-42c1-a1b3-027cd4f583cb": {
+   "derived_cost_usd_from_measured_tokens": 0.359464,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 1,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "4520f882-715a-482d-8e87-1cb3cbdfe975": {
+   "derived_cost_usd_from_measured_tokens": 0.714599,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 1,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "1bff4551-1d54-4e37-b2e0-d5c3f2ea4a45": {
+   "derived_cost_usd_from_measured_tokens": 0.03883,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 1,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  },
+  "116e791e-890c-42b1-ba90-1db02e8bfd45": {
+   "derived_cost_usd_from_measured_tokens": 0.323801,
+   "derived_cost_basis": "all_calls_measured",
+   "derived_cost_calls_measured": 1,
+   "derived_cost_calls_unmeasured": 0,
+   "derived_cost_is_provider_billed": false,
+   "derived_cost_method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded"
+  }
+ },
+ "method": "core.cost_receipts.price_call over the run ledger cost_calls table, priced with the committed receipt price table (sha256 b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e); the same fingerprint the run itself recorded",
+ "price_table_sha256": "b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e",
+ "calls_total": 59,
+ "calls_measured": 53,
+ "calls_unmeasured": 6,
+ "tasks_with_a_call": 30,
+ "derived_total_usd": 12.268258,
+ "derived_total_is_a_floor": true,
+ "derived_total_is_provider_billed": false,
+ "pricer_refusals": {}
+}


### PR DESCRIPTION
exp034가 실제로 얼마를 썼는지, 실행 자신은 말하지 못합니다. 토큰 수는 진짜이므로 그 토큰에서 금액을 **재구성**해 `derived_cost.json` 한 파일로 남깁니다. 실행이 기록한 금액(없음)과는 끝까지 섞지 않습니다.

## 실행이 금액을 남기지 못한 진짜 이유

exp034의 영수증은 **30개 과제 전부, 44개 항목 전부** `status: "partial"` /
`missing_reasons: ["call_reachability_unknown"]`입니다. 예외 없습니다(전수 확인).

`exp035_codex_foundry_full220.yaml`(~243행)은 그 이유를 **"이 배포가
`model_price_table.json`에 없어서"**라고 적어 두었습니다. **사실이 아닙니다.**
가격표에는 `gpt-5.4`가 있고, `providers/azure:gpt-5.4-2026-03-05` 전용 항목까지
있습니다. 가격표에 줄을 추가해도 `partial`은 그대로입니다.

진짜 이유는 `core/codex_runner.py`의 `_reserve_call`에 이미 적혀 있습니다 —
영수증은 **요청 하나당이 아니라 턴 하나당** 발행됩니다:

> Codex opens however many requests it needs inside a turn and reports only a
> running thread total, so a per-request receipt would be a row we invented.

즉 **하네스가 요청을 하나씩 세어주지 않기 때문**이지, 가격을 몰라서가 아닙니다.
`call_reachability_unknown`은 여기서 "세지 못한 호출까지 덮는 줄"이라는 뜻으로
쓰입니다 — `cost_metering.py`의 미정산 예약이라는 뜻과는 다릅니다.

exp035 YAML은 **지금 도는 220 실행에 물려 있는 고정 설정이라 고치지 않습니다.**
정정은 이 PR과 exp035 보고서, 다음 실험 기록에 남깁니다.

## 이 금액은 직접 손으로 검산했습니다

요약을 다시 읽은 게 아니라 **원자료에서 다시 계산**했습니다.

적용 단가는 `providers/azure:gpt-5.4-2026-03-05`입니다 — 입력 $2.50/M,
**캐시 입력 $0.25/M**, 출력 $15.00/M, `reasoning_billed_as: "output"`.
(`/models/gpt-5.4`의 $1.25/$5.00은 Azure 경유가 아닌 단가라 여기 해당하지
않습니다. 그 단가로는 $13.62가 나옵니다.)

`price_call`이 문서화한 규칙 두 가지를 그대로 따랐습니다 — 캐시 토큰은
`input_tokens`에 **이미 포함**되어 있으므로 차액만 정가로 치고, 추론 토큰은
출력 안에 **이미 포함**되어 있으므로 따로 더하지 않습니다.

| 항목 | 토큰 | 단가 | 금액 |
|---|---:|---:|---:|
| 입력(캐시 제외) | 1,770,789 | $2.50/M | $4.4269725 |
| 캐시 입력 | 7,537,280 | $0.25/M | $1.8843200 |
| 출력(추론 141,341 포함) | 397,131 | $15.00/M | $5.9569650 |
| **합계** | | | **$12.2682575** |

6자리 반올림 → **$12.268258**. 파일의 `derived_total_usd`와 **끝자리까지
일치합니다.**

## 읽는 사람이 알아야 할 두 가지

**1) 이 금액은 바닥값입니다.** 원장 59줄 중 **53줄이 정산됨(settled)**,
**6줄은 예약만 되고 정산되지 않았습니다(reserved)** — 호출을 열어 두고
사용량 보고를 받지 못한 줄이라 계산에서 빠집니다.

줄(row)과 과제(task)는 다른 단위지만, 여기서는 **정산 안 된 6줄이 서로 다른
6개 과제에 하나씩** 걸려 있습니다(6개 과제 모두 `derived_cost_calls_unmeasured: 1`,
합이 최상위 `calls_unmeasured: 6`과 일치 — 직접 확인했습니다). 그래서 그 6개
과제만 `derived_cost_basis: "floor_unmeasured_sends_excluded"`이고, 나머지 24개
과제는 `all_calls_measured`입니다. 전체가 `derived_total_is_a_floor: true`인
이유가 이것이고, 실제 금액은 이보다 큽니다.

덧붙여, **정산된 53줄조차** `call_reachability_unknown`을 달고 있습니다.
위에서 말한 "턴 하나당 한 장"이 바로 이것입니다 — 정산이 됐다고 해서 그 안의
요청 수를 센 것은 아닙니다.

**2) 청구액이 아닙니다.** `derived_total_is_provider_billed: false` —
제공자가 청구한 금액이 아니라 우리가 토큰에서 되살린 금액입니다.
과제별 30줄을 더하면 $12.268264로 **6마이크로달러** 높은데, 이는 줄마다
6자리에서 반올림해서 생기는 차이입니다. 반올림 전에 계산한 `derived_total_usd`가
기준값입니다.

사용한 가격표 지문은 `b01b384c532b1457804e3a77713d2b079b06b363a5ff3b8b939fe65a4cb30b4e`
— **실행 자신이 기록한 것과 같은 지문**입니다. 지금 220 실행이 도는 동안
`model_price_table.json`은 건드리지 않습니다.

## 범위

결과물 파일 **1개 추가**뿐입니다. `batch-runner/` 소스 0줄,
`batch-run.yml` 0줄, 실험 YAML 0줄 — 진행 중인 220 실행에 영향 없습니다.

**비용과 점수는 다른 것입니다.** 이 파일은 얼마를 썼는지만 말하고,
잘했는지는 한 마디도 하지 않습니다.
