### PR TITLE
무료 점검이 한 번도 가보지 않은 길을 보증했습니다 — 첫 유료 실행의 중단 원인

### DIFF
--- a/.github/workflows/agentic-v2-stage-run.yml
+++ b/.github/workflows/agentic-v2-stage-run.yml
@@ -446,12 +446,20 @@ jobs:
       #
       # `if-no-files-found: warn` is not a shrug. The ledger file is created
       # when the ledger is opened, which is before the first call goes out and
-      # before any task runs, so an empty artifact means the run died earlier
-      # than that -- earlier than anything could be charged. The first paid
-      # dispatch, on 2026-09-11, was exactly this: it uploaded nothing because
-      # it crashed opening the ledger, and `collect` said so rather than
-      # calling five unrun tasks a stage. An empty artifact here is a claim
-      # about spend, and the claim is none.
+      # before any task runs. So nothing arriving here means the run died
+      # earlier than that -- earlier than anything could be charged.
+      #
+      # The first paid dispatch, on 2026-09-11, was exactly this. It crashed
+      # opening the ledger, `agentic-v2-run/` held no file to upload, and the
+      # run finished with zero artifacts: not an empty archive, none at all,
+      # which is what `warn` does with an empty directory. `collect` then
+      # refused to call five unrun tasks a stage, which is the behaviour this
+      # step is here to feed. Nothing uploaded is a claim about spend, and the
+      # claim is none.
+      #
+      # It is only that claim because of the ordering above. If the ledger were
+      # ever opened later than the first call, the same silence would mean the
+      # opposite, and nothing here would say so.
       #
       # Named per shard because artifact names have to be unique within a run,
       # and because a directory of seventeen indistinguishable `-run` archives

--- a/.github/workflows/agentic-v2-stage-run.yml
+++ b/.github/workflows/agentic-v2-stage-run.yml
@@ -154,6 +154,13 @@ jobs:
       # until then nothing in this job exercised the one part of the path that
       # had never run in CI at all. A cohort can be perfectly priced, sealed and
       # bound and still hand every task an empty directory.
+      #
+      # The last one was added after the first paid dispatch, on 2026-09-11,
+      # crashed on a constructor keyword. Every test above it passed that day,
+      # and the dry run below reported that every condition for the paid run
+      # was met, because none of them touched the paid branch. It holds the
+      # part of the paid setup a free job can reach, and it is the reason the
+      # dry run's claim is now narrower than it was.
       - name: Test the runner
         run: |
           set -euo pipefail
@@ -166,7 +173,8 @@ jobs:
             tests/test_free_checks_agree_on_the_loop.py \
             tests/test_agentic_v2_reference_staging.py \
             tests/test_agentic_v2_preregistration.py \
-            tests/test_run_agentic_v2_stage.py
+            tests/test_run_agentic_v2_stage.py \
+            tests/test_the_dry_run_certified_a_path_it_never_reached.py
 
       # No charge. The revision is the one the catalogue was built from and the
       # one every figure in the plan rests on; the binding hashes the wording it
@@ -435,6 +443,15 @@ jobs:
 
       # Before the report, and `always()`, because an unrecorded spend is the
       # one outcome with no way back. Cost missing is partial, never zero.
+      #
+      # `if-no-files-found: warn` is not a shrug. The ledger file is created
+      # when the ledger is opened, which is before the first call goes out and
+      # before any task runs, so an empty artifact means the run died earlier
+      # than that -- earlier than anything could be charged. The first paid
+      # dispatch, on 2026-09-11, was exactly this: it uploaded nothing because
+      # it crashed opening the ledger, and `collect` said so rather than
+      # calling five unrun tasks a stage. An empty artifact here is a claim
+      # about spend, and the claim is none.
       #
       # Named per shard because artifact names have to be unique within a run,
       # and because a directory of seventeen indistinguishable `-run` archives

--- a/batch-runner/scripts/run_agentic_stage_d_probe.py
+++ b/batch-runner/scripts/run_agentic_stage_d_probe.py
@@ -301,6 +301,33 @@ def build_record(
     }
 
 
+def the_paid_setup_a_dry_run_can_reach() -> list[str]:
+    """Load the part of the paid path that needs no Azure and no guest.
+
+    Returns what broke, empty when nothing did. A named function rather than a
+    block inside the dry run, because a block inside the dry run can only be
+    tested by running the dry run, and this script's dry run refuses on any
+    host that is not the one C2 booted on. That refusal is correct and it is
+    also why both of the existing dry-run tests stop several hundred lines
+    above here, against a missing artefact. A check nothing can execute is the
+    shape of the defect this is here to close, not a fix for it.
+
+    Two files, and only two. The route, the client, the Firecracker boot and
+    the probe's own tool list are reachable from neither this function nor the
+    job that calls it, and are not claimed to be.
+    """
+    problems: list[str] = []
+    for reading, load in (
+        ("the substrate manifest", lambda: AgenticV2SubstrateManifest.load(SUBSTRATE_MANIFEST)),
+        ("the price table", load_price_table),
+    ):
+        try:
+            load()
+        except Exception as broke:  # noqa: BLE001 - reported, not handled
+            problems.append(f"{reading} cannot be loaded: {broke!r}")
+    return problems
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Stage D: one paid task over one real guest per call."
@@ -389,9 +416,30 @@ def main(argv: list[str] | None = None) -> int:
     print()
 
     if args.dry_run:
+        # Reach what the paid path loads before speaking for it. This script
+        # had the same sentence, and the same shape, as the V2 stage runner:
+        # a `return 0` several hundred lines above a branch no free job has
+        # ever executed. On 2026-09-11 that shape cost the stage runner a paid
+        # dispatch, which died on a constructor keyword after its identity and
+        # route checks had passed.
+        broke = the_paid_setup_a_dry_run_can_reach()
+        if broke:
+            print("Dry run. Nothing was asked, nothing was booted and "
+                  "nothing was spent.\n")
+            for problem in broke:
+                print(f"  - {problem}")
+            print(
+                "\nThe paid run loads this after the model client is built, "
+                "so it would have failed there. Failing here instead."
+            )
+            return 1
         print(
             "Dry run. Nothing was asked, nothing was booted and nothing was "
-            "spent. Every condition for the paid run is met."
+            "spent. Every condition this job can reach is met, including the "
+            "substrate manifest and the price table the paid run loads.\n\n"
+            "It cannot reach the model or the machine. The route, the client, "
+            "the Firecracker boot and the probe itself are checked in the paid "
+            "run and nowhere else."
         )
         return 0
 

--- a/batch-runner/scripts/run_agentic_v2_stage.py
+++ b/batch-runner/scripts/run_agentic_v2_stage.py
@@ -409,6 +409,49 @@ def check_the_plan_priced_this_stage(plan: dict, stage: str, bound, catalog) -> 
     return pricing, list(pricing.problems)
 
 
+def open_the_ledger(into: Path, *, run_id: str):
+    """Open the sqlite ledger the paid run settles every call into.
+
+    One function rather than one call site, because the dry run opens it too --
+    against a directory it throws away -- and the point of that is that the two
+    cannot drift apart. The paid run reached this line for the first time ever
+    on 2026-09-11 and died on it: the constructor had grown a required
+    ``run_id`` keyword and this call had not, so the stage crashed after the
+    identity check, the route check and the cohort binding had all passed.
+
+    Nothing caught it earlier because nothing could. The dry run returned
+    several hundred lines above, having printed that every condition for the
+    paid run was met, and the paid branch it was speaking for had never been
+    executed -- not in CI, not in a test. A ``TypeError`` on a keyword argument
+    is the cheapest possible version of that gap. The expensive version is the
+    same gap one line further down, after the model has been asked.
+    """
+    from core.cost_receipts import CostReceiptLedger
+
+    return CostReceiptLedger(str(into / "cost_receipts.sqlite3"), run_id=run_id)
+
+
+def the_paid_setup_a_dry_run_can_reach(stage: str) -> list[str]:
+    """Run the paid path's setup against a throwaway directory.
+
+    Returns what broke, empty when nothing did. Called from the dry run, so the
+    free job pays for this class of mistake instead of the paid one.
+
+    It is deliberately not much: the ledger is the only part of the paid setup
+    that needs no Azure identity, and the free job holds none. The voice, the
+    route, the deployment and the conversation cannot be reached from here and
+    are not claimed to be. Saying which is the other half of the fix -- the
+    sentence this used to print claimed all of them.
+    """
+    with tempfile.TemporaryDirectory(prefix=f"agentic-v2-{stage}-dry-") as scratch:
+        try:
+            ledger = open_the_ledger(Path(scratch), run_id="dry-run")
+        except Exception as broke:  # noqa: BLE001 - reported, not handled
+            return [f"the paid run's cost ledger cannot be opened: {broke!r}"]
+        ledger.close()
+    return []
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Run one pre-registered Agentic Sandbox V2 stage."
@@ -605,9 +648,31 @@ def main() -> int:
     print()
 
     if args.dry_run:
+        # Reach the paid setup before speaking for it. The sentence below used
+        # to say every condition for the paid run was met, and on 2026-09-11 a
+        # paid run that had just been told exactly that died on the next part
+        # of the script the dry run never executes.
+        broke = the_paid_setup_a_dry_run_can_reach(args.stage)
+        if broke:
+            print("Dry run. Nothing was asked and nothing was spent.\n")
+            for problem in broke:
+                print(f"  - {problem}")
+            print(
+                "\nThis is a paid-run condition and it is not met, so the paid "
+                "run would have failed after its identity and route checks had "
+                "passed. Failing here instead."
+            )
+            return 1
         print(
             "Dry run. Nothing was asked and nothing was spent. Every condition "
-            "for the paid run is met."
+            "this job can reach is met: the plan, the seal, the cohort, the "
+            "amounts, the staged inputs, and the ledger the paid run settles "
+            "into.\n\n"
+            "It cannot reach the model. This job holds no Azure identity, so "
+            "the route, the deployment and the conversation itself are checked "
+            "in the paid job and nowhere else. A green dry run is not a "
+            "promise that the paid run will reach the model -- only that it "
+            "will not be stopped by anything checkable without one."
         )
         return 0
 
@@ -848,15 +913,15 @@ def main() -> int:
             ),
         )
 
-        from core.cost_receipts import CostReceiptLedger
-
         if rehearsing is not None:
             # Every task ends unaccounted, which is the true answer. A rehearsal
             # makes no call, and a ledger row saying $0 would be the one number
             # that reads as a measurement of a model that was never asked.
             receipt_for = lambda task, attempt: None  # noqa: E731
         else:
-            ledger = CostReceiptLedger(str(into / "cost_receipts.sqlite3"))
+            # Through the same helper the dry run calls, so this line cannot
+            # drift from the one that is supposed to be checking it.
+            ledger = open_the_ledger(into, run_id=run_id)
 
             def receipt_for(task, attempt: int):
                 outcome = held.outcome_of(task.task_id, attempt)

--- a/batch-runner/tests/test_run_agentic_stage_d_probe.py
+++ b/batch-runner/tests/test_run_agentic_stage_d_probe.py
@@ -495,3 +495,50 @@ def test_the_refusal_happens_without_an_azure_route_configured():
 
     assert finished.returncode == 1
     assert "Traceback" not in finished.stderr
+
+
+# ── what the dry run is allowed to say ────────────────────────────────────
+#
+# Both tests above stop on a missing artefact, several hundred lines above the
+# dry run's own exit. That is not a gap in them -- it is the C2 check doing its
+# job, and it is also why this script's dry run cannot be run to completion
+# anywhere except the host C2 booted on. For a long time the sentence it printed
+# there was "Every condition for the paid run is met", and nothing could have
+# contradicted it.
+#
+# On 2026-09-11 the V2 stage runner, which had the identical sentence and the
+# identical shape, sent out its first paid dispatch four minutes after a green
+# dry run and died on a constructor keyword in a branch no dry run executes. The
+# claim moved here for the same reason it moved there.
+
+
+def test_the_files_the_paid_run_loads_can_be_loaded():
+    """The substrate manifest and the price table, for real.
+
+    The two pieces of stage D's paid setup that need no Azure identity and no
+    booted guest -- so the only two the free job has any business vouching for.
+    """
+    assert runner.the_paid_setup_a_dry_run_can_reach() == []
+
+
+def test_a_file_that_will_not_load_is_reported_rather_than_waved_through(
+    monkeypatch,
+):
+    """A missing price table is a paid-run failure, found for nothing."""
+    monkeypatch.setattr(
+        runner, "SUBSTRATE_MANIFEST", Path("/nonexistent/capabilities.json")
+    )
+
+    problems = runner.the_paid_setup_a_dry_run_can_reach()
+
+    assert len(problems) == 1
+    assert "the substrate manifest cannot be loaded" in problems[0]
+
+
+def test_the_dry_run_no_longer_speaks_for_the_machine_or_the_model():
+    """It can reach neither, and now says so."""
+    source = RUNNER_PATH.read_text(encoding="utf-8")
+
+    assert "Every condition for the paid run is met" not in source
+    assert "Every condition this job can reach is met" in source
+    assert "It cannot reach the model or the machine" in source

--- a/batch-runner/tests/test_run_agentic_v2_stage.py
+++ b/batch-runner/tests/test_run_agentic_v2_stage.py
@@ -114,7 +114,7 @@ def test_every_registered_stage_is_priced_and_dry_runs_to_zero(stage):
     finished = _run("--stage", stage, "--dry-run")
 
     assert finished.returncode == 0, finished.stdout + finished.stderr
-    assert "Every condition for the paid run is met" in finished.stdout
+    assert "Every condition this job can reach is met" in finished.stdout
     assert "nothing was spent" in finished.stdout
 
 
@@ -193,11 +193,24 @@ def _run(*args, env=None):
 
 @needs_dataset
 def test_the_priced_stage_dry_runs_to_zero_without_any_azure_environment():
-    """The whole path minus the network, with nothing configured to reach it."""
+    """The whole path minus the network, with nothing configured to reach it.
+
+    The assertion below used to read "Every condition for the paid run is met",
+    which is what the script printed and what this test therefore pinned. On
+    2026-09-11 a paid run that had just been told exactly that crashed on a
+    constructor keyword in a branch no dry run executes. The sentence was never
+    checkable from here: this job holds no Azure identity, so the route, the
+    deployment and the conversation are out of its reach by design.
+
+    What it can reach it now reaches, so the narrower claim is worth more than
+    the broad one was.
+    """
     finished = _run("--stage", "advance_check_5", "--dry-run")
 
     assert finished.returncode == 0, finished.stdout + finished.stderr
-    assert "Every condition for the paid run is met" in finished.stdout
+    assert "Every condition this job can reach is met" in finished.stdout
+    assert "the ledger the paid run settles into" in finished.stdout
+    assert "It cannot reach the model" in finished.stdout
     assert "nothing was spent" in finished.stdout
 
 

--- a/batch-runner/tests/test_the_dry_run_certified_a_path_it_never_reached.py
+++ b/batch-runner/tests/test_the_dry_run_certified_a_path_it_never_reached.py
@@ -1,0 +1,208 @@
+"""The dry run certified a path it had never reached.
+
+On 2026-09-11 the first paid ``advance_check_5`` dispatch passed the OIDC
+identity check, the route check, the deployment check and the cohort binding,
+printed its run id and where it would write, and then died:
+
+    TypeError: CostReceiptLedger.__init__() missing 1 required keyword-only
+    argument: 'run_id'
+
+Four minutes earlier a dry run of the same stage had finished with "Every
+condition for the paid run is met". Both sentences were produced by the same
+script. The dry run returned several hundred lines above the line that broke,
+so the branch it was speaking for had never been executed -- not in CI, not in
+a test, not once.
+
+The signature fix is one keyword. These tests are about the other half: that
+the free job now reaches the paid run's setup, and that the sentence it prints
+says what it checked rather than what it hoped.
+
+One thing worth keeping, because it changes what the lesson is. mypy had this.
+Run against the pre-fix file it says, at the exact line:
+
+    scripts/run_agentic_v2_stage.py:859: error: Missing named argument "run_id"
+    for "CostReceiptLedger"  [call-arg]
+
+It was the fourth of ninety-three errors across twenty-two files, and nothing
+in CI type-checks ``scripts/``. So the defect was not invisible; it was sitting
+in output nobody reads because the output is mostly noise. These tests close
+the one hole. The wider fix -- a type check this script actually has to pass --
+is its own change and is not in this one.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+SCRIPTS = BATCH_RUNNER_ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import run_agentic_v2_stage as stage  # noqa: E402
+from core.cost_receipts import CostReceiptLedger  # noqa: E402
+
+
+# ── the line that broke ───────────────────────────────────────────────────
+
+
+def test_the_ledger_opens_with_the_arguments_the_paid_run_gives_it(tmp_path):
+    """The whole of the original defect, in one call.
+
+    Against the real class, not a double. A double with a forgiving signature
+    is how the paid path passed review while being uncallable.
+    """
+    ledger = stage.open_the_ledger(tmp_path, run_id="a-run")
+
+    assert isinstance(ledger, CostReceiptLedger)
+    assert ledger.run_id == "a-run"
+    assert (tmp_path / "cost_receipts.sqlite3").exists()
+    ledger.close()
+
+
+def test_the_ledger_carries_the_run_id_rather_than_defaulting_to_something():
+    """``run_id`` is required, and that is the right shape for it.
+
+    A ledger that invented its own run id would have made this call keep
+    working and put every shard's rows under a name nobody chose.
+    """
+    import inspect
+
+    parameter = inspect.signature(CostReceiptLedger.__init__).parameters["run_id"]
+
+    assert parameter.default is inspect.Parameter.empty
+    assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+
+
+# ── the free job now reaches it ───────────────────────────────────────────
+
+
+def test_the_dry_run_opens_the_ledger_the_paid_run_will_write_to(tmp_path):
+    """The check that makes the failure free instead of paid."""
+    assert stage.the_paid_setup_a_dry_run_can_reach("advance_check_5") == []
+
+
+def test_a_broken_ledger_is_a_problem_the_dry_run_reports(monkeypatch):
+    """The same TypeError, arriving in the job that costs nothing.
+
+    Had this existed on 2026-09-11 the paid dispatch would not have been made:
+    the dry run ahead of it would have gone red.
+    """
+
+    def cannot_be_opened(into, *, run_id):
+        raise TypeError("missing 1 required keyword-only argument: 'run_id'")
+
+    monkeypatch.setattr(stage, "open_the_ledger", cannot_be_opened)
+
+    problems = stage.the_paid_setup_a_dry_run_can_reach("advance_check_5")
+
+    assert len(problems) == 1
+    assert "cost ledger cannot be opened" in problems[0]
+
+
+def test_the_scratch_directory_does_not_survive_the_check(monkeypatch):
+    """A dry run writes nothing that outlives it, ledger included."""
+    seen: list[Path] = []
+
+    real = stage.open_the_ledger
+
+    def remember(into, *, run_id):
+        seen.append(Path(into))
+        return real(into, run_id=run_id)
+
+    monkeypatch.setattr(stage, "open_the_ledger", remember)
+    stage.the_paid_setup_a_dry_run_can_reach("advance_check_5")
+
+    assert seen and not seen[0].exists()
+
+
+# ── the sentence it prints ────────────────────────────────────────────────
+
+
+def test_the_paid_run_opens_its_ledger_through_the_same_helper():
+    """One call site, so the dry run cannot be checking a different line.
+
+    Two calls to the constructor -- one in the dry run and one in the paid
+    path -- would let exactly this defect back in the moment they drifted.
+    """
+    source = (SCRIPTS / "run_agentic_v2_stage.py").read_text(encoding="utf-8")
+
+    assert source.count("CostReceiptLedger(") == 1
+    assert source.count("open_the_ledger(") == 3  # def, dry run, paid run
+
+
+def test_the_dry_run_no_longer_claims_the_paid_run_will_reach_the_model():
+    """The sentence that was false, and why it was false.
+
+    The free job holds no `id-token`, so it has no Azure identity and cannot
+    check the route, the deployment or the conversation. Claiming every
+    condition was met is how a green dry run preceded a paid crash.
+    """
+    source = (SCRIPTS / "run_agentic_v2_stage.py").read_text(encoding="utf-8")
+
+    assert "Every condition for the paid run is met" not in source
+    assert "Every condition " in source and "this job can reach" in source
+    assert "cannot reach the model" in source
+
+
+@pytest.mark.parametrize(
+    "promise",
+    ["the plan", "the seal", "the cohort", "the amounts", "the staged inputs"],
+)
+def test_the_dry_run_names_what_it_did_check(promise):
+    """Narrowing a claim is only useful if the narrower one is specific."""
+    source = (SCRIPTS / "run_agentic_v2_stage.py").read_text(encoding="utf-8")
+
+    assert promise in source
+
+
+# ── the same gap, one line further down ───────────────────────────────────
+#
+# The ledger crash was cheap because it happened before the first call. Two
+# calls in the paid path are not cheap in the same way: `receipt_for` runs
+# once per task *after* the model has answered, and it calls `model_turns_of`
+# and then `bind_run_to_ledger`. A keyword drifting in either of those is the
+# identical mistake arriving after the money is spent, and with no receipt
+# written for the task that was just paid for -- which is the one outcome the
+# whole ledger exists to prevent.
+#
+# Neither can be reached without a real conversation outcome, so no dry run
+# will ever execute them. Binding the arguments is the part that can be
+# checked without one, and it is the part that broke.
+
+
+def test_the_receipt_call_after_the_model_answers_still_binds():
+    """`model_turns_of` accepts exactly the keywords the paid path passes."""
+    import inspect
+
+    from core.agentic_v2_conversation_runner import model_turns_of
+
+    inspect.signature(model_turns_of).bind(
+        object(),  # the outcome; only its presence is being checked here
+        run_id="a-run",
+        task_id="a-task",
+        attempt=1,
+        provider="azure",
+        requested_model="gpt-5.4",
+        deployment="gpt-5.4",
+        resolved_model=None,
+    )
+
+
+def test_the_ledger_binding_after_the_model_answers_still_binds():
+    """And `bind_run_to_ledger` accepts what it is handed next."""
+    import inspect
+
+    from core.agentic_v2_cost_binding import bind_run_to_ledger
+
+    inspect.signature(bind_run_to_ledger).bind(
+        object(),  # the ledger
+        task_id="a-task",
+        model_turns=(),
+    )


### PR DESCRIPTION
2026-09-11 20:39, Agentic Sandbox V2의 **첫 유료 실행**을 보냈습니다. 신원
확인, 경로 확인, 배포 확인, 과제 묶음 확인을 모두 통과하고 실행 이름까지 찍은
뒤에 멈췄습니다.

```
TypeError: CostReceiptLedger.__init__() missing 1 required keyword-only
argument: 'run_id'
```

4분 전, 같은 단계의 무료 점검은 **"유료 실행의 모든 조건이 충족되었습니다"**
라고 끝냈습니다. 두 문장은 같은 스크립트가 만든 것입니다. 고칠 것은 빠진
인자 하나가 아니라 이 구조입니다.

### 아무것도 잡지 못한 이유

무료 점검은 문제가 난 줄보다 수백 줄 위에서 끝납니다. 그 아래 유료 구간은
**한 번도 실행된 적이 없습니다** — CI에서도, 테스트에서도. 유료 발사 직전에
도는 시험 파일 8개가 그날 아침 전부 통과했는데, 그중 어느 것도 유료 구간을
건드리지 않기 때문입니다.

mypy는 알고 있었습니다. 고치기 전 파일에 돌리면 바로 그 줄을 짚습니다.

```
scripts/run_agentic_v2_stage.py:859: error: Missing named argument "run_id"
for "CostReceiptLedger"  [call-arg]
```

22개 파일 93개 오류 중 4번째였고, CI에서 `scripts/`를 타입 검사하는 작업은
없습니다. 보이지 않았던 게 아니라, 아무도 읽지 않는 출력 안에 있었습니다.

### 고친 것

**원장을 여는 자리를 하나로 모았습니다.** `open_the_ledger` 하나를 유료
실행과 무료 점검이 같이 부릅니다. 무료 점검은 버릴 임시 디렉터리에 대고
엽니다. 호출 자리가 둘이면 검사하는 줄과 실행되는 줄이 다시 갈라집니다.

**문장을 실제로 확인한 범위로 좁혔습니다.** 무료 작업에는 Azure 신원이 없어
경로·배포·대화는 구조적으로 확인할 수 없습니다. 이제 확인한 것(계획, 봉인,
과제 묶음, 금액, 입력 파일, 원장)을 열거하고, **모델에는 닿을 수 없다**고,
무료 점검이 초록이어도 유료 실행이 모델에 닿는다는 보장은 아니라고 말합니다.

새 시험 파일은 유료 발사 직전 게이트의 8개 목록에 들어갑니다. 이제 이 종류의
실수는 야간 전체 시험이 아니라 발사 직전에 걸립니다.

### 한 줄 아래의 같은 구멍

`receipt_for`는 **모델이 답한 뒤** 과제마다 실행되고, `model_turns_of`와
`bind_run_to_ledger`를 부릅니다. 여기서 같은 실수가 나면 **돈을 쓴 뒤에**
터지고, 방금 돈을 낸 과제에 영수증이 없습니다. 원장이 막으려는 바로 그 결과.

가정하지 않고 확인했습니다 — 두 함수의 서명은 유료 구간이 넘기는 인자와 정확히
맞습니다. 앞으로도 맞도록 인자 결합을 시험 두 개로 고정했습니다.

### stage D 탐침도 같았습니다

고치다가 발견했습니다. 같은 문장, 같은 구조입니다. 그 스크립트의 무료 점검도
유료 구간보다 수백 줄 위에서 끝나고, C2가 부팅한 호스트가 아니면 아예 거부
합니다 — 기존 무료 점검 시험 두 개가 둘 다 그 선언보다 한참 위에서 멈추는
이유입니다. 이제 Azure도 게스트도 필요 없는 두 가지(substrate 명세, 가격표)를
실제로 읽습니다. 여기서는 돌릴 수 없는 검사를 읽어서만 확인하는 것은 고침이
아니라 결함과 같은 모양이라, 별도 함수로 빼서 시험했습니다.

### 이 PR이 고치지 않는 것

**실패한 유료 실행의 지출은 $0입니다.** 추정이 아니라 유도된 값입니다 —
원장은 859줄, `run_manifest`는 898줄이라 과제가 하나도 돌지 않았고,
`azure_ai_route_preflight.py`는 모델 호출을 하지 않습니다. 요청 0건이므로
이 $0은 가격 누락이 아니라 요청 건수입니다.

**이어하기는 여전히 고장입니다.** CI에서 일지도 원장도 복원되지 않아,
`run_id`를 채운 재실행은 묶음 전체를 다시 돌리고 다시 냅니다. 새 실행(빈
`run_id`)은 영향 없습니다. 별도 변경으로 갑니다.

---

전체 시험 11248 통과 / 18 건너뜀 / 46 제외. 손댄 어느 파일에도 mypy 신규
오류 없음.