### PR TITLE
fix(v2): the six tasks that got nothing reported as fine

### DIFF
--- a/batch-runner/core/agentic_v2_reference_staging.py
+++ b/batch-runner/core/agentic_v2_reference_staging.py
@@ -303,6 +303,28 @@ class TaskStaging:
             return False
         return not any(one.is_readable for one in self.extractions)
 
+    @property
+    def worked_from_the_prompt_alone(self) -> bool:
+        """The task named files and not one readable character reached it.
+
+        A superset of :attr:`could_open_nothing`, and the reason it exists is
+        that the subset reads as reassurance where it is least deserved.
+        ``could_open_nothing`` asks its question of the files that arrived, so a
+        task whose every file was refused has no files to ask about and comes
+        back ``False`` -- the same answer given by a task that got everything
+        and read it fine. Six of the 220 are in exactly that position: every
+        file refused for size, nothing delivered, and the summary saying no.
+
+        True here means the model had the prompt and nothing else, however it
+        got there. That is the whole question a result needs answering, because
+        a thin answer to a task in this state is the environment's, and reading
+        it as the model's would be reading a fault we introduced as a finding
+        about the thing under test.
+        """
+        if not self.named:
+            return False
+        return not any(one.is_readable for one in self.extractions)
+
     def as_dict(self) -> dict[str, Any]:
         return {
             "task_id": self.task_id,
@@ -314,6 +336,7 @@ class TaskStaging:
             "guide": self.guide,
             "everything_arrived": self.everything_arrived,
             "could_open_nothing": self.could_open_nothing,
+            "worked_from_the_prompt_alone": self.worked_from_the_prompt_alone,
         }
 
 
@@ -980,6 +1003,7 @@ def staging_record(stagings: Sequence[TaskStaging]) -> dict[str, Any]:
     needed = [one for one in stagings if one.named]
     short = [one for one in needed if one.ran_without_its_inputs]
     blind = [one for one in needed if one.could_open_nothing]
+    prompt_only = [one for one in needed if one.worked_from_the_prompt_alone]
     reasons: dict[str, int] = {}
     for one in stagings:
         for refusal in one.refused:
@@ -996,6 +1020,7 @@ def staging_record(stagings: Sequence[TaskStaging]) -> dict[str, Any]:
         "tasks_given_everything_they_named": len(needed) - len(short),
         "tasks_that_ran_without_some_input": len(short),
         "tasks_that_could_open_nothing": len(blind),
+        "tasks_that_worked_from_the_prompt_alone": len(prompt_only),
         "files_delivered": sum(len(one.delivered) for one in stagings),
         "bytes_delivered": sum(
             file.size_bytes for one in stagings for file in one.delivered
@@ -1006,7 +1031,11 @@ def staging_record(stagings: Sequence[TaskStaging]) -> dict[str, Any]:
             f"{len(needed) - len(short)} of {len(needed)} tasks that name "
             "reference files were given all of them. "
             f"{len(short)} were not, and each missing file is named below. A "
-            "failure on one of those is not evidence about the model."
+            "failure on one of those is not evidence about the model. "
+            f"{len(prompt_only)} are further along than that: nothing readable "
+            "reached them at all, so whatever they answered was answered from "
+            "the prompt, and grading them against the inputs they never saw "
+            "would be scoring this environment and calling it the model."
         ),
         "what_a_rendering_is": (
             "a text extraction made by core.file_reader, staged beside the file "

--- a/batch-runner/tests/test_agentic_v2_reference_staging.py
+++ b/batch-runner/tests/test_agentic_v2_reference_staging.py
@@ -1071,6 +1071,146 @@ def test_the_record_counts_blind_tasks_and_renderings_by_outcome(
     assert [one["could_open_nothing"] for one in record["tasks"]] == [True, False]
 
 
+def test_a_task_whose_every_file_was_refused_is_not_reported_as_fine(
+    snapshot, tmp_path
+):
+    """The state `could_open_nothing` cannot see, and the one that costs most.
+
+    That field asks its question of the files that arrived. Refuse them all and
+    there is nothing to ask about, so it answers False -- the same False a task
+    gets for receiving everything and reading it fine. The worst case and the
+    best case were printing identically.
+
+    Six of the 220 are here: every named file over the workspace limit, nothing
+    delivered, and a `.wav` or an `.mp4` behind the refusal so the rendering
+    carries a description of the file rather than anything in it.
+    """
+    big = snapshot / "reference_files" / "abc123" / "track.wav"
+    big.write_bytes(b"RIFF" + b"\x00" * 4000)
+
+    result = _render(
+        snapshot, tmp_path, "reference_files/abc123/track.wav", limit=512
+    )
+
+    assert result.delivered == ()
+    assert _reasons(result) == [staging.TOO_LARGE_FOR_THE_WORKSPACE]
+    assert result.could_open_nothing is False
+    assert result.worked_from_the_prompt_alone is True
+
+
+def test_a_task_naming_nothing_did_not_work_from_the_prompt_alone(
+    snapshot, tmp_path
+):
+    """It had no inputs to lose, and marking it would drown the six that did.
+
+    95 of the 220 name no reference files. If those counted here the field
+    would report 101 and mean nothing: the number exists to say whose answer
+    was written without inputs it was promised, and a task promised none was
+    not deprived of anything.
+    """
+    result = _render(snapshot, tmp_path)
+
+    assert result.named == 0
+    assert result.worked_from_the_prompt_alone is False
+
+
+def test_one_readable_rendering_is_enough_to_clear_it(snapshot, tmp_path):
+    """Refused bytes are survivable; refused bytes with no text are not.
+
+    The distinction the field turns on. Both files here are over the limit and
+    neither is delivered, so `everything_arrived` is False for the task either
+    way -- but one of them rendered, and a task holding 2,456 characters of its
+    own contract is not working from the prompt alone.
+    """
+    room = snapshot / "reference_files" / "abc123"
+    (room / "track.wav").write_bytes(b"RIFF" + b"\x00" * 4000)
+    (room / "contract.txt").write_text("the agreed rate " * 100, encoding="utf-8")
+
+    result = _render(
+        snapshot,
+        tmp_path,
+        "reference_files/abc123/track.wav",
+        "reference_files/abc123/contract.txt",
+        limit=512,
+    )
+
+    assert result.delivered == ()
+    assert len(result.refused) == 2
+    assert result.worked_from_the_prompt_alone is False
+
+
+def test_the_record_counts_and_names_the_prompt_alone_tasks(snapshot, tmp_path):
+    """A count to skim and, underneath it, which tasks it was.
+
+    The count alone would be the same mistake this field was added to fix: a
+    reader who cannot get from `2` to the two task ids cannot check whether a
+    weak answer came from a model or from an empty directory.
+    """
+    room = snapshot / "reference_files" / "abc123"
+    (room / "track.wav").write_bytes(b"RIFF" + b"\x00" * 4000)
+    (room / "notes.txt").write_text("readable", encoding="utf-8")
+    starved = _render(
+        snapshot, tmp_path / "a", "reference_files/abc123/track.wav", limit=512
+    )
+    fed = _render(snapshot, tmp_path / "b", "reference_files/abc123/notes.txt")
+
+    record = staging_record([starved, fed])
+
+    assert record["tasks_that_worked_from_the_prompt_alone"] == 1
+    assert [
+        one["worked_from_the_prompt_alone"] for one in record["tasks"]
+    ] == [True, False]
+    assert "answered from the prompt" in record["what_that_means"]
+
+
+def test_the_tasks_no_text_reader_can_ever_serve_are_named_from_the_catalogue():
+    """Seven tasks name audio, video or images and nothing else.
+
+    Not a defect and not fixable by raising a limit: a `.wav` has no text in it
+    at any size, so for these seven the rendering is a description of the file
+    and the model works from the prompt. The 220-task rehearsal found nine
+    tasks with no readable input, and these are seven of them -- the other two
+    are a `.docx` the reader could not open and a `.pdf` with no text layer,
+    which are reader gaps rather than a property of the task.
+
+    Derived here rather than written down, because the honest sentence about
+    this environment depends on it: results for these seven measure what a
+    model does with a prompt and a filename, and pooling them with the other
+    213 makes the environment's ceiling look like the model's.
+
+    Only the extensions are used. How large the files are decides whether their
+    bytes arrive, which is a fact about a run and belongs in its record, not in
+    a test that never opens the dataset.
+    """
+    from core.execution_envelope_tasks import full_run_tasks, load_task_catalog
+
+    unreadable_by_any_text_reader = {
+        ".avi", ".bmp", ".gif", ".heic", ".jpeg", ".jpg", ".m4a", ".mov",
+        ".mp3", ".mp4", ".png", ".tif", ".tiff", ".wav", ".webp", ".zip",
+    }
+    catalog = load_task_catalog()
+    by_id = catalog.by_task_id()
+    named = [
+        by_id[task_id]
+        for task_id in full_run_tasks(catalog)
+        if by_id[task_id].reference_file_count
+    ]
+    media_only = [
+        one
+        for one in named
+        if all(
+            extension.lower() in unreadable_by_any_text_reader
+            for extension in one.reference_file_extensions
+        )
+    ]
+
+    assert len(named) == 125
+    assert len(media_only) == 7
+    assert "38889c3b-e3d4-49c8-816a-3cc8e5313aba" in {
+        one.task_id for one in media_only
+    }
+
+
 def test_the_record_says_what_a_rendering_is_and_is_not(snapshot, tmp_path):
     """A reader of the record must not take an extraction for the file.
 


### PR DESCRIPTION
Nine of the 220 tasks receive no readable input. Six of them were being reported as fine.

## What was wrong

`TaskStaging.could_open_nothing` asks its question of the files that *arrived*. A task whose every file was refused has no arrived files to ask about, so the property returns `False` — the same answer given by a task that received everything and read it all without trouble.

Six tasks are in exactly that position: every reference file refused for size, nothing delivered, summary says no problem.

## What this adds

`worked_from_the_prompt_alone` — true when a task named reference files and not one readable character reached it, however it got there. A superset of `could_open_nothing`, and the distinction matters because a thin answer to a task in this state is the environment's, not the model's. Grading it against inputs it never saw would be scoring this environment and calling it the model.

Surfaced per task in `as_dict()`, counted in the cohort summary as `tasks_that_worked_from_the_prompt_alone`, and named in `what_that_means` so the count is not the only place it appears.

## Measured on the real staged bytes

From a model-free rehearsal over the full cohort (no model call, no spend):

| | |
|---|---|
| tasks | 220 — 125 name reference files, 95 name none |
| reference files | 261 — 237 delivered, 24 refused for size |
| given everything they named | 109 |
| ran without some input | 16 |
| `could_open_nothing` (old field) | 3 |
| `worked_from_the_prompt_alone` (new) | **9** |

The nine split 6 / 3: six had zero bytes arrive, three had files arrive that no reader could open. The old field saw only the three.

Five refused files still render extractable text, and five tasks are carried by that alone — the workspace limit costs raw bytes but never the extraction, because both refusal branches still call `_extract_one` before `continue`. That is why the number is 9 and not 14.

## Tests

Five added:

- a task whose every file was refused is not reported as fine
- a task naming nothing did not work from the prompt alone (95 tasks name nothing; counting them would report 101 and mean nothing)
- one readable rendering is enough to clear it
- the record counts *and names* the prompt-alone tasks
- the tasks no text reader can ever serve are named from the catalogue — 7 of the 125 name only media extensions

Full backend suite: 11158 passed, 18 skipped, 0 failed.

## Not in scope

The nine tasks are a run condition, not a defect to fix here. They need recording in the pre-registration before the paid run so their results are not read as model failure. Seven of them are an environment ceiling (media-only inputs, no text reader can serve them); two are reader gaps (one unopenable `.docx`, one scanned `.pdf`).
