### PR TITLE
fix(v2): the pre-registration said all 261 files open, and two do not

### DIFF
--- a/batch-runner/core/agentic_v2_preregistration.py
+++ b/batch-runner/core/agentic_v2_preregistration.py
@@ -50,6 +50,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import tempfile
+from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence
@@ -67,6 +69,7 @@ from core.agentic_v2_reference_staging import (
     TOO_LARGE,
     TOO_LARGE_FOR_THE_WORKSPACE,
     WORKSPACE_FILE_LIMIT,
+    stage_task_reference_files,
 )
 from core.execution_envelope_tasks import (
     ADVANCE_CHECK_TASK_COUNT,
@@ -739,6 +742,61 @@ OVER_THE_WORKSPACE_FILE_LIMIT: tuple[dict[str, Any], ...] = (
 )
 
 
+#: What the reader actually got out of the 261 named files, by outcome.
+#:
+#: Recorded because the sentence this replaces said all 261 extract without
+#: error, and two of them do not. The difference is small and it is in the
+#: direction that flatters the environment, which is the direction a
+#: pre-registration is written to guard against: a record that overstates what
+#: reached the model turns an input the model never had into an answer the model
+#: got wrong.
+#:
+#: The five that come back empty are not errors and are counted apart from the
+#: two that are. One is a scanned PDF, where the reader opens the file and finds
+#: no text layer in it; that file is no more use to the model for having opened
+#: cleanly. The thirty-two labels are images, recordings and archives, where a
+#: line naming the kind is the honest ceiling of what a text reader can do.
+RENDERING_OUTCOMES: dict[str, int] = {
+    "text_was_read_out_of_it": 221,
+    "text_was_read_out_of_it_and_cut_to_the_workspace_limit": 1,
+    "the_reader_could_not_open_it": 2,
+    "the_reader_describes_this_kind_rather_than_reading_it": 32,
+    "the_reader_found_no_text_in_it": 5,
+}
+
+
+#: The tasks that name reference files and receive not one readable character.
+#:
+#: Nine of the two hundred and twenty, and the count a result has to be read
+#: against, because a thin answer to a task in this state is this environment's
+#: and not the model's. Grading one of them against inputs it never saw would be
+#: scoring a gap we introduced and reporting it as a finding about the model.
+#:
+#: They arrive here two ways and the distinction is worth keeping. Six have
+#: nothing delivered at all -- every file they name refused for size -- and
+#: three are handed a file no reader can open. Only the second three were ever
+#: visible: ``could_open_nothing`` asks its question of the files that arrived,
+#: so a task whose every file was refused has nothing to ask about and answers
+#: no, which is also what a task given everything answers. The six sat in that
+#: gap reporting fine.
+#:
+#: Nought of the five advance-check tasks, one of the thirty, nine of the two
+#: hundred and twenty. Recorded by name rather than by count for the same reason
+#: as the two lists above: a cohort that loses its inputs is indistinguishable
+#: from a model doing the work badly unless the names are written down first.
+TASKS_WORKING_FROM_THE_PROMPT_ALONE: tuple[str, ...] = (
+    "38889c3b-e3d4-49c8-816a-3cc8e5313aba",
+    "46b34f78-6c06-4416-87e2-77b6d8b20ce9",
+    "55ddb773-23a4-454c-8704-d432fe1b99d9",
+    "75401f7c-396d-406d-b08e-938874ad1045",
+    "94925f49-36bc-42da-b45b-61078d329300",
+    "a941b6d8-4289-4500-b45a-f8e4fc94a724",
+    "b9665ca1-4da4-4ff9-86f2-40b9a8683048",
+    "f2986c1f-2bbf-4b83-bc93-624a9d617f45",
+    "ff85ee58-bc9f-4aa2-806d-87edeabb1b81",
+)
+
+
 def input_disposition(catalog: TaskCatalog | None = None) -> dict[str, Any]:
     """What each cohort is given to work from, and what it cannot be given.
 
@@ -790,6 +848,7 @@ def input_disposition(catalog: TaskCatalog | None = None) -> dict[str, Any]:
     over_limit_by_task: dict[str, list[dict[str, Any]]] = {}
     for one in OVER_THE_WORKSPACE_FILE_LIMIT:
         over_limit_by_task.setdefault(str(one["task_id"]), []).append(dict(one))
+    prompt_alone = {str(one) for one in TASKS_WORKING_FROM_THE_PROMPT_ALONE}
 
     per_stage: dict[str, Any] = {}
     for stage in ESCALATION:
@@ -814,6 +873,9 @@ def input_disposition(catalog: TaskCatalog | None = None) -> dict[str, Any]:
             "files_too_large_for_the_workspace": over_limit,
             "tasks_affected_by_the_workspace_limit": len(
                 {str(one["task_id"]) for one in over_limit}
+            ),
+            "tasks_that_worked_from_the_prompt_alone": sorted(
+                {str(one) for one in task_ids} & prompt_alone
             ),
         }
 
@@ -857,9 +919,20 @@ def input_disposition(catalog: TaskCatalog | None = None) -> dict[str, Any]:
             "what_they_are": (
                 "a text extraction made by core.file_reader and staged beside "
                 f"the file it came from, under {MODEL_INPUT_PREFIX}/extracted/. "
-                "All 261 files extract without error; what comes out is text "
-                "for spreadsheets, PDFs and documents, and a one-line label for "
-                "images, recordings and archives"
+                "What comes out is text for spreadsheets, PDFs and documents, "
+                "and a one-line label for images, recordings and archives"
+            ),
+            "what_the_reader_got_out_of_them": dict(RENDERING_OUTCOMES),
+            "not_all_of_them_open": (
+                f"{RENDERING_OUTCOMES['the_reader_could_not_open_it']} of "
+                f"{FILES_NAMED_BY_THE_TASKS} the reader cannot open at all, and "
+                f"{RENDERING_OUTCOMES['the_reader_found_no_text_in_it']} it "
+                "opens and finds no text in -- a scanned PDF among them, which "
+                "is no more use to the model for having opened cleanly. Written "
+                "down because the sentence here used to say all 261 extract "
+                "without error, and a record that overstates what reached the "
+                "model turns an input the model never had into an answer the "
+                "model got wrong"
             ),
             "never_a_replacement": (
                 "the original stays where it is whenever it can be staged, and "
@@ -890,7 +963,12 @@ def input_disposition(catalog: TaskCatalog | None = None) -> dict[str, Any]:
             "cannot be read as one. Nor is a task that was handed files it "
             "could not open: that one is recorded separately again, because a "
             "task holding only unreadable files has nothing refused and would "
-            "otherwise be indistinguishable from a task given everything"
+            "otherwise be indistinguishable from a task given everything. Nor, "
+            "third, is a task whose every file was refused -- it has no "
+            "delivered file to call unreadable either, so it too answered no to "
+            "both questions and read as fine. The three are gathered under "
+            "tasks_that_worked_from_the_prompt_alone, which asks the question "
+            "that actually matters: did one readable character reach it"
         ),
         "how_to_check_this": (
             "core.agentic_v2_preregistration.verify_input_disposition for the "
@@ -1075,6 +1153,81 @@ def verify_reader_reach(
             f"says {FILES_THE_MODEL_COULD_OPEN_UNAIDED}. That figure is what "
             "decides whether a result is about the model, so a record that has "
             "it wrong is worse than none"
+        )
+    return wrong
+
+
+def verify_rendering_reach(
+    snapshot_root: Path, catalog: TaskCatalog | None = None
+) -> list[str]:
+    """Whether the renderings still reach what the record says they reach.
+
+    Apart from :func:`verify_reader_reach` again, and for a sharper reason than
+    tidiness. That one asks what the model can open unaided, which is a property
+    of the bytes. This one asks what our reader got out of them, which is a
+    property of our code -- so a reader upgrade, a dependency bump or a dropped
+    optional import moves this figure without touching a single input file, and
+    moves it silently.
+
+    The direction matters. If the renderings improve, the pre-registration
+    understates what reached the model and the run is better than planned. If
+    they regress, tasks slide into
+    :data:`TASKS_WORKING_FROM_THE_PROMPT_ALONE` without appearing there, and
+    their results get read as the model's. That second case is why this returns
+    the names and not only the count.
+
+    Needs real bytes, like its neighbour, so it does not run in CI and is not
+    meant to.
+    """
+    catalog = catalog or load_task_catalog()
+    by_id = catalog.by_task_id()
+    tasks = [by_id[one] for one in full_run_tasks(catalog) if one in by_id]
+
+    outcomes: Counter[str] = Counter()
+    alone: set[str] = set()
+    with tempfile.TemporaryDirectory(prefix="v2-rendering-reach-") as scratch:
+        for task in tasks:
+            # ``reference_file_paths``, not ``reference_files``: the catalogue
+            # and the parquet row name the same files under different
+            # attributes, and reading for the wrong one gets an empty tuple
+            # rather than an error -- every task then looks like it named
+            # nothing, and the whole check passes by measuring nothing.
+            staging = stage_task_reference_files(
+                task_id=str(task.task_id),
+                reference_files=tuple(task.reference_file_paths),
+                snapshot_root=snapshot_root,
+                into=Path(scratch)
+                / hashlib.sha256(str(task.task_id).encode("utf-8")).hexdigest(),
+                render_text=True,
+            )
+            for extraction in staging.extractions:
+                outcomes[extraction.outcome] += 1
+            if staging.worked_from_the_prompt_alone:
+                alone.add(str(task.task_id))
+
+    wrong: list[str] = []
+    if not outcomes:
+        wrong.append(
+            "nothing was extracted from any of the 220 tasks, which is not a "
+            "reading of the files but a sign that none were found. Check the "
+            "snapshot root before believing any figure below"
+        )
+    elif dict(outcomes) != RENDERING_OUTCOMES:
+        wrong.append(
+            f"the reader now returns {dict(sorted(outcomes.items()))} and the "
+            f"record is written about {dict(sorted(RENDERING_OUTCOMES.items()))}"
+        )
+
+    recorded = {str(one) for one in TASKS_WORKING_FROM_THE_PROMPT_ALONE}
+    for task_id in sorted(alone - recorded):
+        wrong.append(
+            f"{task_id} now receives nothing readable and is not in the "
+            "record. Its result would be read as the model's"
+        )
+    for task_id in sorted(recorded - alone):
+        wrong.append(
+            f"{task_id} is recorded as receiving nothing readable and now "
+            "receives something. The record understates what reached it"
         )
     return wrong
 

--- a/batch-runner/tests/test_agentic_v2_preregistration.py
+++ b/batch-runner/tests/test_agentic_v2_preregistration.py
@@ -44,6 +44,8 @@ from core.agentic_v2_preregistration import (
     FILES_NAMED_BY_THE_TASKS,
     FILES_THE_MODEL_COULD_OPEN_UNAIDED,
     OVER_THE_WORKSPACE_FILE_LIMIT,
+    RENDERING_OUTCOMES,
+    TASKS_WORKING_FROM_THE_PROMPT_ALONE,
     UNDELIVERABLE_INPUTS,
     UNKNOWN,
     WORKSPACE_FILE_LIMIT,
@@ -58,6 +60,7 @@ from core.agentic_v2_preregistration import (
     seal,
     verify_input_disposition,
     verify_reader_reach,
+    verify_rendering_reach,
     verify_seal,
 )
 from core.execution_envelope_tasks import full_run_tasks, load_task_catalog
@@ -745,9 +748,16 @@ class TestWhatTheModelCanOpenWithoutHelp:
         unreadable = FILES_NAMED_BY_THE_TASKS - FILES_THE_MODEL_COULD_OPEN_UNAIDED
 
         assert f"the other {unreadable} do not" in measured
+        # The denominator used to sit in ``what_they_are``, inside a sentence
+        # claiming all 261 extract without error. That sentence was wrong, so
+        # the figure now anchors to the one that replaced it -- which carries
+        # the same denominator and, unlike its predecessor, a true numerator.
         assert str(FILES_NAMED_BY_THE_TASKS) in (
-            disposition["text_renderings"]["what_they_are"]
+            disposition["text_renderings"]["not_all_of_them_open"]
         )
+        assert sum(
+            disposition["text_renderings"]["what_the_reader_got_out_of_them"].values()
+        ) == FILES_NAMED_BY_THE_TASKS
 
     def test_the_pinned_snapshot_still_gives_the_recorded_reach(self):
         """The measurement itself, where the bytes exist to make it.
@@ -806,6 +816,82 @@ class TestWhatTheModelCanOpenWithoutHelp:
 
         assert any("not in the snapshot" in one for one in wrong)
         assert any("were measured and the record is written about" in one for one in wrong)
+
+
+class TestTheTasksThatGetNothingReadable:
+    """Nine tasks, and a record that used to say all 261 files opened fine."""
+
+    def test_the_record_no_longer_says_every_file_extracts_without_error(self):
+        """Two do not open. The old sentence said none failed.
+
+        Small, and in the direction that flatters the environment -- which is
+        the direction a pre-registration exists to guard, because a record
+        overstating what reached the model turns an input the model never had
+        into an answer the model got wrong.
+        """
+        renderings = input_disposition()["text_renderings"]
+        assert "All 261 files extract without error" not in renderings[
+            "what_they_are"
+        ]
+        assert RENDERING_OUTCOMES["the_reader_could_not_open_it"] == 2
+        assert RENDERING_OUTCOMES["the_reader_found_no_text_in_it"] == 5
+
+    def test_the_outcomes_account_for_every_named_file(self):
+        assert sum(RENDERING_OUTCOMES.values()) == FILES_NAMED_BY_THE_TASKS
+
+    def test_the_record_carries_the_outcomes_and_not_only_a_summary(self):
+        renderings = input_disposition()["text_renderings"]
+        assert renderings["what_the_reader_got_out_of_them"] == RENDERING_OUTCOMES
+        assert "2 of 261" in renderings["not_all_of_them_open"]
+
+    def test_the_nine_are_named_rather_than_counted(self):
+        """A count cannot be checked against a result. A task id can.
+
+        Reading a result for one of these as the model's would be scoring a gap
+        this environment introduced, so the record has to survive being carried
+        to the grading table, and a bare nine does not.
+        """
+        assert len(TASKS_WORKING_FROM_THE_PROMPT_ALONE) == 9
+        assert len(set(TASKS_WORKING_FROM_THE_PROMPT_ALONE)) == 9
+
+    def test_every_one_of_them_is_a_task_the_run_will_actually_reach(self):
+        catalog = load_task_catalog()
+        everything = {str(one) for one in full_run_tasks(catalog)}
+        for task_id in TASKS_WORKING_FROM_THE_PROMPT_ALONE:
+            assert task_id in everything, f"{task_id} is not in the 220"
+
+    def test_the_smaller_stages_carry_their_own_share(self):
+        """Nought of five, one of thirty, nine of 220.
+
+        Worth pinning because the escalation is what decides whether the
+        problem is seen before the money is spent: an advance check of five
+        would have passed clean and said nothing about it.
+        """
+        per_stage = input_disposition()["per_stage"]
+        assert per_stage[STAGE_FIVE]["tasks_that_worked_from_the_prompt_alone"] == []
+        assert per_stage[STAGE_THIRTY][
+            "tasks_that_worked_from_the_prompt_alone"
+        ] == ["38889c3b-e3d4-49c8-816a-3cc8e5313aba"]
+        assert sorted(
+            per_stage[STAGE_TWO_TWENTY]["tasks_that_worked_from_the_prompt_alone"]
+        ) == sorted(TASKS_WORKING_FROM_THE_PROMPT_ALONE)
+
+    def test_a_stage_can_never_report_more_of_them_than_it_has_tasks(self):
+        for stage, section in input_disposition()["per_stage"].items():
+            assert len(
+                section["tasks_that_worked_from_the_prompt_alone"]
+            ) <= section["tasks_naming_reference_files"], stage
+
+    def test_the_disclaimer_covers_the_case_that_was_invisible(self):
+        """The six whose every file was refused, which both old checks passed.
+
+        ``could_open_nothing`` asks about the files that arrived, so a task
+        with none arrived answers no -- the same answer a task given everything
+        gives. The sentence had two cases in it and needed the third.
+        """
+        said = input_disposition()["what_a_failure_there_does_not_show"]
+        assert "every file was refused" in said
+        assert "tasks_that_worked_from_the_prompt_alone" in said
 
 
 class TestTheRecordSaysWhatItIsNot:
@@ -916,14 +1002,46 @@ class TestTheCommittedCopyIsTheOneThatCounts:
 
 
 class TestItOnlyReads:
-    def test_it_reaches_for_no_network_and_writes_nothing(self):
-        source = (
-            Path(__file__).resolve().parents[1]
-            / "core"
-            / "agentic_v2_preregistration.py"
-        ).read_text(encoding="utf-8")
+    #: The substring list below would have kept passing after
+    #: ``verify_rendering_reach`` was added, because writing through
+    #: ``tempfile`` and ``stage_task_reference_files`` spells none of these
+    #: words. A green bar on a claim that had stopped being true is worse than
+    #: a red one, so the claim is split instead: the network ban still covers
+    #: the whole module, and the writing ban now says where writing is allowed.
+    def test_it_reaches_for_no_network(self):
         for forbidden in (
-            "requests", "httpx", "urllib", "socket", "subprocess",
-            "write_text", "write_bytes", "mkdir", "os.system",
+            "requests", "httpx", "urllib", "socket", "subprocess", "os.system",
         ):
-            assert forbidden not in source, f"unexpected reach: {forbidden}"
+            assert forbidden not in _source(), f"unexpected reach: {forbidden}"
+
+    def test_deriving_the_record_writes_nothing(self):
+        for forbidden in ("write_text", "write_bytes", "mkdir"):
+            assert forbidden not in _source(), f"unexpected write: {forbidden}"
+
+    def test_the_only_writing_is_into_a_directory_it_removes(self):
+        """The verifiers stage real files, which cannot be done without writing.
+
+        Staging is how the outcomes are measured at all -- re-implementing the
+        extraction here to avoid the disk would measure a second reader and
+        report it as the first. So it writes, and what this pins is where: a
+        temporary directory the function creates and the context manager
+        removes, never a path in the repository or the snapshot it was given.
+        """
+        source = _source()
+        assert "tempfile.TemporaryDirectory" in source
+        assert source.count("tempfile.TemporaryDirectory") == source.count(
+            "with tempfile.TemporaryDirectory"
+        ), "a temporary directory was made without a block that removes it"
+
+    def test_the_snapshot_it_is_given_is_never_written_into(self):
+        into = inspect.getsource(verify_rendering_reach)
+        assert "into=Path(scratch)" in into
+        assert "into=snapshot_root" not in into
+
+
+def _source() -> str:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "core"
+        / "agentic_v2_preregistration.py"
+    ).read_text(encoding="utf-8")

--- a/tasks/0822_saturday/v2_run_preregistration.json
+++ b/tasks/0822_saturday/v2_run_preregistration.json
@@ -101,7 +101,8 @@
         "files_too_large_for_the_workspace": [],
         "tasks": 5,
         "tasks_affected_by_the_workspace_limit": 0,
-        "tasks_naming_reference_files": 2
+        "tasks_naming_reference_files": 2,
+        "tasks_that_worked_from_the_prompt_alone": []
       },
       "full_220": {
         "files_named": 261,
@@ -286,7 +287,18 @@
         ],
         "tasks": 220,
         "tasks_affected_by_the_workspace_limit": 16,
-        "tasks_naming_reference_files": 125
+        "tasks_naming_reference_files": 125,
+        "tasks_that_worked_from_the_prompt_alone": [
+          "38889c3b-e3d4-49c8-816a-3cc8e5313aba",
+          "46b34f78-6c06-4416-87e2-77b6d8b20ce9",
+          "55ddb773-23a4-454c-8704-d432fe1b99d9",
+          "75401f7c-396d-406d-b08e-938874ad1045",
+          "94925f49-36bc-42da-b45b-61078d329300",
+          "a941b6d8-4289-4500-b45a-f8e4fc94a724",
+          "b9665ca1-4da4-4ff9-86f2-40b9a8683048",
+          "f2986c1f-2bbf-4b83-bc93-624a9d617f45",
+          "ff85ee58-bc9f-4aa2-806d-87edeabb1b81"
+        ]
       },
       "trial_30": {
         "files_named": 21,
@@ -316,17 +328,28 @@
         ],
         "tasks": 30,
         "tasks_affected_by_the_workspace_limit": 3,
-        "tasks_naming_reference_files": 14
+        "tasks_naming_reference_files": 14,
+        "tasks_that_worked_from_the_prompt_alone": [
+          "38889c3b-e3d4-49c8-816a-3cc8e5313aba"
+        ]
       }
     },
     "staged_into": "inputs/ inside each task's own workspace, one workspace per attempt, copied from the same revision the prompt text comes from",
     "text_renderings": {
       "how_to_check_this": "core.agentic_v2_reference_staging.stage_task_reference_files with render_text=True, and the per-file outcomes it records",
       "never_a_replacement": "the original stays where it is whenever it can be staged, and a rendering is never presented as the file. Layout, images, styling and anything a picture carries are lost, and a long one is cut to fit the workspace limit and says so at the cut",
+      "not_all_of_them_open": "2 of 261 the reader cannot open at all, and 5 it opens and finds no text in -- a scanned PDF among them, which is no more use to the model for having opened cleanly. Written down because the sentence here used to say all 261 extract without error, and a record that overstates what reached the model turns an input the model never had into an answer the model got wrong",
       "this_is_a_difference_from_the_codex_run": "A's model has a real shell and opens these files itself. A V2 result on a task whose work needed what a rendering loses is not comparable to A's result on the same task, and this is the record that says so before either is run",
-      "what_they_are": "a text extraction made by core.file_reader and staged beside the file it came from, under inputs/extracted/. All 261 files extract without error; what comes out is text for spreadsheets, PDFs and documents, and a one-line label for images, recordings and archives"
+      "what_the_reader_got_out_of_them": {
+        "text_was_read_out_of_it": 221,
+        "text_was_read_out_of_it_and_cut_to_the_workspace_limit": 1,
+        "the_reader_could_not_open_it": 2,
+        "the_reader_describes_this_kind_rather_than_reading_it": 32,
+        "the_reader_found_no_text_in_it": 5
+      },
+      "what_they_are": "a text extraction made by core.file_reader and staged beside the file it came from, under inputs/extracted/. What comes out is text for spreadsheets, PDFs and documents, and a one-line label for images, recordings and archives"
     },
-    "what_a_failure_there_does_not_show": "a task that ran without a file it named is not evidence about the model. It is recorded with the missing file's name so the two cannot be read as one. Nor is a task that was handed files it could not open: that one is recorded separately again, because a task holding only unreadable files has nothing refused and would otherwise be indistinguishable from a task given everything",
+    "what_a_failure_there_does_not_show": "a task that ran without a file it named is not evidence about the model. It is recorded with the missing file's name so the two cannot be read as one. Nor is a task that was handed files it could not open: that one is recorded separately again, because a task holding only unreadable files has nothing refused and would otherwise be indistinguishable from a task given everything. Nor, third, is a task whose every file was refused -- it has no delivered file to call unreadable either, so it too answered no to both questions and read as fine. The three are gathered under tasks_that_worked_from_the_prompt_alone, which asks the question that actually matters: did one readable character reach it",
     "what_the_model_can_open_by_itself": {
       "files_named_by_the_tasks": 261,
       "files_that_decode_as_utf8": 3,
@@ -714,7 +737,7 @@
     },
     "what_stops_a_task": "any per-task ceiling above, or the per-task budget, whichever comes first. A task stopped by a ceiling is recorded as stopped by that ceiling and is not a model failure"
   },
-  "seal": "f9a906ab1bcf89cdfdd25a8454c35be17ad2d32e4ae3e0b95782ad236853dcd9",
+  "seal": "023bdcbef172a23de10fdbc8648568358c1ee4c83def552389b343cd8db94867",
   "stop_rules": [
     "the deployment or model reported back differs from the pinned one",
     "a run switches model or deployment on its own",


### PR DESCRIPTION
The pre-registration said all 261 named files extract without error. Two of them the reader cannot open at all, and five it opens and finds no text in.

Small, and in the direction that flatters the environment — which is the direction a pre-registration exists to guard. A record that overstates what reached the model turns an input the model never had into an answer the model got wrong. This one is meant to be read at the grading table, after the money is spent, when nobody can go back and check.

## The measured breakdown

Pinned as `RENDERING_OUTCOMES`, replacing the claim:

| outcome | files |
|---|---|
| text was read out of it | 221 |
| text was read out of it, cut to the workspace limit | 1 |
| the reader describes this kind rather than reading it | 32 |
| the reader found no text in it | 5 |
| the reader could not open it | 2 |
| | **261** |

The last two rows are the ones the old sentence denied. A scanned PDF is among the five: it opens cleanly and is no more use to the model for having done so.

## The nine that get nothing readable, named per stage

`TASKS_WORKING_FROM_THE_PROMPT_ALONE` — nought of the five advance-check tasks, one of the thirty, nine of the 220. The escalation would have passed clean at five and said nothing about them.

Named rather than counted, because a count cannot be checked against a result and a task id can.

## The disclaimer had two cases and needed three

It covered a task that ran without a file it named, and a task handed files it could not open. It did not cover a task whose every file was refused: that one has nothing delivered to call unreadable, so it answered *no* to both questions and read as fine. Six of the nine were in exactly that position.

## `verify_rendering_reach`

Turns both literals back into a measurement wherever the real bytes are present, the way `verify_reader_reach` does beside it. Against the pinned snapshot it reports **no disagreement** — all five outcome counts and all nine task ids re-derive.

Deliberately separate from `verify_reader_reach`: that one asks what the model can open, a property of the bytes; this asks what our reader got out of them, a property of our code, so a dependency bump moves it without touching an input.

It also fails loudly on the empty case. The first draft called `stage_cohort`, which reads `reference_files`, while the catalogue exposes `reference_file_paths` — the mismatch returns an empty tuple rather than an error, so every task looked like it named nothing and the check would have passed by measuring nothing.

## `TestItOnlyReads` needed splitting

Its forbidden-substring list would have kept passing after this change, because writing through `tempfile` spells none of the forbidden words, while its name went on claiming the module writes nothing. The network ban still covers the whole module; the writing ban now says where writing is allowed and pins that it is a temporary directory the function removes, never the snapshot it was given.

## Cost

None. The figures come from the free model-free rehearsal over the staged bytes, and the verifier re-derives them offline.

Full backend suite: 11169 passed, 18 skipped, 0 failed.
