### PR TITLE
fix(v2): which model answered was thrown away, and never checked

### DIFF
--- a/batch-runner/core/agentic_v2_run_driver.py
+++ b/batch-runner/core/agentic_v2_run_driver.py
@@ -32,9 +32,11 @@ in prose, and it would be easy to claim all eight by naming them. Four of them
 are about the run's own record — the seal, a pinned deployment, a gate, an
 approved amount — and are checked before anything starts, by code that is not
 this. :data:`RULES_THIS_DRIVER_WATCHES` names by index the ones a loop can
-observe while it runs, and :data:`RULES_THIS_DRIVER_CANNOT_SEE` names the rest.
-Both are derived from :data:`~core.agentic_v2_preregistration.STOP_RULES` rather
-than retyped, so a rule added there without a decision here fails a test.
+observe while it runs, :data:`RULES_A_CALLER_CAN_HAND_THIS_DRIVER` names the
+one it watches only when the caller passes ``stop_when``, and
+:data:`RULES_THIS_DRIVER_CANNOT_SEE` names the rest. All three are derived from
+:data:`~core.agentic_v2_preregistration.STOP_RULES` rather than retyped, so a
+rule added there without a decision here fails a test.
 
 Nothing here asks a model. The model is behind ``runner_factory``, which is the
 seam the caller supplies and the one thing still blocked.
@@ -90,7 +92,6 @@ RULES_THIS_DRIVER_WATCHES: dict[int, str] = {
 #: Written down because a driver that silently enforced two of eight would read
 #: as a driver that enforced eight.
 RULES_THIS_DRIVER_CANNOT_SEE: dict[int, str] = {
-    0: "the deployment is pinned and compared where the model client is built",
     1: "a model or deployment switch is visible to the voice, not to this loop",
     2: "the seal is verified before a run starts",
     3: "gate state is checked by the gate's own free check",
@@ -98,9 +99,30 @@ RULES_THIS_DRIVER_CANNOT_SEE: dict[int, str] = {
     5: "the ledger's writability is the ledger's own refusal",
 }
 
-if set(RULES_THIS_DRIVER_WATCHES) | set(RULES_THIS_DRIVER_CANNOT_SEE) != set(
-    range(len(STOP_RULES))
-):  # pragma: no cover - import guard
+#: Rules this loop enforces only if the caller hands it the comparison.
+#:
+#: Separate from the two dicts above because the difference is real and the
+#: honest thing is to say so: these are watched when ``stop_when`` is passed
+#: and by nobody at all when it is not. Listing them beside the unconditional
+#: ones would be the same overclaim this file exists to avoid, and leaving them
+#: in "cannot see" would hide that the seam is there.
+RULES_A_CALLER_CAN_HAND_THIS_DRIVER: dict[int, str] = {
+    0: "what a reply named can only be compared against what the plan pinned "
+    "by something holding both. The plan belongs to the caller and the "
+    "replies to the voice, and the voice's own guard is per conversation -- "
+    "so two tasks answered by two different models pass every check inside "
+    "both. Neither half is this loop's to hold, so the comparison arrives "
+    "through stop_when. This entry used to read that the deployment was "
+    "'compared where the model client is built', which is before any reply "
+    "exists: the half of the rule that says *reported back* had no reader "
+    "anywhere in the run",
+}
+
+if (
+    set(RULES_THIS_DRIVER_WATCHES)
+    | set(RULES_THIS_DRIVER_CANNOT_SEE)
+    | set(RULES_A_CALLER_CAN_HAND_THIS_DRIVER)
+) != set(range(len(STOP_RULES))):  # pragma: no cover - import guard
     raise RuntimeError(
         "a stop rule was added or removed without deciding whether this driver "
         "can see it"
@@ -227,6 +249,7 @@ def run_manifest(
     condition_name: str = "condition_a",
     clock: Callable[[], float] = time.monotonic,
     on_task: Callable[[str, Mapping[str, Any]], None] | None = None,
+    stop_when: Callable[[str], "StoppedEarly | None"] | None = None,
 ) -> RunOutcome:
     """Run a fixed manifest, resuming what a previous run left.
 
@@ -234,6 +257,19 @@ def run_manifest(
     task's cost receipt, or ``None`` when this run kept no ledger. ``None`` is
     not free — it becomes a ``not_run`` receipt status and keeps the run's
     ceiling below ``complete``.
+
+    ``stop_when`` is asked, after each task, whether a rule this loop cannot
+    check for itself has been broken; it is handed the task that just finished
+    and returns a :class:`StoppedEarly` or ``None``. It exists for rule 0 —
+    see :data:`RULES_A_CALLER_CAN_HAND_THIS_DRIVER` — where the comparison
+    needs the plan on one side and the model's replies on the other, and this
+    loop holds neither.
+
+    A caller enforcing such a rule should wire the runner's ``cancel_requested``
+    to the same condition. The two stop different things: cancelling ends the
+    task that is running, and this ends the run with the rule named. Without
+    the second, a run that halted finishes a manifest of cancelled tasks and
+    reports ``stopped_early`` as nothing.
     """
     manifest = list(tasks)
     if not manifest:
@@ -357,6 +393,16 @@ def run_manifest(
             outcome.rows.append(row)
             if on_task is not None:
                 on_task(task_id, row)
+
+        # Asked after the row is kept, so the task that tripped the rule is in
+        # the record rather than dropped by the halt. Asked even when there is
+        # no row, because a task the journal had already decided is not a
+        # reason to stop checking.
+        if stop_when is not None:
+            asked = stop_when(task_id)
+            if asked is not None:
+                outcome.stopped = asked
+                break
 
         if consecutive_defects >= CONSECUTIVE_RUNNER_DEFECTS_THAT_STOP_A_RUN:
             outcome.stopped = StoppedEarly(

--- a/batch-runner/scripts/run_agentic_v2_stage.py
+++ b/batch-runner/scripts/run_agentic_v2_stage.py
@@ -51,7 +51,7 @@ import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable, Mapping
 
 BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
 if str(BATCH_RUNNER_ROOT) not in sys.path:
@@ -75,7 +75,7 @@ from core.agentic_v2_manifest_binding import (  # noqa: E402
     bind_stage,
     binding_record,
 )
-from core.agentic_v2_preregistration import STAGE_SIZES  # noqa: E402
+from core.agentic_v2_preregistration import STAGE_SIZES, STOP_RULES  # noqa: E402
 from core.agentic_v2_reference_staging import (  # noqa: E402
     MODEL_INPUT_PREFIX,
     TaskStaging,
@@ -86,7 +86,11 @@ from core.agentic_v2_reference_staging import (  # noqa: E402
 from core.agentic_v2_route_check import (  # noqa: E402
     check_route_is_the_one_the_plan_fixed,
 )
-from core.agentic_v2_run_driver import DriverRefused, run_manifest  # noqa: E402
+from core.agentic_v2_run_driver import (  # noqa: E402
+    DriverRefused,
+    StoppedEarly,
+    run_manifest,
+)
 from core.agentic_v2_sharding import ShardRefused  # noqa: E402
 from core.agentic_v2_sharding import parse as parse_shard  # noqa: E402
 from core.agentic_v2_stage_one_budget import (  # noqa: E402
@@ -181,6 +185,137 @@ def read_pinned_dataset(parquet: Path) -> list[DatasetRow]:
         )
         for row in frame.itertuples()
     ]
+
+
+def names_that_answered(voices: Iterable[Any]) -> tuple[str, ...]:
+    """Every distinct model name that came back, in sorted order.
+
+    A voice that never spoke holds ``None`` and is not a name. A voice that
+    spoke to a reply which named nothing holds ``""`` -- also not a name, and
+    deliberately not treated as one: see :func:`answered_by_something_else`.
+    """
+    return tuple(
+        sorted(
+            {
+                str(voice.resolved_model)
+                for voice in voices
+                if voice is not None and voice.resolved_model
+            }
+        )
+    )
+
+
+def answered_by_something_else(
+    voices: Iterable[Any], *, pinned_model: str
+) -> tuple[str, ...]:
+    """Names that came back and are not the one the plan pinned.
+
+    The one computation behind both the halt and the record, so the run cannot
+    stop for a reason its own record disagrees with.
+
+    Three states, and only one of them is this:
+
+    ``matched``
+        the reply named the pinned model. Nothing to do.
+    ``differed``
+        the reply named something else. The plan's first stop condition, and
+        the run must not continue: every result after it would belong to a
+        model the pre-registration does not describe.
+    ``not reported``
+        the reply named nothing at all -- ``resolved_model`` is ``""``. Not
+        counted here, so it does not halt the run. The rule is written about a
+        name that *differs*, and a provider omitting a field is not a model
+        switch; halting on it would end a paid stage over a missing header.
+        It is a real gap in the evidence all the same, so it is counted in the
+        record under ``attempts_that_reported_no_model`` rather than passed
+        over. Recorded, not enforced -- and the record says which.
+
+    An empty ``pinned_model`` returns nothing. A plan that pins no name has no
+    claim to check, and inventing one here would make this function the thing
+    that decided what the run was allowed to be.
+    """
+    if not pinned_model:
+        return ()
+    return tuple(
+        name for name in names_that_answered(voices) if name != pinned_model
+    )
+
+
+def model_calls_record(
+    voices: Mapping[tuple[str, int], Any], *, pinned_model: str
+) -> dict:
+    """Every paid call, as the voice that made it recorded it.
+
+    The sqlite ledger beside this is the bill. This is the evidence the bill
+    was made from, and it is kept because the two are computed from different
+    things and disagreement between them is worth being able to see: the
+    ledger prices from the committed price list, and the voice prices from the
+    same list keyed by the name the reply gave.
+
+    ``resolved_model`` is the point of it. A deployment is an alias, and what
+    answers behind it can change without the alias changing -- so "which model
+    produced these 220 results" is not answered by the deployment name, and
+    after the run there is nowhere else to look. Recorded per attempt rather
+    than once for the run because a run that was answered by two different
+    models is exactly the case worth catching, and a single field could not
+    show it.
+
+    ``spent_usd`` is ``None`` when any call in the attempt had no price, and
+    that is deliberate: a total that quietly drops the calls it could not
+    price reads as the whole bill and is not one. Missing is partial, never
+    zero.
+
+    No prompt and no reply text -- token counts, names and amounts only, the
+    same rule the rest of this script follows.
+    """
+    per_attempt: list[dict[str, Any]] = []
+    unpriced = 0
+    unnamed = 0
+    spoke = [voice for voice in voices.values() if voice is not None]
+    for (task_id, attempt), voice in sorted(voices.items()):
+        if voice is None:
+            continue
+        rows = voice.ledger()
+        spent = voice.spent_usd()
+        unpriced += sum(1 for row in rows if row.get("price_missing"))
+        if voice.resolved_model == "":
+            unnamed += 1
+        per_attempt.append(
+            {
+                "task_id": task_id,
+                "attempt": attempt,
+                "resolved_model": voice.resolved_model,
+                "calls": rows,
+                "spent_usd": None if spent is None else str(spent),
+            }
+        )
+    differed = answered_by_something_else(spoke, pinned_model=pinned_model)
+    return {
+        "what_this_is": (
+            "one row per model call, as the voice that made it saw it. The "
+            "bill is the ledger; this is what the bill was made from"
+        ),
+        "per_attempt": per_attempt,
+        "pinned_model": pinned_model,
+        "models_that_answered": list(names_that_answered(spoke)),
+        "answered_by_something_else": list(differed),
+        "attempts_that_reported_no_model": unnamed,
+        "what_no_model_reported_means": (
+            "the reply carried no model name. The call happened and was "
+            "charged for; which model made it is not known and cannot be "
+            "recovered afterwards. This does not stop the run -- the stop "
+            "condition is written about a name that differs, and an omitted "
+            "field is not a model switch -- so it is counted here instead of "
+            "being passed over"
+        ),
+        "calls_with_no_price": unpriced,
+        "what_no_price_means": (
+            "the committed price list has no entry for the model the reply "
+            "named. The call happened and cost something; the amount is not "
+            "known here and is not zero. The tokens and the model name are "
+            "kept above, so it can be worked out once the list covers it"
+        ),
+    }
 
 
 #: What the fixture backend is, in words that survive being quoted.
@@ -410,6 +545,12 @@ def main() -> int:
     ceilings = ceilings_from(plan, chosen)
     connection = plan.get("azure_connection") or {}
     deployment = str((plan.get("model") or {}).get("deployment") or "")
+    # The name the plan says will answer, as opposed to the alias it will be
+    # asked through. The plan pins both and they are not the same fact: the
+    # deployment is the address, and this is the claim about who is behind it.
+    # Read here so the stop condition below has something to compare against;
+    # until now it was read only to print an estimate.
+    pinned_model = str((plan.get("model") or {}).get("resolved_model") or "")
     resource = str(connection.get("account") or "")
     profile = {
         "tool_contract_version": "2.0",
@@ -533,12 +674,24 @@ def main() -> int:
             attempts[task_id] = attempts.get(task_id, 0) + 1
             return attempts[task_id]
 
+        # Kept, rather than built and dropped. Each voice reads the model name
+        # out of every reply it gets, holds it, and refuses the run if a later
+        # reply names a different one -- so the voice is the only thing in the
+        # run that knows which model actually answered. It also prices each
+        # call against that name as it goes. Both were being thrown away with
+        # the voice at the end of the task, which left the receipt unable to
+        # answer the one question it exists to answer: what was this a bill
+        # for. Keyed by the budget's identity because that is the only handle
+        # ``voice_for`` is given, and ``TaskConversations`` files the same
+        # budget object under the task and attempt it belongs to.
+        voices_by_budget: dict[int, Any] = {}
+
         # One voice per task, built on that task's own budget. A single voice
         # reused across the stage would hold task one's ceiling for all of
         # them, and the later tasks would be refused by an ceiling that had
         # nothing to do with them. See build_runner_factory's docstring.
         def voice_for(budget):
-            return AzureFoundryVoice(
+            voice = AzureFoundryVoice(
                 client=managed.client,
                 deployment=deployment,
                 resource=resource,
@@ -547,6 +700,88 @@ def main() -> int:
                 max_output_tokens_per_turn=ceilings.max_written_tokens_per_turn,
                 request_timeout_seconds=ceilings.max_seconds,
                 prices=prices,
+            )
+            voices_by_budget[id(budget)] = voice
+            return voice
+
+        def voice_of(task_id: str, attempt: int):
+            """The voice that spoke for one attempt, or ``None``.
+
+            ``None`` for a rehearsal, and for an attempt refused before a voice
+            was ever built. Both are states where no model answered, so there
+            is no resolved model to report and saying so is correct.
+            """
+            budget = held.budgets.get((str(task_id), int(attempt)))
+            if budget is None:
+                return None
+            return voices_by_budget.get(id(budget))
+
+        # ── the plan's first stop condition ───────────────────────────────
+        #
+        # Rule 0: "the deployment or model reported back differs from the
+        # pinned one", which the plan writes out as "Stop at once if the model
+        # name or deployment name reported back differs from the one fixed
+        # above."
+        #
+        # It was written into the plan and implemented nowhere. The driver's
+        # own table of who enforces what attributed it to the model client,
+        # which is built before any reply exists and can only see the name
+        # being asked for -- so the half of the condition that says *reported
+        # back* had no reader anywhere in the run.
+        #
+        # Not rule 1, which is the neighbouring and different claim that a run
+        # switched on its own mid-conversation. The voice does hold that one:
+        # it raises when two replies in one conversation name two different
+        # models. What no part of the run held is the comparison against the
+        # name the plan pinned.
+        #
+        # That comparison needs two things which meet in this function and
+        # nowhere else: the name the plan pinned, and the names the replies
+        # carried. The voice sees only its own replies, and its guard is per
+        # conversation -- so two tasks answered by two different models pass
+        # every check inside both and arrive here as one experiment reported
+        # as one thing. This is the level the rule is written at, so this is
+        # where it is enforced.
+        #
+        # Wired into both seams on purpose, because they stop different
+        # amounts of spending:
+        #
+        #   cancel_requested  is read at the top of every model turn and
+        #                     before every tool call, so the task that saw the
+        #                     wrong name does not take another turn. This is
+        #                     the one that saves money.
+        #   stop_when         is read by the driver between tasks, so the run
+        #                     ends with `stopped_early` naming the rule
+        #                     instead of quietly finishing a manifest of
+        #                     cancelled tasks. This is the one that saves the
+        #                     record.
+        #
+        # Either alone is wrong in a way that matters. Cancelling without
+        # stopping leaves a run that halted looking like a run that completed;
+        # stopping without cancelling pays for the rest of the current task's
+        # turns before anyone looks.
+        def wrong_model_answered() -> tuple[str, ...]:
+            return answered_by_something_else(
+                voices_by_budget.values(), pinned_model=pinned_model
+            )
+
+        def cancel_requested() -> bool:
+            return bool(wrong_model_answered())
+
+        def stop_when(after_task: str):
+            differed = wrong_model_answered()
+            if not differed:
+                return None
+            return StoppedEarly(
+                rule_index=0,
+                rule=STOP_RULES[0],
+                detail=(
+                    f"the plan pins {pinned_model!r} and a reply came back "
+                    f"named {', '.join(repr(name) for name in differed)}. "
+                    "Every result after this point would belong to a model "
+                    "the pre-registration does not describe"
+                ),
+                after_task=after_task,
             )
 
         workspaces = into / "workspaces"
@@ -605,6 +840,7 @@ def main() -> int:
             profile=profile,
             conversations=held,
             attempt_of=attempt_of,
+            cancel_requested=cancel_requested,
             **(
                 {"voice": rehearsing}
                 if rehearsing is not None
@@ -626,6 +862,7 @@ def main() -> int:
                 outcome = held.outcome_of(task.task_id, attempt)
                 if outcome is None:
                     return None
+                spoke = voice_of(task.task_id, attempt)
                 turns = model_turns_of(
                     outcome,
                     run_id=run_id,
@@ -634,7 +871,25 @@ def main() -> int:
                     provider="azure",
                     requested_model=deployment,
                     deployment=deployment,
-                    resolved_model=None,
+                    # What the reply named, not what was asked for. Passing
+                    # None left the ledger's own column empty and priced the
+                    # call against the deployment alias instead -- which is
+                    # the right amount only if the two strings happen to
+                    # match, and the record kept nothing that would let anyone
+                    # check whether they did.
+                    #
+                    # If they do not match, these calls settle as
+                    # `price_missing`. That is the true state: the committed
+                    # price list has no entry for the model that answered, and
+                    # an amount worked out from a different model's rates is
+                    # not a smaller error than a missing one. It is also the
+                    # recoverable direction -- `model_calls` below keeps the
+                    # tokens and the name, so the amount can be worked out
+                    # later once the price list covers it, whereas a name
+                    # thrown away at the end of the task is gone.
+                    resolved_model=(
+                        spoke.resolved_model if spoke is not None else None
+                    ),
                 )
                 return bind_run_to_ledger(
                     ledger, task_id=task.task_id, model_turns=turns
@@ -647,6 +902,7 @@ def main() -> int:
             journal_path=into / "journal.jsonl",
             collect_into=into / "deliverables",
             receipt_for=receipt_for,
+            stop_when=stop_when,
             on_task=lambda task_id, row: print(
                 # `status`, not a `success` key -- the row is a report row and
                 # has never carried one, so the old `row.get("success")` read
@@ -687,6 +943,16 @@ def main() -> int:
         # record's `unmet_needs` says which tasks *want* files; this says which
         # got them. A result is read against this one.
         "reference_files": staging_record(stagings),
+        # Which model answered, per attempt, and what each call is known to
+        # have cost. The deployment name is in `chosen_settings` already; this
+        # is what came back, which is not the same fact.
+        "model_calls": model_calls_record(
+            {
+                key: voices_by_budget.get(id(budget))
+                for key, budget in held.budgets.items()
+            },
+            pinned_model=pinned_model,
+        ),
         "environment": environment_note(profile),
         "route_fingerprint": (
             rehearsal_is_not_a_run()

--- a/batch-runner/tests/test_agentic_v2_run_driver.py
+++ b/batch-runner/tests/test_agentic_v2_run_driver.py
@@ -17,9 +17,11 @@ from core.agentic_v2_deliverable_collection import DELIVERABLE_ROOT
 from core.agentic_v2_preregistration import STOP_RULES
 from core.agentic_v2_run_driver import (
     CONSECUTIVE_RUNNER_DEFECTS_THAT_STOP_A_RUN,
+    RULES_A_CALLER_CAN_HAND_THIS_DRIVER,
     RULES_THIS_DRIVER_CANNOT_SEE,
     RULES_THIS_DRIVER_WATCHES,
     DriverRefused,
+    StoppedEarly,
     TaskToRun,
     run_manifest,
 )
@@ -106,15 +108,37 @@ def _run(tmp_path, tasks, script, **kwargs):
 
 def test_every_stop_rule_is_either_watched_or_accounted_for():
     watched = set(RULES_THIS_DRIVER_WATCHES)
+    handed = set(RULES_A_CALLER_CAN_HAND_THIS_DRIVER)
     unseen = set(RULES_THIS_DRIVER_CANNOT_SEE)
     assert watched & unseen == set()
-    assert watched | unseen == set(range(len(STOP_RULES)))
+    assert watched & handed == set()
+    assert handed & unseen == set()
+    assert watched | handed | unseen == set(range(len(STOP_RULES)))
 
 
-def test_the_driver_watches_only_two_of_the_eight():
+def test_the_driver_watches_only_two_of_the_eight_on_its_own():
     """Claiming all eight would be the easy and wrong thing to do."""
     assert len(RULES_THIS_DRIVER_WATCHES) == 2
     assert len(STOP_RULES) == 8
+
+
+def test_the_rule_a_caller_can_hand_it_is_not_counted_as_watched():
+    """A seam that a caller may decline to use is not the same as enforcement.
+
+    Rule 0 moved out of "cannot see" when ``stop_when`` was added, and the
+    temptation at that moment is to move it into "watches" — which would read
+    as three rules enforced whatever the caller does. It is one rule enforced
+    when the caller wires it, and the two dicts keep those apart.
+
+    Rule 1 stays where it was. It is the neighbouring claim — a run switching
+    model on its own — and the voice really does hold that one, raising when
+    two replies in one conversation name two different models. Rule 0 is the
+    comparison against the pinned name, which nothing held.
+    """
+    assert set(RULES_A_CALLER_CAN_HAND_THIS_DRIVER) == {0}
+    assert 0 not in RULES_THIS_DRIVER_WATCHES
+    assert 0 not in RULES_THIS_DRIVER_CANNOT_SEE
+    assert 1 in RULES_THIS_DRIVER_CANNOT_SEE
 
 
 # ── the ordinary run ─────────────────────────────────────────────────────
@@ -518,3 +542,75 @@ def test_the_callback_sees_each_row_as_it_lands(tmp_path):
     seen = []
     _run(tmp_path, _tasks(3), _success, on_task=lambda tid, row: seen.append(tid))
     assert seen == ["task-0001", "task-0002", "task-0003"]
+
+
+# ── the rule a caller hands it ───────────────────────────────────────────
+
+
+def test_a_caller_can_stop_the_run_after_a_named_task(tmp_path):
+    outcome, _ = _run(
+        tmp_path,
+        _tasks(4),
+        _success,
+        stop_when=lambda task_id: (
+            StoppedEarly(
+                rule_index=0,
+                rule=STOP_RULES[0],
+                detail="a reply named a model the plan did not pin",
+                after_task=task_id,
+            )
+            if task_id == "task-0002"
+            else None
+        ),
+    )
+    assert outcome.stopped is not None
+    assert outcome.stopped.rule_index == 0
+    assert outcome.stopped.after_task == "task-0002"
+    assert outcome.summary["stopped_early"] is not None
+
+
+def test_the_task_that_tripped_it_is_still_in_the_record(tmp_path):
+    """The halt must not swallow the evidence for the halt.
+
+    Asked after the row is kept, so the run that stopped still shows what the
+    last task did. A check placed before the append would leave a record whose
+    final task is missing -- the one a reader would go looking for first.
+    """
+    seen: list[str] = []
+    outcome, _ = _run(
+        tmp_path,
+        _tasks(4),
+        _success,
+        on_task=lambda tid, row: seen.append(tid),
+        stop_when=lambda task_id: (
+            StoppedEarly(
+                rule_index=0,
+                rule=STOP_RULES[0],
+                detail="stopped here",
+                after_task=task_id,
+            )
+            if task_id == "task-0002"
+            else None
+        ),
+    )
+    assert [row["task_id"] for row in outcome.rows] == ["task-0001", "task-0002"]
+    assert seen == ["task-0001", "task-0002"]
+
+
+def test_a_run_with_no_stop_when_behaves_exactly_as_before(tmp_path):
+    outcome, _ = _run(tmp_path, _tasks(3), _success)
+    assert outcome.stopped is None
+    assert len(outcome.rows) == 3
+
+
+def test_a_stop_when_that_never_fires_does_not_shorten_the_run(tmp_path):
+    asked: list[str] = []
+
+    def never(task_id):
+        asked.append(task_id)
+        return None
+
+    outcome, _ = _run(tmp_path, _tasks(3), _success, stop_when=never)
+    assert outcome.stopped is None
+    assert len(outcome.rows) == 3
+    assert asked == ["task-0001", "task-0002", "task-0003"]

--- a/batch-runner/tests/test_run_agentic_v2_stage.py
+++ b/batch-runner/tests/test_run_agentic_v2_stage.py
@@ -33,6 +33,7 @@ import re
 import subprocess
 import sys
 import tempfile
+from decimal import Decimal
 from pathlib import Path
 
 import pytest
@@ -692,3 +693,422 @@ def test_a_rehearsal_collects_a_deliverable_for_every_task_onto_disk(tmp_path):
     assert len(collected) == 5
     for one in collected:
         assert "must not be scored as one" in one.read_text("utf-8")
+
+
+# ── Which model answered ──────────────────────────────────────────────────
+#
+# A deployment is an alias. What answers behind it carries its own name, the
+# voice reads that name out of every reply, and the run used to drop it along
+# with the voice at the end of each task. The receipt was then priced against
+# the alias, which is the right amount only if the two strings agree -- and
+# nothing kept was capable of showing whether they did.
+
+
+class _Spoke:
+    """A voice that has finished speaking, with only what the record reads.
+
+    The method names are the real voice's, and
+    :func:`test_the_stand_in_has_the_same_shape_as_the_voice_it_stands_in_for`
+    is what holds them to it. The first draft of this class invented
+    ``ledger_rows``; every test here passed, and the real
+    :class:`~core.agentic_v2_model_voice.AzureFoundryVoice` has ``ledger``.
+    The record would have raised ``AttributeError`` while being assembled --
+    on the first paid run, after the money was spent, in the one place that
+    writes down what it was spent on.
+    """
+
+    def __init__(self, resolved_model, rows, spent):
+        self.resolved_model = resolved_model
+        self._rows = rows
+        self._spent = spent
+
+    def ledger(self):
+        return [dict(row) for row in self._rows]
+
+    def spent_usd(self):
+        return self._spent
+
+
+def _call(*, price="0.40", model="gpt-5.4"):
+    return {
+        "turn": 1,
+        "requested_deployment": "gpt-5.4",
+        "resolved_model": model,
+        "input_tokens": 1000,
+        "output_tokens": 200,
+        "history_entries_sent": 0,
+        "price_usd": price,
+        "price_missing": price is None,
+    }
+
+
+def test_the_stand_in_has_the_same_shape_as_the_voice_it_stands_in_for():
+    """A stub shaped to the code proves the code agrees with the stub.
+
+    Every test below builds ``_Spoke`` rather than a real voice, because
+    reaching a real one needs a paid call. That trade is only safe while the
+    two have the same surface, and nothing else in this file checks it: the
+    stub is written by the same hand as the code it stands in for, so a
+    misremembered method name is invisible from both sides.
+
+    Checked against the real class rather than an instance, which needs no
+    client, no budget and no network.
+    """
+    from core.agentic_v2_model_voice import AzureFoundryVoice
+
+    for name in ("ledger", "spent_usd"):
+        assert callable(getattr(AzureFoundryVoice, name, None)), (
+            f"the record calls {name}() on a voice and the real voice has no "
+            "such method"
+        )
+    assert "resolved_model" in AzureFoundryVoice.__dataclass_fields__
+
+    invented = set(vars(_Spoke)) - {"__init__", "__module__", "__qualname__"}
+    invented -= {"__doc__", "__dict__", "__weakref__"}
+    for name in invented:
+        assert hasattr(AzureFoundryVoice, name), (
+            f"_Spoke exposes {name}(), which the real voice does not -- so a "
+            "test using it is testing something that cannot happen"
+        )
+
+
+def test_the_record_names_the_model_that_answered_and_not_the_one_asked_for():
+    """The whole point. The alias is already in chosen_settings."""
+    written = runner.model_calls_record(
+        {
+            ("task-1", 1): _Spoke(
+                "gpt-5.4-2026-08-01", [_call(model="gpt-5.4-2026-08-01")], None
+            )
+        },
+        pinned_model="gpt-5.4",
+    )
+
+    assert written["models_that_answered"] == ["gpt-5.4-2026-08-01"]
+    assert written["per_attempt"][0]["resolved_model"] == "gpt-5.4-2026-08-01"
+
+
+def test_one_run_answered_by_two_models_is_visible_rather_than_averaged():
+    """Recorded per attempt, because a single field could not show this.
+
+    The voice refuses a run whose replies change model mid-conversation, but
+    that guard is per voice and there is one voice per task. Two tasks in the
+    same stage answered by different models would pass every check inside the
+    conversation and still be two experiments reported as one.
+    """
+    written = runner.model_calls_record(
+        {
+            ("task-1", 1): _Spoke("gpt-5.4-2026-08-01", [_call()], None),
+            ("task-2", 1): _Spoke("gpt-5.4-2026-09-01", [_call()], None),
+        },
+        pinned_model="gpt-5.4",
+    )
+
+    assert written["models_that_answered"] == [
+        "gpt-5.4-2026-08-01",
+        "gpt-5.4-2026-09-01",
+    ]
+    assert len(written["per_attempt"]) == 2
+
+
+def test_an_attempt_with_an_unpriced_call_totals_nothing_rather_than_zero():
+    """Missing is partial. A zero would be averaged with real amounts."""
+    written = runner.model_calls_record(
+        {("task-1", 1): _Spoke("something-new", [_call(price=None)], None)},
+        pinned_model="gpt-5.4",
+    )
+
+    assert written["per_attempt"][0]["spent_usd"] is None
+    assert written["calls_with_no_price"] == 1
+    assert "is not zero" in written["what_no_price_means"]
+
+
+def test_the_calls_that_could_not_be_priced_are_counted_not_left_to_be_noticed():
+    """Across every attempt, so one bad call in 220 tasks is not buried."""
+    written = runner.model_calls_record(
+        {
+            ("task-1", 1): _Spoke("m", [_call(), _call(price=None)], None),
+            ("task-2", 1): _Spoke("m", [_call()], Decimal("0.40")),
+        },
+        pinned_model="gpt-5.4",
+    )
+
+    assert written["calls_with_no_price"] == 1
+    assert written["per_attempt"][1]["spent_usd"] == "0.40"
+
+
+def test_an_attempt_no_voice_spoke_for_is_left_out_rather_than_priced_at_zero():
+    """A refused attempt made no call. An empty row would read as a free one."""
+    written = runner.model_calls_record(
+        {("task-1", 1): None}, pinned_model="gpt-5.4"
+    )
+
+    assert written["per_attempt"] == []
+    assert written["models_that_answered"] == []
+
+
+def test_it_keeps_no_prompt_and_no_reply():
+    """Same rule as the rest of the script: names, counts and amounts only."""
+    written = runner.model_calls_record(
+        {("task-1", 1): _Spoke("gpt-5.4", [_call()], Decimal("0.40"))},
+        pinned_model="gpt-5.4",
+    )
+
+    allowed = {
+        "turn",
+        "requested_deployment",
+        "resolved_model",
+        "input_tokens",
+        "output_tokens",
+        "history_entries_sent",
+        "price_usd",
+        "price_missing",
+    }
+    for row in written["per_attempt"][0]["calls"]:
+        assert set(row) <= allowed, f"unexpected field: {set(row) - allowed}"
+
+
+def test_the_receipt_is_settled_against_what_the_reply_named():
+    """Read from the source, because reaching this needs a paid call.
+
+    Checked as text rather than behaviour on purpose, and narrowly: the
+    binding used to pass a literal ``resolved_model=None`` beside a deployment
+    it had every reason to believe was the answer. The ledger then filled its
+    own column from the alias and the receipt read as complete.
+    """
+    source = RUNNER_PATH.read_text("utf-8")
+    binding = source.split("def receipt_for(")[1].split("def ")[0]
+
+    assert "resolved_model=None" not in binding
+    assert "spoke.resolved_model" in binding
+
+
+def test_the_voice_that_spoke_for_an_attempt_is_still_reachable_afterwards():
+    """The voices are kept. Dropping them is what lost the name."""
+    source = RUNNER_PATH.read_text("utf-8")
+
+    assert "voices_by_budget[id(budget)] = voice" in source
+    assert "def voice_of(" in source
+
+
+@needs_dataset
+def test_a_rehearsal_names_no_model_because_none_answered(tmp_path):
+    """The section is present and empty, rather than absent.
+
+    Absent would have to be read as "not recorded"; empty says no model was
+    asked, which is the true state of a rehearsal and the one thing it must
+    never be mistaken for.
+    """
+    into = tmp_path / "rehearsal"
+
+    _run("--stage", "advance_check_5", "--rehearse", "--into", str(into))
+    record = json.loads((into / "rehearsal_record.json").read_text("utf-8"))
+
+    assert record["model_calls"]["models_that_answered"] == []
+    assert record["model_calls"]["per_attempt"] == []
+    assert record["model_calls"]["calls_with_no_price"] == 0
+    assert record["model_calls"]["answered_by_something_else"] == []
+    assert record["model_calls"]["attempts_that_reported_no_model"] == 0
+    # Present even here, so a reader of an empty section knows what the
+    # comparison would have been against rather than having to infer that
+    # there was one.
+    assert record["model_calls"]["pinned_model"] == "gpt-5.4"
+
+
+# ── The plan's first stop condition ───────────────────────────────────────
+#
+# "Stop at once if the model name or deployment name reported back differs
+# from the one fixed above."
+#
+# Written into the plan and implemented nowhere. The plan's `resolved_model`
+# was read in two places -- copied into the pre-registration record, and used
+# to price the estimate -- and compared against a reply in neither. Because
+# the estimate is priced from the same pinned name, an entirely different
+# model answering every call would have produced an estimate and a receipt
+# that agreed exactly: two numbers matching, neither touching the fact.
+
+
+def _voices(*names):
+    return [_Spoke(name, [_call()], Decimal("0.40")) for name in names]
+
+
+def test_the_pinned_model_answering_is_not_a_mismatch():
+    assert (
+        runner.answered_by_something_else(
+            _voices("gpt-5.4"), pinned_model="gpt-5.4"
+        )
+        == ()
+    )
+
+
+def test_a_different_name_coming_back_is_the_mismatch():
+    assert runner.answered_by_something_else(
+        _voices("gpt-5.4", "gpt-5.4-turbo"), pinned_model="gpt-5.4"
+    ) == ("gpt-5.4-turbo",)
+
+
+def test_a_reply_that_named_nothing_does_not_halt_the_run():
+    """Three states, and only one of them is a switch.
+
+    ``resolved_model`` is ``""`` when the reply carried no model field. The
+    rule is written about a name that *differs*; a provider omitting a header
+    is not a model switch, and ending a paid stage over one would be this code
+    inventing a stop condition rather than enforcing the written one. Counted
+    in the record instead — see the test below.
+    """
+    assert (
+        runner.answered_by_something_else(_voices(""), pinned_model="gpt-5.4")
+        == ()
+    )
+
+
+def test_a_voice_that_never_spoke_is_not_a_mismatch():
+    assert (
+        runner.answered_by_something_else([None], pinned_model="gpt-5.4")
+        == ()
+    )
+
+
+def test_a_plan_that_pins_no_model_has_no_claim_to_check():
+    """Deciding here what the run was allowed to be would be the wrong fix.
+
+    A plan with no pinned name is a gap in the plan. Inventing a comparison
+    against the deployment alias would hide it behind a check that passes.
+    """
+    assert (
+        runner.answered_by_something_else(
+            _voices("anything-at-all"), pinned_model=""
+        )
+        == ()
+    )
+
+
+def test_the_record_carries_the_pinned_name_beside_the_one_that_answered():
+    written = runner.model_calls_record(
+        {("task-1", 1): _Spoke("gpt-5.4-turbo", [_call()], Decimal("0.40"))},
+        pinned_model="gpt-5.4",
+    )
+
+    assert written["pinned_model"] == "gpt-5.4"
+    assert written["models_that_answered"] == ["gpt-5.4-turbo"]
+    assert written["answered_by_something_else"] == ["gpt-5.4-turbo"]
+
+
+def test_a_matching_run_says_so_rather_than_leaving_the_field_out():
+    written = runner.model_calls_record(
+        {("task-1", 1): _Spoke("gpt-5.4", [_call()], Decimal("0.40"))},
+        pinned_model="gpt-5.4",
+    )
+
+    assert written["answered_by_something_else"] == []
+    assert written["attempts_that_reported_no_model"] == 0
+
+
+def test_replies_that_named_no_model_are_counted_even_though_they_do_not_halt():
+    """Recorded, not enforced -- and the record says which.
+
+    Not halting is a decision, and a decision that leaves no trace reads
+    afterwards as a case nobody thought about.
+    """
+    written = runner.model_calls_record(
+        {
+            ("task-1", 1): _Spoke("", [_call()], Decimal("0.40")),
+            ("task-2", 1): _Spoke("gpt-5.4", [_call()], Decimal("0.40")),
+        },
+        pinned_model="gpt-5.4",
+    )
+
+    assert written["attempts_that_reported_no_model"] == 1
+    assert written["models_that_answered"] == ["gpt-5.4"]
+    assert written["answered_by_something_else"] == []
+    assert "not a model switch" in written["what_no_model_reported_means"]
+
+
+def test_the_halt_and_the_record_are_the_same_computation():
+    """So a run cannot stop for a reason its own record disagrees with.
+
+    Both read ``answered_by_something_else``. Two implementations of "did the
+    name differ" would be two chances to disagree, and the disagreement would
+    only ever show up in a run that had already stopped.
+    """
+    source = RUNNER_PATH.read_text("utf-8")
+    block = source.split("def wrong_model_answered(")[1].split("factory =")[0]
+
+    assert block.count("answered_by_something_else") == 1
+    assert "def cancel_requested()" in block
+    assert "def stop_when(" in block
+    assert "wrong_model_answered()" in block
+
+
+def test_both_seams_are_wired_because_they_stop_different_things():
+    """Read from the source: reaching either needs a paid call.
+
+    ``cancel_requested`` is read before every model turn and every tool call,
+    so the task that saw the wrong name does not take another turn -- that is
+    the one that saves money. ``stop_when`` is read between tasks, so the run
+    ends with the rule named instead of quietly finishing a manifest of
+    cancelled tasks -- that is the one that saves the record. Either alone is
+    wrong in a way that matters.
+    """
+    source = RUNNER_PATH.read_text("utf-8")
+    factory = source.split("factory = build_runner_factory(")[1].split(")")[0]
+    driving = source.split("outcome = run_manifest(")[1].split("except ")[0]
+
+    assert "cancel_requested=cancel_requested" in factory
+    assert "stop_when=stop_when" in driving
+
+
+def test_the_stop_names_the_rule_the_plan_wrote_rather_than_a_new_one():
+    """Rule 0 by index, out of STOP_RULES, not retyped.
+
+    A halt that quoted its own sentence would be a rule this code invented,
+    and the pre-registration would not contain it.
+    """
+    source = RUNNER_PATH.read_text("utf-8")
+    block = source.split("def stop_when(")[1].split("\n\n")[0]
+
+    assert "rule_index=0" in block
+    assert "STOP_RULES[0]" in block
+
+
+def test_it_enforces_the_reported_back_rule_and_not_its_neighbour():
+    """Rule 0 and rule 1 are adjacent and different, and the first draft of
+    this work implemented 0 while naming 1.
+
+    Rule 0 compares a reply against the name the plan pinned, which nothing
+    held. Rule 1 is a run switching on its own mid-conversation, which the
+    voice does hold -- it raises when two replies in one conversation name two
+    different models. Claiming 1 here would have moved a rule that already had
+    an enforcer and left the one with none still uncovered, while every test
+    went green.
+    """
+    from core.agentic_v2_preregistration import STOP_RULES
+
+    assert "reported back" in STOP_RULES[0]
+    assert "pinned" in STOP_RULES[0]
+    assert "on its own" in STOP_RULES[1]
+
+
+def test_the_plan_still_pins_a_model_for_the_comparison_to_use():
+    """The check is only as good as the name it compares against.
+
+    If the plan stopped pinning one, ``answered_by_something_else`` would
+    return nothing for every run and the stop condition would silently become
+    unenforced again -- passing, quietly, forever.
+    """
+    plan = yaml.safe_load(
+        runner.STAGE_ONE_PLAN_PATH.read_text(encoding="utf-8")
+    )
+
+    assert str(plan["model"]["resolved_model"]).strip()
+
+
+def test_the_written_rule_is_about_a_name_that_differs():
+    """Pinned because the implementation reads it narrowly on purpose.
+
+    An omitted name does not halt the run. That is defensible only while the
+    rule says *differs*; if it is ever rewritten to cover a missing name, this
+    fails and the narrow reading has to be revisited.
+    """
+    from core.agentic_v2_preregistration import STOP_RULES
+
+    assert "differs" in STOP_RULES[0].lower()


### PR DESCRIPTION
Two defects, one story. The first throws away the evidence; the second is the stop rule that needed it and was never implemented.

## The run did not keep which model answered

The voice reads the model name out of every reply and refuses the run if a later reply names a different one. Then the task ends, the voice is dropped, and the name goes with it.

So the receipt settled with `resolved_model=None` and the ledger filled its own column from the deployment alias. That is the right amount only if the alias and the answering model share a string, and the run kept nothing capable of showing whether they did. A deployment is an address; what stands behind it carries its own name and can be swapped without the address changing.

"Which model produced these 220 results" had no answer in the artifact, and after the run there is nowhere else to look.

Where the two strings agree, nothing changes. Where they do not, those calls now settle as `price_missing` — the true state, since the committed price list is an exact-match lookup with no entry for the model that answered. A figure worked out from a different model's rates is not a smaller error than a missing one, and it is the unrecoverable direction: tokens and name are both in the record now, so the amount can be derived later, whereas a name dropped at the end of a task is gone.

`spent_usd` is null for any attempt holding an unpriced call — all or nothing. A total that quietly drops what it could not price reads as the whole bill. Missing is partial, never zero.

## Stop rule 0 was written into the plan and implemented nowhere

> Stop at once if the model name or deployment name **reported back** differs from the one fixed above.

The plan's `resolved_model` was read in exactly two places — copied into the record, and used to price the estimate — and compared against a reply in neither.

The driver's own table of who-enforces-what attributed the rule to the model client. That client is built before any reply exists and can only see the name being *asked for*. The half of the rule that says *reported back* had no reader anywhere in the run.

It is also the failure that would have gone unnoticed. The estimate is priced from the same pinned name, so a wholly different model answering every call produces an estimate and a receipt that agree exactly: two numbers matching, neither touching the fact.

Worth saying plainly, since the two fields sit next to each other and could be read as two separate pinned names being cross-checked: today the plan pins `deployment: "gpt-5.4"` and `resolved_model: "gpt-5.4"` — the same string. That equality is the plan's *claim*, and the defect was that nothing anywhere compared it against a reply. The check now compares the claim against what came back, which is the comparison that was missing; it does not compare the plan against itself.

**Not rule 1**, which is the adjacent and different claim that a run switched on its own mid-conversation — the voice does hold that one. Relabelling rule 1 would have moved a rule that already had an enforcer and left the uncovered one still uncovered, with every test green. A test now pins which of the two this is.

## Wired into both seams, because they stop different things

| seam | stops | what it saves |
|---|---|---|
| `cancel_requested` | the running task, before its next turn | the money |
| `stop_when` | the run, with the rule named | the record |

Without the first, a halted run keeps paying for turns. Without the second, it finishes a manifest of cancelled tasks and reports `stopped_early` as nothing. One shared computation behind both, so the halt and the record cannot disagree about why.

`run_manifest` grows a third attribution dict, `RULES_A_CALLER_CAN_HAND_THIS_DRIVER`, kept separate from the two it has. A rule watched only when the caller wires it is not a rule the loop enforces, and listing it beside the unconditional ones would be the same overclaim that file exists to avoid.

## A missing name does not halt the run

The rule says *differs*. A provider omitting a field is not a model switch, and ending a paid stage over one would be this code inventing a stop condition rather than enforcing the written one.

It is counted instead, as `attempts_that_reported_no_model`, because a decision that leaves no trace reads afterwards as a case nobody thought about. Recorded, not enforced — and the record says which.

## The stand-in had the same wrong name as the code

The first draft called `voice.ledger_rows()`. The real voice has `ledger()`. Nine tests passed, because the stub was written by the same hand and carried the same mistake.

That `AttributeError` fires on the first paid run, while assembling the record, after the money is spent, in the one place that writes down what it was spent on. `_Spoke` is now held to the real class's surface in both directions by a test that needs no client, no budget and no network.

## Cost

None. No model call, no host started. The rehearsal shows the `model_calls` section present, empty, with the pinned name beside it — which is a rehearsal's true state and the one thing it must never be mistaken for.

Full backend suite on the final state: **11198 passed, 18 skipped, 0 failed**. The two changed suites are 54 and 38 of those.
