### PR TITLE
fix(v2): a halt was treated as one shard's business whichever rule it was

### DIFF
--- a/.github/workflows/agentic-v2-stage-run.yml
+++ b/.github/workflows/agentic-v2-stage-run.yml
@@ -252,6 +252,10 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      # Listing this run's own artifacts, so a shard can see whether a sibling
+      # already halted the run. Read-only and scoped to Actions; it grants no
+      # ability to write an artifact, a check or a commit.
+      actions: read
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
@@ -339,6 +343,52 @@ jobs:
           cd batch-runner
           python scripts/azure_ai_route_preflight.py
 
+      # ── Has a sibling already found out this run is not what it says? ──
+      #
+      # `fail-fast: false` above is right about most failures and wrong about
+      # five of the eight stop rules, and the difference is not severity. Those
+      # five trip on something every shard shares -- one deployment, one seal,
+      # one set of gates, one approved amount for the whole cohort. A sibling
+      # that halted on one of them has found out something about *this* shard
+      # too, and the tasks this job would add are tasks attributed to a run
+      # that cannot support them. Which five, and why each, is written down in
+      # `RULES_ABOUT_THE_WHOLE_RUN` beside the rules themselves.
+      #
+      # What this cannot do, said plainly so nobody reads it as more: it does
+      # not stop a shard that is already running. Jobs cannot cancel their
+      # siblings, and a job that is mid-conversation has already been charged.
+      # It stops the *next wave*. At `max-parallel: 4` a rule-0 halt in the two
+      # hundred and twenty costs about four shards instead of seventeen, which
+      # is a great deal better than seventeen and is not zero.
+      #
+      # `continue-on-error: true` below is load-bearing and it is also the soft
+      # spot. It has to be there: on the genuine first wave no artifact matches
+      # the pattern, the action treats that as an error, and without the flag
+      # the first shard of every stage would fail before it started. The cost
+      # is that a real failure -- `actions: read` dropped from the permissions
+      # block, a rate-limited API, a renamed artifact -- looks exactly the same
+      # from the next step. Nothing is downloaded, `sibling-records` is never
+      # created, and a missing directory is precisely how the first wave is
+      # meant to be allowed through. The refusal does not report a problem in
+      # that case; it silently becomes a no-op and every shard starts. The
+      # permission is pinned by a test for that reason, not for tidiness.
+      - name: Fetch what the other shards have reported
+        id: siblings
+        continue-on-error: true
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: agentic-v2-${{ inputs.stage }}-shard-*
+          path: sibling-records
+
+      - name: Refuse to start if one of them stopped the run
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          python scripts/check_agentic_v2_stage_coverage.py \
+            --records ../sibling-records \
+            --stage "${{ inputs.stage }}" \
+            --before-starting
+
       # `project-ci` because that is what the plan fixes, along with the account
       # and the project. The runner checks all three against the route it was
       # given and refuses after building the client and before asking it
@@ -399,9 +449,11 @@ jobs:
           if-no-files-found: warn
 
       # This reports on one shard, and says so. A green job here means this
-      # piece finished, not that the stage ran: that sentence is only earned
-      # once every shard has reported and `coverage_problems` has been shown
-      # nothing was run twice and nothing was missed.
+      # piece finished, not that the stage ran: that sentence is earned by the
+      # `collect` job below, which is what finally calls `coverage_problems`.
+      # It was named in this comment long before anything invoked it -- the
+      # function existed, was tested, and no step anywhere ran it, so "nothing
+      # was run twice and nothing was missed" was a claim with no checker.
       - name: Report what happened
         if: ${{ always() }}
         env:
@@ -418,3 +470,60 @@ jobs:
           echo "Shard $SHARD finished with $STAGE_EXIT. The stage is not" \
                "finished until every shard has reported."
           exit "$STAGE_EXIT"
+
+  # ── Did the stage run? ──────────────────────────────────────────────────
+  #
+  # The only job entitled to that sentence, and the reason it is a separate one:
+  # no shard can answer it. A shard knows its own tasks finished; whether the
+  # cohort was covered exactly once, and whether anybody halted on something
+  # that puts the rest in question, are facts about the set.
+  #
+  # `always()`, because the interesting case is the one where a shard failed.
+  # A collect step that only ran on success would be silent in exactly the
+  # situation it exists for.
+  #
+  # It writes nothing, charges nothing and fetches no dataset -- the cohort
+  # comes from the committed catalogue, which is the list the run was bound to.
+  collect:
+    name: Did the stage run?
+    needs: paid
+    if: ${{ always() && inputs.mode == 'paid' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      # No `id-token`. This job never reaches Azure and must not be able to:
+      # it is the one that decides whether the stage ran, and a checker that
+      # could also spend is a checker with something to protect.
+      actions: read
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: batch-runner/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          pip install -r requirements.txt
+
+      - name: Fetch every shard's record
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: agentic-v2-${{ inputs.stage }}-shard-*
+          path: shard-records
+
+      # Fails when the stage did not run, which includes the case where every
+      # shard was green and one task was missed. A count would have passed that.
+      - name: Check coverage and halts
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          python scripts/check_agentic_v2_stage_coverage.py \
+            --records ../shard-records \
+            --stage "${{ inputs.stage }}" \
+            --collect

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ batch-runner/scripts/*
 !batch-runner/scripts/check_execution_envelope_advance_check.py
 !batch-runner/scripts/check_agentic_stage_one_ceiling.py
 !batch-runner/scripts/check_agentic_containment.py
+!batch-runner/scripts/check_agentic_v2_stage_coverage.py
 !batch-runner/scripts/build_gdpval_task_catalog.py
 !batch-runner/scripts/build_gold_deliverable_manifest.py
 !batch-runner/scripts/analyze_gold_ceiling.py

--- a/batch-runner/core/agentic_v2_preregistration.py
+++ b/batch-runner/core/agentic_v2_preregistration.py
@@ -444,6 +444,72 @@ STOP_RULES: tuple[str, ...] = (
     "reach the next",
 )
 
+#: Stop rules whose trigger is a fact about the run, not about one shard.
+#:
+#: A stage above five tasks is run as a matrix of shards, and that matrix sets
+#: ``fail-fast: false`` on a deliberate argument: a shard that failed has
+#: already been charged for the turns it made, and cancelling its siblings
+#: throws away work that was paid for. That argument is right for most of the
+#: eight. It is wrong for these, and the difference is not about severity.
+#:
+#: These five trip on something every shard shares -- one deployment, one seal,
+#: one set of gates, one approved amount for the whole cohort. A sibling's halt
+#: is therefore evidence about *this* shard as well, and the sixteen jobs still
+#: to come are not "results that were paid for": they are spend producing
+#: records that say something the run cannot support. Rule 0 is the plainest
+#: case. If the deployment answered under a name the plan does not pin, it will
+#: answer under that name for every remaining shard, and each one adds tasks
+#: attributed to a model that did not do them.
+#:
+#: The other three are classified below rather than left out, so that a ninth
+#: rule cannot join the tuple and default quietly to the permissive answer.
+#:
+#: Out of scope here on purpose: this says which halts propagate, not what
+#: happens to a stage afterwards. Even a per-shard halt leaves the stage
+#: unfinished, and :func:`~core.agentic_v2_sharding.coverage_problems` is what
+#: refuses to call it run.
+RULES_ABOUT_THE_WHOLE_RUN: dict[int, str] = {
+    0: "every shard is asked through the same deployment, so a reply that "
+    "named something other than the pinned model is not one shard's bad luck",
+    1: "the switch is in the thing all the shards are talking to",
+    2: "there is one pre-registration and one seal over it; a seal that no "
+    "longer verifies did not stop verifying for one shard only",
+    3: "the gates are in the checked-out source, identical in every job, so a "
+    "gate found open is open in all of them",
+    4: "the approved amount is for the whole cohort and never per shard -- "
+    "which is the point of pricing a stage rather than a job. Sixteen shards "
+    "that are each 'within budget' are how the approval gets spent several "
+    "times over",
+}
+
+#: Stop rules that really are one shard's own business.
+#:
+#: The same test as above, applied honestly rather than cautiously. For these
+#: the matrix's ``fail-fast: false`` comment is exactly right: a failed shard is
+#: a finding and the other sixteen are still results.
+#:
+#: Rule 5 is the arguable one and is written down as arguable. A ledger that
+#: cannot be written may be one runner's disk, which says nothing about
+#: another's, or it may be a broken path that every shard will hit -- in which
+#: case every shard halts on its own and nothing needed propagating. Stopping
+#: fifteen paid-for shards on the strength of the weaker reading is the more
+#: expensive way to be wrong, and it is the reading this entry declines.
+RULES_THAT_ARE_ONE_SHARDS_OWN: dict[int, str] = {
+    5: "one runner failing to write its ledger says nothing about another "
+    "runner's disk; if the cause is shared, each shard finds it unaided",
+    6: "three consecutive runner defects is a fact about this code on this "
+    "shard's tasks, and the next shard's tasks are different ones",
+    7: "the guest is this job's, and so is its failure to come clean",
+}
+
+if (set(RULES_ABOUT_THE_WHOLE_RUN) | set(RULES_THAT_ARE_ONE_SHARDS_OWN)) != set(
+    range(len(STOP_RULES))
+) or (set(RULES_ABOUT_THE_WHOLE_RUN) & set(RULES_THAT_ARE_ONE_SHARDS_OWN)):
+    raise RuntimeError(  # pragma: no cover - import guard
+        "a stop rule was added, removed or classified twice without deciding "
+        "whether a sibling shard's halt is evidence about the rest of the run"
+    )
+
 #: Things that are results and are recorded as such. Written down beside the
 #: stop rules because the temptation is to treat a bad number as a fault.
 NOT_STOP_RULES: tuple[str, ...] = (
@@ -1271,6 +1337,19 @@ def record(catalog: TaskCatalog | None = None) -> dict[str, Any]:
             "residual_after_alignment": residual_after_alignment(comparisons),
         },
         "stop_rules": list(STOP_RULES),
+        # Which of them a sibling shard's halt is evidence about. In the record
+        # rather than only in the source because it decides whether a stage
+        # with one halted shard has sixteen usable results or none, and that is
+        # a question asked at the grading table, by somebody holding the record
+        # and not the code.
+        "stop_rules_about_the_whole_run": {
+            STOP_RULES[index]: why
+            for index, why in sorted(RULES_ABOUT_THE_WHOLE_RUN.items())
+        },
+        "stop_rules_that_are_one_shards_own": {
+            STOP_RULES[index]: why
+            for index, why in sorted(RULES_THAT_ARE_ONE_SHARDS_OWN.items())
+        },
         "not_stop_rules": list(NOT_STOP_RULES),
         "what_this_is_not": _what_this_is_not(),
     }

--- a/batch-runner/core/agentic_v2_shard_collection.py
+++ b/batch-runner/core/agentic_v2_shard_collection.py
@@ -1,0 +1,230 @@
+"""Whether a set of finished shards may be called the stage, and what a halt meant.
+
+Three things were true of the sharded path and none of them was visible from
+inside a shard.
+
+**`coverage_problems` had no caller.** The workflow comment says the sentence
+"the stage ran" is earned "once every shard has reported and ``coverage_problems``
+has been shown nothing was run twice and nothing was missed". The function
+exists, is tested, and was invoked by nothing that runs. A check named in a
+comment and wired to nothing is the same defect as a stop rule written into a
+plan and implemented nowhere, and it fails the same way: silently, in the
+direction that flatters the run.
+
+**Nothing outside the driver read ``stopped_early``.** A shard that halted wrote
+the rule into its record and exited non-zero, and then no step anywhere opened
+that record. A stage with one halted shard and sixteen green ones could be
+collected and read as a stage that finished.
+
+**A halt was treated as one shard's business whichever rule it was.** The
+matrix sets ``fail-fast: false`` on a good argument -- a shard that failed was
+already charged for the turns it made, and cancelling its siblings throws away
+paid-for work. That argument holds for a runner defect and does not hold for a
+reply that named the wrong model, because the deployment is the same one every
+other shard is about to ask. ``RULES_ABOUT_THE_WHOLE_RUN`` is where that split
+is written down and argued; this module is what reads it.
+
+**What this deliberately does not do.** It does not stop a shard that is already
+running. Nothing here can: the jobs are concurrent and a job cannot cancel a
+sibling. What :func:`siblings_that_stopped_the_run` offers is narrower and worth
+stating as narrow -- a shard *about to start* can decline to, so a halt in one
+wave stops the waves after it. At ``max-parallel: 4`` that bounds a rule-0 halt
+in the two hundred and twenty to about four shards' spend instead of seventeen.
+It is not zero and must not be described as zero.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from core.agentic_v2_preregistration import (
+    RULES_ABOUT_THE_WHOLE_RUN,
+    RULES_THAT_ARE_ONE_SHARDS_OWN,
+    STOP_RULES,
+)
+from core.agentic_v2_sharding import Shard, coverage_problems
+
+#: The file each shard leaves behind, inside its own artifact directory.
+RUN_RECORD_NAME = "run_record.json"
+
+
+class ShardRecordUnreadable(ValueError):
+    """Raised for a record that cannot be made to mean anything.
+
+    Deliberately not a return value. Every other disagreement in this module is
+    reported as a problem string so that all of them can be shown at once, but a
+    record that will not parse is not a finding about the run -- it is this code
+    being unable to look. Telling the two apart matters, because "the stage is
+    fine" and "the stage could not be checked" are read very differently and a
+    list of strings makes them look the same.
+    """
+
+
+def read_shard_records(directory: Path) -> list[tuple[str, dict[str, Any]]]:
+    """Every shard record under ``directory``, with the folder it came from.
+
+    The artifacts download one folder per shard, named for the shard, and the
+    folder name is kept because it is the only thing a person can use to find
+    the job again. The record's own ``shard.index`` is what the checks use;
+    where the two disagree that is itself worth seeing, so neither is discarded
+    in favour of the other.
+    """
+    found: list[tuple[str, dict[str, Any]]] = []
+    for path in sorted(directory.rglob(RUN_RECORD_NAME)):
+        try:
+            body = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as problem:
+            raise ShardRecordUnreadable(
+                f"{path} could not be read as a run record: {problem}"
+            ) from problem
+        if not isinstance(body, Mapping):
+            raise ShardRecordUnreadable(
+                f"{path} parsed to {type(body).__name__} and not an object"
+            )
+        found.append((path.parent.name, dict(body)))
+    return found
+
+
+def _shard_of(record: Mapping[str, Any]) -> Shard:
+    piece = record.get("shard")
+    if not isinstance(piece, Mapping):
+        raise ShardRecordUnreadable(
+            "a run record has no `shard` object, so there is no way to say "
+            "which piece of the cohort it covered"
+        )
+    try:
+        return Shard(
+            index=int(piece["index"]),
+            of=int(piece["of"]),
+            task_ids=tuple(str(task_id) for task_id in piece["task_ids"]),
+            cohort_size=int(piece["cohort_size"]),
+        )
+    except (KeyError, TypeError, ValueError) as problem:
+        raise ShardRecordUnreadable(
+            f"a run record's `shard` object is not usable: {problem}"
+        ) from problem
+
+
+def _halt_in(record: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    run = record.get("run")
+    if not isinstance(run, Mapping):
+        return None
+    stopped = run.get("stopped_early")
+    return stopped if isinstance(stopped, Mapping) else None
+
+
+def _rule_index_of(halt: Mapping[str, Any]) -> int | None:
+    """Which of the eight, by index, or ``None`` if the record does not say.
+
+    Prefers the recorded index and falls back to matching the rule text, because
+    the index is what the classification is keyed on and the text is what
+    survives a record being read by something that does not have this code.
+    Returns ``None`` rather than guessing when neither is usable: an
+    unrecognised halt is handled by the caller as the most serious case, and a
+    wrong guess here would quietly make it the least serious one.
+    """
+    index = halt.get("rule_index")
+    if isinstance(index, int) and 0 <= index < len(STOP_RULES):
+        return index
+    text = str(halt.get("rule") or "").strip()
+    for position, rule in enumerate(STOP_RULES):
+        if rule == text:
+            return position
+    return None
+
+
+def siblings_that_stopped_the_run(
+    records: Iterable[tuple[str, Mapping[str, Any]]],
+) -> list[str]:
+    """Reasons a shard that has not started yet should not start.
+
+    Only the halts that are facts about the whole run. A sibling that hit three
+    runner defects, or could not write its ledger, or left a guest dirty, is a
+    finding about itself and is no reason to refuse a shard whose tasks,
+    runner and guest are all different ones.
+
+    An unrecognised halt counts. A record naming a rule this code cannot place
+    is either a rule that was added without this classification being revisited
+    or a record this code does not understand, and both are reasons to stop
+    rather than to carry on spending.
+    """
+    reasons: list[str] = []
+    for name, record in records:
+        halt = _halt_in(record)
+        if halt is None:
+            continue
+        index = _rule_index_of(halt)
+        detail = str(halt.get("detail") or "").strip()
+        if index is None:
+            reasons.append(
+                f"shard {name} stopped on a rule this code cannot place "
+                f"({halt.get('rule')!r}). An unplaced rule is treated as a "
+                f"fact about the whole run, because the alternative is to "
+                f"keep spending on the strength of not recognising it"
+                + (f": {detail}" if detail else "")
+            )
+            continue
+        if index not in RULES_ABOUT_THE_WHOLE_RUN:
+            continue
+        reasons.append(
+            f"shard {name} stopped on rule {index}, {STOP_RULES[index]}. "
+            f"{RULES_ABOUT_THE_WHOLE_RUN[index]}"
+            + (f". {detail}" if detail else "")
+        )
+    return reasons
+
+
+def stage_problems(
+    records: Sequence[tuple[str, Mapping[str, Any]]],
+    *,
+    task_ids: Sequence[str],
+) -> list[str]:
+    """Every reason this set of shards is not the stage it was meant to be.
+
+    Coverage and halts together, because they are the same question asked twice.
+    Coverage asks whether every task was run once; halts ask whether what ran
+    was the run that was registered. A stage needs both, and a check that
+    answered only the first would pass a cohort answered throughout by the
+    wrong model.
+    """
+    problems: list[str] = []
+    if not records:
+        return ["no shard record was found, so nothing here can say what ran"]
+
+    problems.extend(
+        coverage_problems(
+            [_shard_of(record) for _, record in records], task_ids=task_ids
+        )
+    )
+
+    for name, record in records:
+        halt = _halt_in(record)
+        if halt is None:
+            continue
+        index = _rule_index_of(halt)
+        detail = str(halt.get("detail") or "").strip()
+        if index is None:
+            problems.append(
+                f"shard {name} stopped on a rule this code cannot place "
+                f"({halt.get('rule')!r})"
+                + (f": {detail}" if detail else "")
+            )
+        elif index in RULES_ABOUT_THE_WHOLE_RUN:
+            problems.append(
+                f"shard {name} stopped on rule {index}, {STOP_RULES[index]} -- "
+                f"which is not one shard's own: "
+                f"{RULES_ABOUT_THE_WHOLE_RUN[index]}. The other shards' results "
+                f"are in question too"
+                + (f". {detail}" if detail else "")
+            )
+        else:
+            problems.append(
+                f"shard {name} stopped on rule {index}, {STOP_RULES[index]}. "
+                f"This one is the shard's own -- "
+                f"{RULES_THAT_ARE_ONE_SHARDS_OWN[index]} -- so the other "
+                f"shards' results stand, but this shard's tasks did not all run"
+                + (f". {detail}" if detail else "")
+            )
+    return problems

--- a/batch-runner/scripts/check_agentic_v2_stage_coverage.py
+++ b/batch-runner/scripts/check_agentic_v2_stage_coverage.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Decide whether a set of finished shards may be called the stage.
+
+Two jobs, because they are asked at two different moments and the wrong one at
+the wrong moment is useless.
+
+``--before-starting`` is asked by a shard that has not run yet, against whatever
+its siblings have already uploaded. It refuses only on the halts that are facts
+about the whole run -- a wrong model name, a broken seal, an open gate, a budget
+already past -- and exits 0 on everything else. It cannot stop a shard that is
+already running; what it stops is the next wave. At ``max-parallel: 4`` that is
+the difference between four shards' spend and seventeen.
+
+``--collect`` is asked once, after every shard has reported. It is the check the
+workflow comment has always said earns the sentence "the stage ran", and until
+now nothing invoked it: every task covered exactly once, and no shard stopped on
+a rule that puts the others in question.
+
+Neither needs the dataset. The cohort comes from the committed catalogue, which
+is the same list the run was bound to, so this can be answered in a bookkeeping
+job with nothing fetched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.agentic_v2_preregistration import (  # noqa: E402
+    ESCALATION,
+    STAGE_SIZES,
+    cohorts,
+)
+from core.agentic_v2_shard_collection import (  # noqa: E402
+    ShardRecordUnreadable,
+    read_shard_records,
+    siblings_that_stopped_the_run,
+    stage_problems,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--records",
+        type=Path,
+        required=True,
+        help=(
+            "directory holding one folder per shard, each with a "
+            "run_record.json. Searched recursively, so the layout "
+            "actions/download-artifact produces works unchanged."
+        ),
+    )
+    parser.add_argument("--stage", required=True, choices=sorted(STAGE_SIZES))
+    what = parser.add_mutually_exclusive_group(required=True)
+    what.add_argument(
+        "--before-starting",
+        action="store_true",
+        help=(
+            "refuse to start this shard if a sibling already halted on "
+            "something that is true of the whole run"
+        ),
+    )
+    what.add_argument(
+        "--collect",
+        action="store_true",
+        help="say whether the finished shards are the stage",
+    )
+    args = parser.parse_args(argv)
+
+    if args.stage not in ESCALATION:  # pragma: no cover - argparse covers it
+        print(f"{args.stage!r} is not a registered stage", file=sys.stderr)
+        return 2
+
+    # A missing directory is not the same as an empty one and the two must not
+    # be answered alike. Before starting, no siblings have uploaded anything yet
+    # on the first wave, and that is the normal case; collecting, a missing
+    # directory means the artifacts did not arrive and the stage cannot be
+    # spoken for at all.
+    if not args.records.is_dir():
+        if args.before_starting:
+            print(
+                f"No sibling records under {args.records}. Nothing has halted "
+                "that this shard can see, so it starts."
+            )
+            return 0
+        print(
+            f"{args.records} does not exist, so no shard record was found and "
+            "nothing here can say what ran.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        records = read_shard_records(args.records)
+    except ShardRecordUnreadable as unreadable:
+        # Never a pass. A record this code cannot read is a record nobody has
+        # checked, and the cheapest wrong answer here is the reassuring one.
+        print(f"A shard record could not be read: {unreadable}", file=sys.stderr)
+        return 1
+
+    if args.before_starting:
+        reasons = siblings_that_stopped_the_run(records)
+        if not reasons:
+            print(
+                f"{len(records)} sibling record(s) read, none halted on "
+                "anything that is true of the whole run. Starting."
+            )
+            return 0
+        print("This shard will not start.\n", file=sys.stderr)
+        for reason in reasons:
+            print(f"  - {reason}", file=sys.stderr)
+        print(
+            "\nThese are the stop rules whose trigger is shared by every "
+            "shard, so running this one would add tasks to a record the run "
+            "cannot support. Shards already in flight are not stopped by "
+            "this: they were charged for their turns before it could be "
+            "asked.",
+            file=sys.stderr,
+        )
+        return 1
+
+    problems = stage_problems(records, task_ids=cohorts()[args.stage])
+    if problems:
+        print(f"{args.stage} has not run.\n", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+
+    covered = sum(len(record["shard"]["task_ids"]) for _, record in records)
+    print(
+        f"{args.stage} ran: {len(records)} shards covered {covered} tasks, "
+        "each exactly once, and none stopped early."
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/batch-runner/tests/test_agentic_v2_shard_collection.py
+++ b/batch-runner/tests/test_agentic_v2_shard_collection.py
@@ -1,0 +1,555 @@
+"""A halt is not always the halting shard's own business.
+
+Three defects in the sharded path, and the tests below are grouped by which.
+
+The matrix's ``fail-fast: false`` is correct for most of the eight stop rules
+and wrong for five of them, and the difference is not severity: it is whether
+the thing that tripped is shared by every shard. These check that the split is
+argued rather than assumed, that a whole-run halt actually stops the next wave,
+and that the stage-level check exists at all -- ``coverage_problems`` was
+written, tested, named in the workflow comment as the thing that earns the
+sentence "the stage ran", and called by nothing that runs.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+SCRIPTS = BATCH_RUNNER_ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import check_agentic_v2_stage_coverage as checker  # noqa: E402
+from core.agentic_v2_preregistration import (  # noqa: E402
+    RULES_ABOUT_THE_WHOLE_RUN,
+    RULES_THAT_ARE_ONE_SHARDS_OWN,
+    STOP_RULES,
+    cohorts,
+)
+from core.agentic_v2_shard_collection import (  # noqa: E402
+    ShardRecordUnreadable,
+    read_shard_records,
+    siblings_that_stopped_the_run,
+    stage_problems,
+)
+
+COHORT = cohorts()["trial_30"]
+
+
+def _record(index: int, of: int, *, halt: dict | None = None) -> dict:
+    """One shard's record, split the way the runner splits: by stride."""
+    mine = tuple(COHORT[index - 1 :: of])
+    return {
+        "stage": "trial_30",
+        "shard": {
+            "index": index,
+            "of": of,
+            "task_count": len(mine),
+            "cohort_size": len(COHORT),
+            "task_ids": list(mine),
+            "covers_whole_stage": of == 1,
+        },
+        "run": {
+            "run_id": f"r{index}",
+            "results": [],
+            "summary": {},
+            "stopped_early": halt,
+            "skipped_on_resume": [],
+        },
+    }
+
+
+def _halt(index: int, detail: str = "a detail") -> dict:
+    return {
+        "rule_index": index,
+        "rule": STOP_RULES[index],
+        "detail": detail,
+        "after_task": COHORT[0],
+    }
+
+
+def _written(tmp_path: Path, records: list[dict]) -> Path:
+    """Laid out the way actions/download-artifact leaves them."""
+    root = tmp_path / "downloaded"
+    for record in records:
+        folder = root / f"agentic-v2-trial_30-shard-{record['shard']['index']}"
+        folder.mkdir(parents=True)
+        (folder / "run_record.json").write_text(
+            json.dumps(record, indent=2), encoding="utf-8"
+        )
+    return root
+
+
+# ── the split itself ──────────────────────────────────────────────────────
+
+
+def test_every_stop_rule_is_on_exactly_one_side_of_the_split():
+    """The guard that makes a ninth rule a decision rather than a default.
+
+    Without it, a rule added to the tuple would be absent from both dicts and
+    treated as the shard's own -- the permissive answer, arrived at by nobody.
+    """
+    whole = set(RULES_ABOUT_THE_WHOLE_RUN)
+    own = set(RULES_THAT_ARE_ONE_SHARDS_OWN)
+
+    assert whole | own == set(range(len(STOP_RULES)))
+    assert not (whole & own)
+
+
+def test_the_rule_about_the_model_that_answered_is_not_a_shards_own():
+    """Rule 0 is the case the whole split exists for.
+
+    One deployment answers every shard. A reply naming something the plan does
+    not pin will name it again for the sixteen still to come.
+    """
+    assert 0 in RULES_ABOUT_THE_WHOLE_RUN
+    assert 0 not in RULES_THAT_ARE_ONE_SHARDS_OWN
+
+
+def test_the_budget_rule_is_shared_because_the_amount_is_for_the_cohort():
+    """The approval prices a stage, never a job.
+
+    Sixteen shards each individually "within budget" is exactly how an approved
+    amount gets spent several times over.
+    """
+    assert 4 in RULES_ABOUT_THE_WHOLE_RUN
+    assert "cohort" in RULES_ABOUT_THE_WHOLE_RUN[4]
+
+
+def test_the_runner_defect_rule_stays_the_shards_own():
+    """Where `fail-fast: false` is right, nothing here overrides it.
+
+    Three consecutive runner defects is a fact about this code on this shard's
+    tasks. The next shard's tasks are different ones, and stopping it would
+    throw away work that was paid for -- which is the matrix comment's argument,
+    and it is correct here.
+    """
+    assert 6 in RULES_THAT_ARE_ONE_SHARDS_OWN
+    assert 6 not in RULES_ABOUT_THE_WHOLE_RUN
+
+
+def test_each_side_says_why_rather_than_only_which():
+    """A classification with no reason cannot be argued with, only obeyed."""
+    for why in list(RULES_ABOUT_THE_WHOLE_RUN.values()) + list(
+        RULES_THAT_ARE_ONE_SHARDS_OWN.values()
+    ):
+        assert len(why.split()) >= 8
+
+
+# ── stopping the next wave ────────────────────────────────────────────────
+
+
+def test_a_sibling_that_halted_on_the_model_name_stops_the_next_shard():
+    reasons = siblings_that_stopped_the_run(
+        [("shard-1", _record(1, 3, halt=_halt(0, "named gpt-4o")))]
+    )
+
+    assert len(reasons) == 1
+    assert "rule 0" in reasons[0]
+    assert "named gpt-4o" in reasons[0]
+
+
+def test_a_sibling_that_halted_on_its_own_trouble_does_not():
+    """The distinction the matrix comment gets right, kept."""
+    assert (
+        siblings_that_stopped_the_run(
+            [("shard-1", _record(1, 3, halt=_halt(6)))]
+        )
+        == []
+    )
+
+
+def test_a_sibling_that_finished_cleanly_stops_nothing():
+    assert siblings_that_stopped_the_run([("shard-1", _record(1, 3))]) == []
+
+
+def test_a_halt_on_a_rule_this_code_cannot_place_stops_the_next_shard():
+    """The unrecognised case resolves towards stopping, not towards spending.
+
+    A record naming a rule this code cannot place is either a ninth rule added
+    without revisiting the split or a record from something else entirely.
+    Both are reasons to stop rather than to carry on paying.
+    """
+    reasons = siblings_that_stopped_the_run(
+        [
+            (
+                "shard-1",
+                _record(
+                    1,
+                    3,
+                    halt={
+                        "rule_index": 99,
+                        "rule": "something nobody has written yet",
+                        "detail": "",
+                        "after_task": COHORT[0],
+                    },
+                ),
+            )
+        ]
+    )
+
+    assert len(reasons) == 1
+    assert "cannot place" in reasons[0]
+
+
+def test_a_halt_is_placed_by_its_text_when_the_index_is_unusable():
+    """Records outlive the code that wrote them.
+
+    The index is what the split is keyed on, but a record read by something
+    holding a different version of this tuple still carries the sentence.
+    """
+    reasons = siblings_that_stopped_the_run(
+        [
+            (
+                "shard-1",
+                _record(
+                    1,
+                    3,
+                    halt={
+                        "rule_index": None,
+                        "rule": STOP_RULES[0],
+                        "detail": "",
+                        "after_task": COHORT[0],
+                    },
+                ),
+            )
+        ]
+    )
+
+    assert len(reasons) == 1
+    assert "cannot place" not in reasons[0]
+    assert "rule 0" in reasons[0]
+
+
+# ── whether the stage ran ─────────────────────────────────────────────────
+
+
+def test_all_three_shards_covering_the_cohort_once_is_the_stage():
+    assert (
+        stage_problems(
+            [(f"shard-{i}", _record(i, 3)) for i in (1, 2, 3)], task_ids=COHORT
+        )
+        == []
+    )
+
+
+def test_a_missing_shard_is_not_the_stage_however_green_the_others_are():
+    problems = stage_problems(
+        [(f"shard-{i}", _record(i, 3)) for i in (1, 2)], task_ids=COHORT
+    )
+
+    assert problems
+    assert any("did not run" in problem for problem in problems)
+
+
+def test_a_whole_run_halt_puts_the_other_shards_results_in_question():
+    problems = stage_problems(
+        [
+            ("shard-1", _record(1, 3, halt=_halt(0))),
+            ("shard-2", _record(2, 3)),
+            ("shard-3", _record(3, 3)),
+        ],
+        task_ids=COHORT,
+    )
+
+    assert len(problems) == 1
+    assert "not one shard's own" in problems[0]
+    assert "other shards' results are in question" in problems[0]
+
+
+def test_a_shards_own_halt_is_reported_without_condemning_the_others():
+    """Both halves said, because only saying one of them misleads.
+
+    The other shards' results do stand. This shard's tasks still did not all
+    run, so the stage is still not the stage.
+    """
+    problems = stage_problems(
+        [
+            ("shard-1", _record(1, 3, halt=_halt(7))),
+            ("shard-2", _record(2, 3)),
+            ("shard-3", _record(3, 3)),
+        ],
+        task_ids=COHORT,
+    )
+
+    assert len(problems) == 1
+    assert "other shards' results stand" in problems[0]
+    assert "did not all run" in problems[0]
+
+
+def test_coverage_is_checked_against_the_cohort_and_not_against_itself():
+    """The check that only works with the real list.
+
+    Every other coverage question can be answered from the shards alone. "Was
+    anything missed" cannot: derive the expected set from what ran and the
+    answer is no by construction. This is why the cohort comes from the
+    committed catalogue rather than from the records.
+    """
+    shards = [(f"shard-{i}", _record(i, 3)) for i in (1, 2, 3)]
+
+    problems = stage_problems(shards, task_ids=list(COHORT) + ["a-task-nobody-ran"])
+
+    assert any("a-task-nobody-ran" in problem for problem in problems)
+
+
+def test_no_records_at_all_is_a_problem_and_not_an_empty_pass():
+    assert stage_problems([], task_ids=COHORT) == [
+        "no shard record was found, so nothing here can say what ran"
+    ]
+
+
+# ── reading what the shards left behind ───────────────────────────────────
+
+
+def test_records_are_found_wherever_the_download_action_put_them(tmp_path):
+    root = _written(tmp_path, [_record(i, 3) for i in (1, 2, 3)])
+
+    found = read_shard_records(root)
+
+    assert len(found) == 3
+    assert [name for name, _ in found] == [
+        "agentic-v2-trial_30-shard-1",
+        "agentic-v2-trial_30-shard-2",
+        "agentic-v2-trial_30-shard-3",
+    ]
+
+
+def test_an_unreadable_record_raises_rather_than_being_reported_as_fine(tmp_path):
+    """"Checked and clean" and "could not be checked" must not look alike."""
+    root = tmp_path / "downloaded" / "shard-1"
+    root.mkdir(parents=True)
+    (root / "run_record.json").write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(ShardRecordUnreadable):
+        read_shard_records(tmp_path / "downloaded")
+
+
+def test_a_record_with_no_shard_object_cannot_be_counted_as_coverage(tmp_path):
+    with pytest.raises(ShardRecordUnreadable):
+        stage_problems([("shard-1", {"run": {}})], task_ids=COHORT)
+
+
+# ── the script, end to end ────────────────────────────────────────────────
+
+
+def test_the_collect_mode_passes_a_stage_that_actually_ran(tmp_path, capsys):
+    root = _written(tmp_path, [_record(i, 3) for i in (1, 2, 3)])
+
+    code = checker.main(
+        ["--records", str(root), "--stage", "trial_30", "--collect"]
+    )
+
+    assert code == 0
+    assert "trial_30 ran" in capsys.readouterr().out
+
+
+def test_the_collect_mode_fails_a_stage_with_a_whole_run_halt(tmp_path, capsys):
+    root = _written(
+        tmp_path,
+        [_record(1, 3, halt=_halt(0)), _record(2, 3), _record(3, 3)],
+    )
+
+    code = checker.main(
+        ["--records", str(root), "--stage", "trial_30", "--collect"]
+    )
+
+    assert code == 1
+    assert "has not run" in capsys.readouterr().err
+
+
+def test_the_before_starting_mode_lets_the_first_wave_through(tmp_path, capsys):
+    """No siblings have uploaded yet, which is the normal first case.
+
+    A missing directory must not read as a problem here, or no stage could ever
+    begin.
+    """
+    code = checker.main(
+        [
+            "--records",
+            str(tmp_path / "nothing-here"),
+            "--stage",
+            "trial_30",
+            "--before-starting",
+        ]
+    )
+
+    assert code == 0
+    assert "so it starts" in capsys.readouterr().out
+
+
+def test_the_before_starting_mode_refuses_after_a_whole_run_halt(tmp_path, capsys):
+    root = _written(tmp_path, [_record(1, 3, halt=_halt(0))])
+
+    code = checker.main(
+        ["--records", str(root), "--stage", "trial_30", "--before-starting"]
+    )
+
+    captured = capsys.readouterr()
+    assert code == 1
+    assert "will not start" in captured.err
+    assert "already in flight are not stopped" in captured.err
+
+
+def test_the_before_starting_mode_starts_after_a_shards_own_halt(tmp_path, capsys):
+    root = _written(tmp_path, [_record(1, 3, halt=_halt(6))])
+
+    code = checker.main(
+        ["--records", str(root), "--stage", "trial_30", "--before-starting"]
+    )
+
+    assert code == 0
+    assert "none halted" in capsys.readouterr().out
+
+
+def test_a_missing_directory_is_a_failure_when_collecting(tmp_path, capsys):
+    """The same absence, answered oppositely, because it means opposite things.
+
+    Before starting it means nobody has finished yet. Collecting, it means the
+    artifacts never arrived and there is nothing to speak for.
+    """
+    code = checker.main(
+        [
+            "--records",
+            str(tmp_path / "nothing-here"),
+            "--stage",
+            "trial_30",
+            "--collect",
+        ]
+    )
+
+    assert code == 1
+    assert "nothing here can say what ran" in capsys.readouterr().err
+
+
+def test_an_unreadable_record_is_never_a_pass_in_either_mode(tmp_path, capsys):
+    root = tmp_path / "downloaded" / "shard-1"
+    root.mkdir(parents=True)
+    (root / "run_record.json").write_text("{not json", encoding="utf-8")
+
+    for mode in ("--before-starting", "--collect"):
+        code = checker.main(
+            [
+                "--records",
+                str(tmp_path / "downloaded"),
+                "--stage",
+                "trial_30",
+                mode,
+            ]
+        )
+        assert code == 1, mode
+        assert "could not be read" in capsys.readouterr().err
+
+
+def test_the_five_task_stage_is_one_shard_and_still_answerable(tmp_path, capsys):
+    """The stage the next paid run is, checked rather than assumed.
+
+    `advance_check_5` is a matrix of one, so none of the cross-shard trouble
+    above can reach it. That is a reason it is safe to run first, not a reason
+    the check should be skipped for it.
+    """
+    five = cohorts()["advance_check_5"]
+    folder = tmp_path / "downloaded" / "agentic-v2-advance_check_5-shard-1"
+    folder.mkdir(parents=True)
+    (folder / "run_record.json").write_text(
+        json.dumps(
+            {
+                "stage": "advance_check_5",
+                "shard": {
+                    "index": 1,
+                    "of": 1,
+                    "task_count": len(five),
+                    "cohort_size": len(five),
+                    "task_ids": list(five),
+                    "covers_whole_stage": True,
+                },
+                "run": {"stopped_early": None},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    code = checker.main(
+        [
+            "--records",
+            str(tmp_path / "downloaded"),
+            "--stage",
+            "advance_check_5",
+            "--collect",
+        ]
+    )
+
+    assert code == 0
+    assert "5 tasks" in capsys.readouterr().out
+
+
+# ── the wiring, which is the whole point ──────────────────────────────────
+#
+# `coverage_problems` was correct, tested and called by nothing for as long as
+# it existed. A test of the function would have stayed green through all of it.
+# These read the workflow.
+
+WORKFLOW = (
+    BATCH_RUNNER_ROOT.parent / ".github" / "workflows" / "agentic-v2-stage-run.yml"
+)
+
+
+def _workflow() -> dict:
+    import yaml
+
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def test_the_stage_coverage_check_is_actually_invoked_by_the_workflow():
+    assert "check_agentic_v2_stage_coverage.py" in WORKFLOW.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_a_shard_asks_before_starting_and_asks_before_it_runs():
+    """Order matters more than presence.
+
+    Asked after `Run` it would be a report. Asked before, it is a refusal, and
+    everything ahead of it in the job is free.
+    """
+    steps = [step.get("name") or "" for step in _workflow()["jobs"]["paid"]["steps"]]
+    refusal = steps.index("Refuse to start if one of them stopped the run")
+    assert refusal < steps.index("Run")
+
+
+def test_the_collect_job_runs_even_when_a_shard_failed():
+    """The case it exists for is the one where something went wrong.
+
+    `needs: paid` alone would skip it exactly then.
+    """
+    collect = _workflow()["jobs"]["collect"]
+    assert collect["needs"] == "paid"
+    assert "always()" in collect["if"]
+
+
+def test_the_job_that_judges_the_run_cannot_reach_azure():
+    """No `id-token`, so it cannot mint a session and cannot spend.
+
+    A checker that could also run the thing it judges is a checker with
+    something to protect.
+    """
+    assert "id-token" not in _workflow()["jobs"]["collect"]["permissions"]
+
+
+def test_the_shards_can_read_this_runs_artifacts_and_nothing_more():
+    """`actions: read` is what listing sibling artifacts needs.
+
+    Pinned because the refusal silently becomes a no-op without it: the
+    download fails, `continue-on-error` swallows it, the directory is missing,
+    and a missing directory is how the first wave legitimately starts.
+    """
+    paid = _workflow()["jobs"]["paid"]["permissions"]
+    assert paid["actions"] == "read"
+    assert "write" not in str(paid.get("actions", ""))

--- a/tasks/0822_saturday/v2_run_preregistration.json
+++ b/tasks/0822_saturday/v2_run_preregistration.json
@@ -737,7 +737,7 @@
     },
     "what_stops_a_task": "any per-task ceiling above, or the per-task budget, whichever comes first. A task stopped by a ceiling is recorded as stopped by that ceiling and is not a model failure"
   },
-  "seal": "023bdcbef172a23de10fdbc8648568358c1ee4c83def552389b343cd8db94867",
+  "seal": "7da8cc9ebdf94ca75f826fe15acf698d5f47deb41c06bd04aa949b71912f33c5",
   "stop_rules": [
     "the deployment or model reported back differs from the pinned one",
     "a run switches model or deployment on its own",
@@ -748,6 +748,18 @@
     "the runner-defect disposition is returned for three consecutive tasks, which means this code and not the work under test is producing the record",
     "the guest cannot be cleaned up between tasks, so one task's state could reach the next"
   ],
+  "stop_rules_about_the_whole_run": {
+    "a gate that this record says is shut reports itself open, without a reviewed change having opened it": "the gates are in the checked-out source, identical in every job, so a gate found open is open in all of them",
+    "a paid call is about to happen with no recorded budget, or recorded spending passes the approved amount": "the approved amount is for the whole cohort and never per shard -- which is the point of pricing a stage rather than a job. Sixteen shards that are each 'within budget' are how the approval gets spent several times over",
+    "a run switches model or deployment on its own": "the switch is in the thing all the shards are talking to",
+    "the deployment or model reported back differs from the pinned one": "every shard is asked through the same deployment, so a reply that named something other than the pinned model is not one shard's bad luck",
+    "the pre-registration seal no longer verifies against the recorded one": "there is one pre-registration and one seal over it; a seal that no longer verifies did not stop verifying for one shard only"
+  },
+  "stop_rules_that_are_one_shards_own": {
+    "the cost ledger cannot be written, so spend would go unattributed": "one runner failing to write its ledger says nothing about another runner's disk; if the cause is shared, each shard finds it unaided",
+    "the guest cannot be cleaned up between tasks, so one task's state could reach the next": "the guest is this job's, and so is its failure to come clean",
+    "the runner-defect disposition is returned for three consecutive tasks, which means this code and not the work under test is producing the record": "three consecutive runner defects is a fact about this code on this shard's tasks, and the next shard's tasks are different ones"
+  },
   "what_this_is": "what a V2 run is committed to before it starts. Committed ahead of execution so that a later result cannot be described as having been planned this way when it was not.",
   "what_this_is_not": [
     "not a statement that the environment is ready. No V2 task has run. What stage one registers is a run with exec_run shut and no guest booted, so the isolation is not exercised by it and no result from it is evidence that the sandbox contains anything",


### PR DESCRIPTION
Three things were true of the sharded path, and none of them was visible
from inside a shard.

── some halts are not the shard's ────────────────────────────────────────

The paid job is a matrix -- one shard for the five, three for the thirty,
seventeen for the two hundred and twenty -- and it sets `fail-fast: false`
on a good argument: a shard that failed has already been charged for the
turns it made, and cancelling its siblings throws away paid-for work.

That argument holds for a runner defect. It does not hold for a reply that
named the wrong model, and the difference is not severity. Five of the
eight stop rules trip on something every shard shares: one deployment, one
seal, one set of gates, one approved amount for the whole cohort. A
sibling's halt on one of those is evidence about *this* shard too, and the
sixteen jobs still to come are not results that were paid for -- they are
spend producing records the run cannot support.

Rule 0 is the plainest. If the deployment answered under a name the plan
does not pin, it answers under that name for every remaining shard, and
each one adds tasks attributed to a model that did not do them. Rule 4 is
the most expensive: the approved amount is for the cohort and never per
job, which is the point of pricing a stage. Sixteen shards that are each
"within budget" are how an approval gets spent several times over.

`RULES_ABOUT_THE_WHOLE_RUN` and `RULES_THAT_ARE_ONE_SHARDS_OWN` sit beside
the rules they classify, with a reason per entry, and a guard that the two
partition the tuple exactly. Both, rather than one and a default, so a
ninth rule cannot join and quietly land on the permissive answer.

Rules 5, 6 and 7 stay the shard's own. Rule 5 is the arguable one and is
written down as arguable: a ledger that cannot be written may be one
runner's disk, which says nothing about another's, or a broken path every
shard will hit -- in which case each finds it unaided. Stopping fifteen
paid-for shards on the weaker reading is the more expensive way to be
wrong.

The refusal runs before `Run` and after everything free, so a shard that
declines to start costs nothing. What it does NOT do, stated as narrow
because it will be quoted: it does not stop a shard already running. Jobs
cannot cancel siblings and a job mid-conversation has already been charged.
It stops the next wave. At `max-parallel: 4` that is roughly four shards'
spend instead of seventeen. Better than seventeen, and not zero.

Its other limit is written above the step. The sibling download carries
`continue-on-error: true`, which it must -- on a genuine first wave nothing
matches the pattern, the action calls that an error, and without the flag
the first shard of every stage would fail before starting. The cost is that
a real failure (the `actions: read` permission dropped, a rate-limited API,
a renamed artifact) is indistinguishable from it: nothing downloads, the
directory is absent, and an absent directory is how the first wave is
legitimately let through. The refusal then becomes a silent no-op. That is
why a test pins the permission.

── nothing outside the driver read `stopped_early` ───────────────────────

A shard that halted wrote the rule into its record and exited non-zero,
and then no step anywhere opened that record. A stage with one halted
shard and sixteen green ones could be collected and read as finished.

── `coverage_problems` had no caller ─────────────────────────────────────

The workflow comment says the sentence "the stage ran" is earned "once
every shard has reported and `coverage_problems` has been shown nothing
was run twice and nothing was missed". The function was written, was
tested, and was invoked by nothing that runs. The same defect as a stop
rule written into a plan and implemented nowhere, failing the same way:
silently, in the direction that flatters the run.

A `collect` job now asks it, on `always()` so that it speaks in the case
it exists for. It holds no `id-token`: the job that judges whether the
stage ran must not be able to run it.

Coverage is checked against the committed catalogue and not against the
records. Every other coverage question can be answered from the shards
alone; "was anything missed" cannot, because deriving the expected set
from what ran makes the answer no by construction.

── smaller things, in the same direction ─────────────────────────────────

An unreadable record raises rather than joining the list of problems.
"Checked and clean" and "could not be checked" read very differently and a
list of strings makes them look identical.

A halt naming a rule this code cannot place counts as a whole-run halt. It
is either a ninth rule added without revisiting the split or a record from
something else, and both are reasons to stop rather than to keep paying.

A missing records directory is a pass before starting and a failure when
collecting. The same absence means opposite things: nobody has finished
yet, versus the artifacts never arrived.

── what this costs and what it does not ──────────────────────────────────

No model call, no spend, no Azure reached. The new job fetches no dataset.

The pre-registration seal changed, because the classification goes into
the record -- whether a stage with one halted shard has sixteen usable
results or none is asked at the grading table by somebody holding the
record and not the code. Regenerated with the repository's own script; no
run has recorded the old seal, so nothing is invalidated by the change.

`.gitignore` gains one un-ignore line, since `batch-runner/scripts/*` is
ignored by default. Shared file, one line, no other entry touched.

`advance_check_5` is a matrix of one and none of this can reach it. That
is a reason the five can be run first, not a reason the check should be
skipped for it, and a test covers the one-shard case.

Full backend suite: 11231 passed, 18 skipped, 46 deselected, 0 failed.
mypy is clean on both new files; the 36 errors it reports are pre-existing
in files this branch does not touch.
