### PR TITLE
유료 경로에서 무료 작업이 한 번도 실행하지 않는 두 줄 — 영수증과 재개

### DIFF
--- a/.github/workflows/agentic-v2-stage-run.yml
+++ b/.github/workflows/agentic-v2-stage-run.yml
@@ -90,9 +90,22 @@ on:
       run_id:
         description: >-
           Names the journal's run and namespaces every ledger call id. Leave
-          empty for a fresh run; reuse an earlier one to resume it. Each shard
-          appends its own number, so resuming a stage resumes every piece of it
-          without two jobs writing to one journal.
+          empty for a fresh run. To resume, give this AND
+          resume_from_github_run — this one alone restores nothing, so the
+          journal is absent, no task is found complete and the whole cohort is
+          paid for a second time. Each shard appends its own number, so
+          resuming a stage resumes every piece of it without two jobs writing
+          to one journal.
+        type: string
+        default: ''
+        required: false
+      resume_from_github_run:
+        description: >-
+          The GitHub run id — the number in the run's URL — whose artifacts
+          hold the journal to carry on from. Nothing can infer this: run_id is
+          a journal name somebody chose, not a number GitHub assigned. Give it
+          with run_id or not at all; either one alone is a full re-pay, and the
+          dry run refuses that pairing before the paid job starts.
         type: string
         default: ''
         required: false
@@ -131,6 +144,28 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
+      # Before `setup-python` and before `pip install`, because this refuses a
+      # dispatch that was typed wrong and there is no reason to spend two
+      # minutes on dependencies first. `python3` is what the runner ships; the
+      # script imports nothing outside the standard library, and a test holds
+      # it to that so this placement stays safe.
+      #
+      # What it catches: half a resume. Restoring the directory without the
+      # run id, or the run id without the restore, both end as a full second
+      # run of the cohort at full price, and neither raises anything — the
+      # journal is simply empty or written under another name, and a correct
+      # driver reading one runs every task.
+      - name: Check the resume inputs are a pair
+        env:
+          RUN_ID: ${{ inputs.run_id }}
+          RESUME_FROM: ${{ inputs.resume_from_github_run }}
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          python3 scripts/check_agentic_v2_resume_inputs.py \
+            --run-id "$RUN_ID" \
+            --resume-from-github-run "$RESUME_FROM"
+
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.10'
@@ -161,6 +196,12 @@ jobs:
       # was met, because none of them touched the paid branch. It holds the
       # part of the paid setup a free job can reach, and it is the reason the
       # dry run's claim is now narrower than it was.
+      #
+      # The resume pair is held here too, even though the guard for it runs
+      # above this step and needs nothing installed. The guard checks a
+      # dispatch; these check that the guard is still wired to the job and that
+      # the paid job still restores what the guard assumes it restores. The two
+      # defects before this one were both a correct function nobody called.
       - name: Test the runner
         run: |
           set -euo pipefail
@@ -174,7 +215,9 @@ jobs:
             tests/test_agentic_v2_reference_staging.py \
             tests/test_agentic_v2_preregistration.py \
             tests/test_run_agentic_v2_stage.py \
-            tests/test_the_dry_run_certified_a_path_it_never_reached.py
+            tests/test_the_dry_run_certified_a_path_it_never_reached.py \
+            tests/test_a_resume_that_only_half_arrives_pays_twice.py \
+            tests/test_the_report_was_handed_a_binding_not_a_receipt.py
 
       # No charge. The revision is the one the catalogue was built from and the
       # one every figure in the plan rests on; the binding hashes the wording it
@@ -277,6 +320,59 @@ jobs:
         run: |
           set -euo pipefail
           echo "SHARD_SLUG=${SHARD//\//-of-}" >> "$GITHUB_ENV"
+
+      # ── Resuming, when a resume was asked for ──────────────────────────
+      #
+      # The journal and the ledger are written under `agentic-v2-run/`, which
+      # leaves this runner only as the artifact uploaded at the end. Until this
+      # step existed, nothing brought either one back, so a dispatch carrying a
+      # `run_id` started against an empty directory: no task was found
+      # complete, the whole cohort ran, and the whole cohort was charged for a
+      # second time. The run printed the run id it was given while doing it, so
+      # its own log read like a resume.
+      #
+      # `name:` and not `pattern:`, because this shard resumes its own piece
+      # and nobody else's. The slug above is what makes the two names line up
+      # across runs: shard `3/17` was `3-of-17` then and is `3-of-17` now.
+      #
+      # The ledger comes back with it, in the same directory and the same
+      # artifact. That is deliberate — a resumed run that opened a fresh ledger
+      # would leave the earlier spend in a file nothing else reads, and the
+      # stage's cost would have to be added up by hand across runs or, more
+      # likely, quietly under-reported.
+      - name: Restore the run being resumed
+        if: ${{ inputs.resume_from_github_run != '' }}
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: agentic-v2-${{ inputs.stage }}-shard-${{ env.SHARD_SLUG }}
+          path: agentic-v2-run/
+          run-id: ${{ inputs.resume_from_github_run }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # A download that matched nothing does not always fail, and a directory
+      # that arrived empty is indistinguishable from a fresh run once the
+      # driver starts reading it. So the journal is checked for by name. The
+      # run id is `<run_id>-shard-<slug>` below, and the journal is scoped by
+      # it, so a file that arrived under the wrong name is caught here too --
+      # the driver would find no rows in it and run everything.
+      - name: Refuse to carry on from nothing
+        if: ${{ inputs.resume_from_github_run != '' }}
+        env:
+          RESUME_FROM: ${{ inputs.resume_from_github_run }}
+        run: |
+          set -euo pipefail
+          JOURNAL="$GITHUB_WORKSPACE/agentic-v2-run/journal.jsonl"
+          if [ ! -f "$JOURNAL" ]; then
+            echo "refusing: a resume from GitHub run $RESUME_FROM was asked" >&2
+            echo "for, but no journal.jsonl arrived for shard $SHARD_SLUG." >&2
+            echo "Starting anyway would run and pay for the whole cohort a" >&2
+            echo "second time. Check that run $RESUME_FROM has an artifact" >&2
+            echo "named agentic-v2-${{ inputs.stage }}-shard-$SHARD_SLUG," >&2
+            echo "and that it has not passed its retention window." >&2
+            exit 1
+          fi
+          echo "Resuming shard $SHARD_SLUG from run $RESUME_FROM:"
+          echo "  $(wc -l < "$JOURNAL") journal rows restored"
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -222,6 +222,16 @@ batch-runner/scripts/*
 # nobody can check. Reads two files and makes no network call.
 !batch-runner/scripts/plan_agentic_v2_shards.py
 
+# Refuses a dispatch that gives half a resume. Resuming a stage needs the
+# journal's run id and the GitHub run id whose artifact holds that journal;
+# either one alone runs the whole cohort again at full price without raising
+# anything, because an absent or foreign journal has no completed tasks in it.
+# Committed because it is the last thing between a mistyped form and a second
+# full charge, and because a guard nobody can read is a guard nobody can check.
+# Imports only the standard library, so it runs before pip install; compares
+# two strings and makes no network call.
+!batch-runner/scripts/check_agentic_v2_resume_inputs.py
+
 # Measures the one thing standing between a stage that runs and a stage whose
 # results mean something: the reference files a task names are not yet present
 # where the model can open them. Committed because the shape of that gap -- how

--- a/batch-runner/scripts/check_agentic_v2_resume_inputs.py
+++ b/batch-runner/scripts/check_agentic_v2_resume_inputs.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Refuse a resume that would quietly become a second full run.
+
+Resuming a V2 stage takes two separate inputs, and either one on its own is
+worse than neither.
+
+``run_id`` names the journal. ``run_manifest`` builds
+``TaskJournal(journal_path, run_id=run_id, task_ids=...)``, so a journal row is
+only found again by a run carrying the same name. ``resume_from_github_run``
+names the GitHub run whose artifact holds that journal, because nothing in a
+dispatch can infer it: the ``run_id`` is a journal name chosen by whoever
+dispatched, not a number GitHub assigns.
+
+So:
+
+* **Both given** -- the directory is restored and the journal inside it is
+  read under the name it was written with. Completed tasks are skipped. This
+  is a resume.
+* **Neither given** -- a fresh journal under a fresh name. Everything runs,
+  and that is what was asked for.
+* **``run_id`` alone** -- nothing restores the directory, so the journal file
+  does not exist. A journal that is not there has no completed tasks in it, so
+  every task runs and every task is paid for a second time. The run looks like
+  a resume in its own logs, because the run id it prints is the one it was
+  given.
+* **``resume_from_github_run`` alone** -- the directory is restored and the
+  journal file is there, but it was written under a different name, so
+  ``TaskJournal`` finds no rows belonging to this run. Same outcome, one step
+  further along: the evidence is present on disk and unreadable.
+
+Both failures cost the full cohort. Neither raises anything: the driver is
+working correctly in both cases, and a correct driver reading an empty journal
+runs everything. That is why this is checked before the paid job starts rather
+than defended against inside it.
+
+Nothing here reaches the network, the model or the ledger. It compares two
+strings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+#: What a resume needs, named the way the dispatch form names them.
+RUN_ID = "run_id"
+RESUME_FROM = "resume_from_github_run"
+
+
+def problems_with(run_id: str, resume_from: str) -> list[str]:
+    """What is wrong with this pair, or an empty list.
+
+    Empty strings are what an unfilled dispatch input arrives as, so they are
+    the "not given" case rather than an error. Whitespace is stripped first:
+    a value that is only spaces was not given either, and letting it through
+    as "given" would turn a stray keystroke into a full re-pay.
+    """
+    run_id = run_id.strip()
+    resume_from = resume_from.strip()
+
+    if run_id and not resume_from:
+        return [
+            f"{RUN_ID} is set to {run_id!r} but {RESUME_FROM} is empty. "
+            "Nothing would restore the journal that run id names, so the "
+            "journal file would not exist, no task would be found complete, "
+            "and the whole cohort would run and be paid for again. Give the "
+            f"GitHub run id of the run being resumed in {RESUME_FROM}, or "
+            f"clear {RUN_ID} to start a fresh run."
+        ]
+
+    if resume_from and not run_id:
+        return [
+            f"{RESUME_FROM} is set to {resume_from!r} but {RUN_ID} is empty. "
+            "The journal would be restored and then read under a different "
+            "run id, so none of its rows would be found, and the whole cohort "
+            "would run and be paid for again. Give the same run id the "
+            f"earlier run used in {RUN_ID}, or clear {RESUME_FROM} to start a "
+            "fresh run."
+        ]
+
+    if resume_from and not resume_from.isdigit():
+        return [
+            f"{RESUME_FROM} is {resume_from!r}, which is not a GitHub run id. "
+            "It is the number in the run's URL -- all digits. A value that is "
+            "not one cannot download anything, and the refusal for that "
+            "arrives after the job has started."
+        ]
+
+    return []
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-id", default="", help="the journal's run name")
+    parser.add_argument(
+        "--resume-from-github-run",
+        default="",
+        help="the GitHub run id whose artifact holds that journal",
+    )
+    args = parser.parse_args(argv)
+
+    found = problems_with(args.run_id, args.resume_from_github_run)
+    if found:
+        for problem in found:
+            print(f"refusing: {problem}", file=sys.stderr)
+        return 1
+
+    if args.run_id.strip():
+        print(
+            f"Resuming journal {args.run_id.strip()!r} from GitHub run "
+            f"{args.resume_from_github_run.strip()}. Tasks already recorded "
+            "complete in that journal will be skipped and not paid for again."
+        )
+    else:
+        print(
+            "A fresh run. No journal is restored and every task in the cohort "
+            "will run."
+        )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    raise SystemExit(main())

--- a/batch-runner/scripts/run_agentic_v2_stage.py
+++ b/batch-runner/scripts/run_agentic_v2_stage.py
@@ -99,6 +99,10 @@ from core.agentic_v2_stage_one_budget import (  # noqa: E402
     price_one_stage,
     run_stage_one_preflight,
 )
+from core.cost_receipts import (  # noqa: E402
+    BUCKET_PROBLEM_SOLVING,
+    STATUS_UNAVAILABLE,
+)
 from core.execution_envelope_cost import (  # noqa: E402
     CostAssumptions,
     load_price_table,
@@ -431,24 +435,139 @@ def open_the_ledger(into: Path, *, run_id: str):
     return CostReceiptLedger(str(into / "cost_receipts.sqlite3"), run_id=run_id)
 
 
+def settle_into_a_receipt(ledger, *, task_id: str, model_turns) -> dict[str, Any]:
+    """Write one task's calls to the ledger and return that task's receipt.
+
+    Two returns are involved and they are not the same object.
+    :func:`~core.agentic_v2_cost_binding.bind_run_to_ledger` returns a note of
+    what it wrote -- call ids, bucket -- which is useful to a caller that wants
+    to log the write, and is not a receipt. The receipt is built by the ledger,
+    from every row standing against the task, and carries the ``status`` the
+    report row is assembled around.
+
+    The paid run returned the first where the second was wanted, and the run
+    died in the report with ``None is not a receipt status`` -- on task one of
+    five, after the calls had been made and charged for. So this is one function
+    with two call sites, like :func:`open_the_ledger` above it: the dry run puts
+    a fabricated turn through it and hands the result to the same report
+    builder, which makes the shape a free check rather than a paid one.
+
+    ``when_empty`` is ``unavailable`` deliberately. Reaching here means the task
+    ran, so ``not_run`` would be a false sentence; and ``complete`` would state
+    a real ``$0`` for a task whose guest was up and whose host bill this process
+    cannot read. An amount that is not known is not zero.
+    """
+    bind_run_to_ledger(ledger, task_id=task_id, model_turns=model_turns)
+    return ledger.receipt_for(
+        task_id,
+        bucket=BUCKET_PROBLEM_SOLVING,
+        when_empty=STATUS_UNAVAILABLE,
+    ).as_dict()
+
+
 def the_paid_setup_a_dry_run_can_reach(stage: str) -> list[str]:
     """Run the paid path's setup against a throwaway directory.
 
     Returns what broke, empty when nothing did. Called from the dry run, so the
     free job pays for this class of mistake instead of the paid one.
 
-    It is deliberately not much: the ledger is the only part of the paid setup
+    It is deliberately not much: the accounting is the part of the paid setup
     that needs no Azure identity, and the free job holds none. The voice, the
     route, the deployment and the conversation cannot be reached from here and
     are not claimed to be. Saying which is the other half of the fix -- the
     sentence this used to print claimed all of them.
+
+    What it does reach is the whole money path from a finished task to a report
+    row: ledger, binding, receipt, metrics, row. Both paid runs so far died in
+    that stretch -- once opening the ledger, once handing the report a binding
+    where a receipt was wanted -- and the second death came after the calls were
+    made. Every line below runs on fabricated turns, so the shape is settled
+    before a model is asked rather than after.
     """
+    from core.agentic_v2_cost_binding import ModelTurn
+    from core.agentic_v2_run_report import build_agentic_v2_metrics, build_result_row
+    from core.agentic_v2_task_journal import TaskStanding
+    from core.cost_receipts import CallUsage
+
+    # A task that made a call and succeeded, and a task that made none and
+    # ended the way the first paid task actually ended. The second is the
+    # `when_empty` branch, which nothing else exercises; both are row shapes the
+    # report builds different halves of, and it was row-building that killed the
+    # run. The file list goes with the ending on purpose -- a successful row
+    # with no files and a failed row with files are both refused.
+    rehearsals = (
+        (
+            "a-task-that-called-the-model",
+            (
+                ModelTurn(
+                    call_id="dry-run:a-task-that-called-the-model:1:call-1",
+                    usage=CallUsage(input_tokens=100, output_tokens=10),
+                    provider="azure",
+                    requested_model="dry-run-deployment",
+                    deployment="dry-run-deployment",
+                    resolved_model="dry-run-deployment",
+                ),
+            ),
+            {"success": True},
+            ("deliverables/a-task-that-called-the-model/answer.md",),
+        ),
+        (
+            "a-task-that-called-nothing",
+            (),
+            {"success": False, "error": "capability_unavailable"},
+            (),
+        ),
+    )
+
     with tempfile.TemporaryDirectory(prefix=f"agentic-v2-{stage}-dry-") as scratch:
         try:
             ledger = open_the_ledger(Path(scratch), run_id="dry-run")
         except Exception as broke:  # noqa: BLE001 - reported, not handled
             return [f"the paid run's cost ledger cannot be opened: {broke!r}"]
-        ledger.close()
+        try:
+            for task_id, turns, record, files in rehearsals:
+                try:
+                    receipt = settle_into_a_receipt(
+                        ledger, task_id=task_id, model_turns=turns
+                    )
+                except Exception as broke:  # noqa: BLE001 - reported, not handled
+                    return [
+                        f"a finished task cannot be settled into a receipt: {broke!r}"
+                    ]
+                standing = TaskStanding(
+                    task_id=task_id,
+                    attempts=1,
+                    abandoned_attempts=0,
+                    last_closed=None,
+                    decision="dry-run",
+                    reason="rehearsal",
+                )
+                try:
+                    metrics = build_agentic_v2_metrics(
+                        record,
+                        standing=standing,
+                        task_wall_time_ms=1.0,
+                        receipt=receipt,
+                    )
+                    build_result_row(
+                        record,
+                        task_id=task_id,
+                        standing=standing,
+                        sector="dry run",
+                        occupation="dry run",
+                        instruction="dry run",
+                        deliverable_files=files,
+                        latency_ms=1.0,
+                        metrics=metrics,
+                        receipt=receipt,
+                    )
+                except Exception as broke:  # noqa: BLE001 - reported, not handled
+                    return [
+                        "a settled task cannot be turned into a report row: "
+                        f"{broke!r}"
+                    ]
+        finally:
+            ledger.close()
     return []
 
 
@@ -666,8 +785,9 @@ def main() -> int:
         print(
             "Dry run. Nothing was asked and nothing was spent. Every condition "
             "this job can reach is met: the plan, the seal, the cohort, the "
-            "amounts, the staged inputs, and the ledger the paid run settles "
-            "into.\n\n"
+            "amounts, the staged inputs, and the whole accounting path a "
+            "finished task takes -- ledger, binding, receipt, metrics, report "
+            "row -- rehearsed on fabricated turns.\n\n"
             "It cannot reach the model. This job holds no Azure identity, so "
             "the route, the deployment and the conversation itself are checked "
             "in the paid job and nowhere else. A green dry run is not a "
@@ -956,7 +1076,11 @@ def main() -> int:
                         spoke.resolved_model if spoke is not None else None
                     ),
                 )
-                return bind_run_to_ledger(
+                # Through the same helper the dry run puts a fabricated turn
+                # through, for the same reason the ledger is opened through one:
+                # the paid path and the path that certifies it must be the same
+                # line of code.
+                return settle_into_a_receipt(
                     ledger, task_id=task.task_id, model_turns=turns
                 )
 

--- a/batch-runner/tests/test_a_resume_that_only_half_arrives_pays_twice.py
+++ b/batch-runner/tests/test_a_resume_that_only_half_arrives_pays_twice.py
@@ -1,0 +1,202 @@
+"""The guard on the two inputs that have to be given together or not at all.
+
+The workflow's ``run_id`` input has said "reuse an earlier one to resume it"
+since it was written, and until now that was false in CI. The journal and the
+ledger are written under ``$GITHUB_WORKSPACE/agentic-v2-run/``, which leaves
+the runner only as an upload artifact, and nothing downloaded it back before a
+run started. A dispatch with ``run_id`` filled in ran the whole cohort again
+and paid for it again, while printing the run id it was given -- so its own
+logs read like a resume.
+
+Restoring the directory fixes half of it. The other half is that the journal
+is scoped by run id: ``run_manifest`` builds
+``TaskJournal(journal_path, run_id=run_id, task_ids=...)``, so rows written
+under one name are not found by a run carrying another. Restore without the
+run id and the journal is on disk and unread. Give the run id without the
+restore and the journal is not there at all. Both cost the full cohort, and
+neither raises: an empty or foreign journal has no completed tasks in it, and
+a correct driver reading one runs everything.
+
+That is the shape these tests hold. Not "does resume work" -- the driver's own
+suite has that, and had it while CI could not resume at all -- but "can the
+pair of inputs be given in a way that quietly means a second full run".
+
+Nothing here runs a stage, calls a model or downloads an artifact.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+SCRIPT = BATCH_RUNNER_ROOT / "scripts" / "check_agentic_v2_resume_inputs.py"
+WORKFLOW = (
+    BATCH_RUNNER_ROOT.parent
+    / ".github"
+    / "workflows"
+    / "agentic-v2-stage-run.yml"
+)
+
+from scripts.check_agentic_v2_resume_inputs import (  # noqa: E402
+    RESUME_FROM,
+    RUN_ID,
+    problems_with,
+)
+
+
+# ── The four ways the pair can arrive ───────────────────────────────────────
+
+
+def test_neither_given_is_a_fresh_run_and_is_allowed():
+    """The ordinary dispatch. Nothing is restored and nothing is claimed."""
+    assert problems_with("", "") == []
+
+
+def test_both_given_is_a_resume_and_is_allowed():
+    """The only combination that actually resumes anything."""
+    assert problems_with("stage-one-take-2", "34645403765") == []
+
+
+def test_a_run_id_with_nothing_to_restore_from_is_refused():
+    """The failure that reads like a resume in its own logs."""
+    (problem,) = problems_with("stage-one-take-2", "")
+    assert RESUME_FROM in problem
+    assert "paid for again" in problem
+
+
+def test_a_restore_with_no_run_id_to_read_it_under_is_refused():
+    """The journal arrives and is unreadable, which looks like no journal."""
+    (problem,) = problems_with("", "34645403765")
+    assert RUN_ID in problem
+    assert "paid for again" in problem
+
+
+# ── The values that are not really values ───────────────────────────────────
+
+
+@pytest.mark.parametrize("blank", ["", " ", "   ", "\t", "\n"])
+def test_whitespace_is_not_a_value(blank):
+    """A stray keystroke in one field must not be read as "given".
+
+    If it were, the pair would look complete, the guard would pass, and the
+    run would go out as the exact failure this guard exists to stop.
+    """
+    assert problems_with(blank, blank) == []
+    assert problems_with("stage-one-take-2", blank) != []
+    assert problems_with(blank, "34645403765") != []
+
+
+def test_a_github_run_id_that_is_not_a_number_is_refused_here():
+    """Refused before the job starts rather than by the download step.
+
+    The download's own refusal arrives after ``paid`` has begun, which is
+    after the Azure login and after the dataset fetch. Nothing is charged
+    there, but it is several minutes later and the message is about an
+    artifact rather than about the thing that was typed wrong.
+    """
+    (problem,) = problems_with("stage-one-take-2", "https://github.com/x/y/actions/runs/1")
+    assert "all digits" in problem
+
+
+# ── The script, run the way the workflow runs it ────────────────────────────
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=BATCH_RUNNER_ROOT,
+    )
+
+
+def test_the_script_exits_zero_for_a_fresh_run():
+    finished = _run()
+    assert finished.returncode == 0, finished.stderr
+    assert "fresh run" in finished.stdout
+
+
+def test_the_script_exits_nonzero_for_half_a_resume():
+    finished = _run("--run-id", "stage-one-take-2")
+    assert finished.returncode == 1
+    assert "refusing" in finished.stderr
+
+
+def test_the_script_says_what_a_resume_will_skip():
+    """The line a person reads before letting a paid run go.
+
+    It names both halves, because the whole class of defect here is one half
+    being present and reading as the pair.
+    """
+    finished = _run(
+        "--run-id", "stage-one-take-2", "--resume-from-github-run", "34645403765"
+    )
+    assert finished.returncode == 0, finished.stderr
+    assert "stage-one-take-2" in finished.stdout
+    assert "34645403765" in finished.stdout
+    assert "not paid for again" in finished.stdout
+
+
+def test_the_script_needs_nothing_installed():
+    """It runs before ``pip install``, so it may import only the standard library.
+
+    The guard is placed immediately after checkout on purpose: a dispatch with
+    half a resume in it should be refused in seconds, not after two minutes of
+    dependency setup. That placement is only safe while this holds.
+    """
+    source = SCRIPT.read_text()
+    for forbidden in ("import yaml", "from core", "import core", "import pandas"):
+        assert forbidden not in source
+
+
+# ── The wiring, which is the half that was missing ──────────────────────────
+
+
+def test_the_workflow_offers_the_input_this_guard_checks():
+    """A guard on an input nobody can fill in guards nothing."""
+    assert f"{RESUME_FROM}:" in WORKFLOW.read_text()
+
+
+def test_the_free_job_actually_calls_the_guard():
+    """The defect this file exists for was a correct function nobody called.
+
+    That is the same shape as the two before it -- ``coverage_problems`` in
+    PR #546 and the ledger constructor in #547 -- so the call site is asserted
+    rather than assumed.
+    """
+    assert "check_agentic_v2_resume_inputs.py" in WORKFLOW.read_text()
+
+
+def test_the_paid_job_restores_the_directory_the_journal_lives_in():
+    """Restoring the record is what makes the run id mean anything."""
+    text = WORKFLOW.read_text()
+    assert "run-id: ${{ inputs.resume_from_github_run }}" in text
+    assert "path: agentic-v2-run/" in text
+
+
+def test_the_paid_job_refuses_a_restore_that_produced_no_journal():
+    """A download that quietly found nothing is the failure mode to catch.
+
+    ``download-artifact`` can succeed with nothing when a name does not match,
+    and the run would then start with an empty directory under a run id --
+    exactly the full re-pay the guard above is for, arrived at the long way
+    round.
+    """
+    assert "agentic-v2-run/journal.jsonl" in WORKFLOW.read_text()
+
+
+def test_the_run_id_input_no_longer_promises_resume_on_its_own():
+    """It said "reuse an earlier one to resume it", which was not true in CI.
+
+    A description is what somebody reads before typing a value into a form
+    that spends money, so it is held here like any other claim.
+    """
+    text = WORKFLOW.read_text()
+    assert "reuse an earlier one to resume it" not in text

--- a/batch-runner/tests/test_run_agentic_v2_stage.py
+++ b/batch-runner/tests/test_run_agentic_v2_stage.py
@@ -203,13 +203,16 @@ def test_the_priced_stage_dry_runs_to_zero_without_any_azure_environment():
     deployment and the conversation are out of its reach by design.
 
     What it can reach it now reaches, so the narrower claim is worth more than
-    the broad one was.
+    the broad one was. It reached further again on 2026-09-11, after the next
+    paid run died one line past the ledger -- handing the report a binding
+    where a receipt was wanted -- so the rehearsal, and this assertion, now run
+    a fabricated task all the way to a report row.
     """
     finished = _run("--stage", "advance_check_5", "--dry-run")
 
     assert finished.returncode == 0, finished.stdout + finished.stderr
     assert "Every condition this job can reach is met" in finished.stdout
-    assert "the ledger the paid run settles into" in finished.stdout
+    assert "ledger, binding, receipt, metrics, report row" in finished.stdout
     assert "It cannot reach the model" in finished.stdout
     assert "nothing was spent" in finished.stdout
 

--- a/batch-runner/tests/test_the_report_was_handed_a_binding_not_a_receipt.py
+++ b/batch-runner/tests/test_the_report_was_handed_a_binding_not_a_receipt.py
@@ -1,0 +1,391 @@
+"""The report was handed a binding where a receipt was wanted.
+
+On 2026-09-11 the second paid ``advance_check_5`` dispatch became the first V2
+run ever to reach the model. It asked, was answered, and both calls settled into
+the ledger. Then it died on task one of five::
+
+    core.agentic_v2_run_report.ReportRowRefused: None is not a receipt status
+
+``receipt_for`` -- the callback the driver asks for each finished task's cost --
+returned :func:`~core.agentic_v2_cost_binding.bind_run_to_ledger`'s value. That
+is a note of what was written: task id, bucket, the call ids settled. It is not
+a receipt and has no ``status``. The report asks for one and refuses a row it
+cannot state a cost standing for, which is the right refusal; the value handed
+to it was simply the wrong object.
+
+The damage is where the two defects differ. The ledger defect a day earlier was
+a ``TypeError`` before anything was asked, and cost nothing. This one waited
+until after the calls had been made and charged for, then threw away the run
+record and the deliverables with it. Same shape both times -- a paid-only line
+that no free job executes -- and that shape is what these tests are about more
+than the one-line fix.
+
+Two things are held here beyond "it works now":
+
+* the paid path and the dry run go through **one** function, so the certifying
+  path cannot drift from the certified one, and
+* a call this repo has no price for settles ``partial``, never a real ``$0``.
+  The pinned deployment is not in the committed price table, so every call the
+  V2 stage makes is currently unpriced. A receipt that rounded that to zero
+  would be the one number in the record that reads as a measurement.
+
+Nothing here calls a model or reaches the network. The ledger is real and
+sqlite-backed in a temporary directory; the turns are fabricated.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+SCRIPTS = BATCH_RUNNER_ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import run_agentic_v2_stage as stage  # noqa: E402
+from core.agentic_v2_cost_binding import ModelTurn, bind_run_to_ledger  # noqa: E402
+from core.agentic_v2_run_report import (  # noqa: E402
+    ReportRowRefused,
+    build_agentic_v2_metrics,
+    build_result_row,
+)
+from core.agentic_v2_task_journal import TaskStanding  # noqa: E402
+from core.cost_receipts import (  # noqa: E402
+    STATUS_COMPLETE,
+    STATUS_PARTIAL,
+    STATUS_UNAVAILABLE,
+    CallUsage,
+)
+
+STAGE_SOURCE = (SCRIPTS / "run_agentic_v2_stage.py").read_text()
+
+
+def _turn(task_id: str, call: str = "call-1", **usage: int) -> ModelTurn:
+    """One model call, named the way the real run names them."""
+    return ModelTurn(
+        call_id=f"a-run:{task_id}:1:{call}",
+        usage=CallUsage(
+            input_tokens=usage.get("input_tokens", 2322),
+            output_tokens=usage.get("output_tokens", 22),
+        ),
+        provider="azure",
+        requested_model="gpt-5.4",
+        deployment="gpt-5.4",
+        resolved_model="gpt-5.4",
+    )
+
+
+def _standing(task_id: str, attempts: int = 1) -> TaskStanding:
+    return TaskStanding(
+        task_id=task_id,
+        attempts=attempts,
+        abandoned_attempts=0,
+        last_closed=None,
+        decision="ran",
+        reason="test",
+    )
+
+
+# ── what the run died of ────────────────────────────────────────────────────
+
+
+def test_the_binding_has_no_status_and_the_report_says_so(tmp_path):
+    """The defect itself, reproduced against the real functions.
+
+    Not a regression test for a typo: it pins *why* the report refused, so a
+    later change that gives the binding a ``status`` key does not quietly make
+    this pass while still filing call ids in the row's cost field.
+    """
+    ledger = stage.open_the_ledger(tmp_path, run_id="a-run")
+    try:
+        binding = bind_run_to_ledger(
+            ledger, task_id="t1", model_turns=(_turn("t1"),)
+        )
+    finally:
+        ledger.close()
+
+    assert "status" not in binding
+    assert set(binding) == {
+        "task_id",
+        "bucket",
+        "settled_call_ids",
+        "runtime_entry_id",
+        "grading_bucket_untouched",
+    }
+
+    with pytest.raises(ReportRowRefused) as refused:
+        build_agentic_v2_metrics(
+            {"success": True},
+            standing=_standing("t1"),
+            task_wall_time_ms=1.0,
+            receipt=binding,
+        )
+    assert "not a receipt status" in str(refused.value)
+
+
+def test_a_settled_task_now_reaches_a_report_row(tmp_path):
+    """The whole stretch the paid run died in, end to end.
+
+    Ledger, binding, receipt, metrics, row. Every one of these is the real
+    function the run calls; a double anywhere in this chain would have let the
+    original defect through, because every part of it worked in isolation.
+    """
+    ledger = stage.open_the_ledger(tmp_path, run_id="a-run")
+    try:
+        receipt = stage.settle_into_a_receipt(
+            ledger, task_id="t1", model_turns=(_turn("t1"),)
+        )
+    finally:
+        ledger.close()
+
+    metrics = build_agentic_v2_metrics(
+        {"success": True},
+        standing=_standing("t1"),
+        task_wall_time_ms=1.0,
+        receipt=receipt,
+    )
+    row = build_result_row(
+        {"success": True},
+        task_id="t1",
+        standing=_standing("t1"),
+        deliverable_files=("deliverables/t1/answer.md",),
+        latency_ms=1.0,
+        metrics=metrics,
+        receipt=receipt,
+    )
+
+    assert row["problem_solving_cost"]["status"] == receipt["status"]
+    assert metrics["agentic_v2_cost_receipt_status"] == receipt["status"]
+
+
+def test_the_failed_task_the_run_actually_had_also_builds_a_row(tmp_path):
+    """Task one ended ``capability_unavailable`` and still needed a row.
+
+    A run whose first task fails must be able to say so. The crash took the
+    failure with it, so the artifact carried no record of the ending at all --
+    the reason had to be read out of a job log.
+    """
+    ledger = stage.open_the_ledger(tmp_path, run_id="a-run")
+    try:
+        receipt = stage.settle_into_a_receipt(
+            ledger, task_id="t1", model_turns=(_turn("t1"),)
+        )
+    finally:
+        ledger.close()
+
+    record = {"success": False, "error": "capability_unavailable"}
+    metrics = build_agentic_v2_metrics(
+        record, standing=_standing("t1"), task_wall_time_ms=1.0, receipt=receipt
+    )
+    row = build_result_row(
+        record,
+        task_id="t1",
+        standing=_standing("t1"),
+        latency_ms=1.0,
+        metrics=metrics,
+        receipt=receipt,
+    )
+
+    assert row["status"] == "error"
+    assert row["error"] == "capability_unavailable"
+    assert row["problem_solving_cost"]["status"] == receipt["status"]
+
+
+# ── what the amount is allowed to say ───────────────────────────────────────
+
+
+def test_an_unpriced_call_is_partial_and_not_a_zero(tmp_path):
+    """The state every V2 call is in today, stated as the record must state it.
+
+    ``gpt-5.4`` has no entry in the committed price table, so the tokens are
+    known and the amount is not. ``partial`` with a null estimate is the true
+    sentence. A ``0.0`` here would be indistinguishable from a task that really
+    cost nothing, and the tokens that would let anyone recompute it later are
+    only kept because the status says the amount is missing.
+    """
+    ledger = stage.open_the_ledger(tmp_path, run_id="a-run")
+    try:
+        receipt = stage.settle_into_a_receipt(
+            ledger, task_id="t1", model_turns=(_turn("t1"),)
+        )
+    finally:
+        ledger.close()
+
+    assert receipt["status"] == STATUS_PARTIAL
+    assert receipt["estimated_cost_usd"] is None
+    assert "price_missing" in receipt["missing_reasons"]
+    assert receipt["model_calls"] == 1
+    assert receipt["usage"]["input_tokens"] == 2322
+    assert receipt["usage"]["output_tokens"] == 22
+
+
+def test_a_partial_receipt_does_not_mark_the_task_cost_accounted(tmp_path):
+    """``usage_complete`` must stay false while the amount is unknown.
+
+    This is the field a reader would take as "this task's cost is known", and
+    the driver settles the journal's ``cost_settled`` on the same test.
+    """
+    ledger = stage.open_the_ledger(tmp_path, run_id="a-run")
+    try:
+        receipt = stage.settle_into_a_receipt(
+            ledger, task_id="t1", model_turns=(_turn("t1"),)
+        )
+    finally:
+        ledger.close()
+
+    metrics = build_agentic_v2_metrics(
+        {"success": True},
+        standing=_standing("t1"),
+        task_wall_time_ms=1.0,
+        receipt=receipt,
+    )
+
+    assert receipt["status"] != STATUS_COMPLETE
+    assert metrics["usage_complete"] is False
+
+
+def test_a_task_that_called_nothing_is_unavailable_rather_than_free(tmp_path):
+    """Silence is not a measured zero.
+
+    ``receipt_for``'s ``when_empty`` offers three readings of an empty ledger
+    and only one of them is true here. ``not_run`` would be false -- reaching
+    this callback means the task ran. ``complete`` would state a real ``$0``
+    for a task whose guest was up and whose host bill this process cannot read.
+    """
+    ledger = stage.open_the_ledger(tmp_path, run_id="a-run")
+    try:
+        receipt = stage.settle_into_a_receipt(
+            ledger, task_id="t-silent", model_turns=()
+        )
+    finally:
+        ledger.close()
+
+    assert receipt["status"] == STATUS_UNAVAILABLE
+    assert receipt["estimated_cost_usd"] is None
+    assert receipt["model_calls"] == 0
+
+
+def test_a_second_attempt_is_added_to_the_task_not_substituted_for_it(tmp_path):
+    """A retried task's receipt covers what the whole task cost.
+
+    The binding writes one attempt's turns. The receipt is built from every row
+    standing against the task, which is why it has to come from the ledger
+    rather than from what was just written -- a task retried once cost both
+    attempts, and the driver asks for the receipt once.
+    """
+    ledger = stage.open_the_ledger(tmp_path, run_id="a-run")
+    try:
+        stage.settle_into_a_receipt(
+            ledger, task_id="t1", model_turns=(_turn("t1", "call-1"),)
+        )
+        receipt = stage.settle_into_a_receipt(
+            ledger, task_id="t1", model_turns=(_turn("t1", "call-2"),)
+        )
+    finally:
+        ledger.close()
+
+    assert receipt["model_calls"] == 2
+    assert receipt["usage"]["input_tokens"] == 2322 * 2
+
+
+def test_one_task_does_not_collect_another_task_s_calls(tmp_path):
+    """The receipt is scoped to its task.
+
+    Worth holding explicitly: the fix moved the amount from "what I just wrote"
+    to "what the ledger holds", and the failure mode of that move is a receipt
+    that quietly bills a task for the whole run.
+    """
+    ledger = stage.open_the_ledger(tmp_path, run_id="a-run")
+    try:
+        stage.settle_into_a_receipt(
+            ledger, task_id="t1", model_turns=(_turn("t1"),)
+        )
+        second = stage.settle_into_a_receipt(
+            ledger, task_id="t2", model_turns=(_turn("t2"),)
+        )
+    finally:
+        ledger.close()
+
+    assert second["model_calls"] == 1
+
+
+# ── the free job now walks the paid path ────────────────────────────────────
+
+
+def test_the_dry_run_settles_and_reports_a_fabricated_task():
+    """The rehearsal the free job runs, against the real functions."""
+    assert stage.the_paid_setup_a_dry_run_can_reach("advance_check_5") == []
+
+
+def test_the_dry_run_would_have_caught_this_defect(monkeypatch):
+    """The point of the rehearsal, stated as the defect it was built for.
+
+    Put the old return value back -- the binding -- and the free job must fail.
+    If this test can be made to pass with a broken paid path, the rehearsal is
+    decoration and the next defect of this shape is paid for again.
+    """
+    ledger_holder = {}
+
+    def hand_back_the_binding(ledger, *, task_id, model_turns):
+        ledger_holder["seen"] = True
+        return bind_run_to_ledger(
+            ledger, task_id=task_id, model_turns=model_turns
+        )
+
+    monkeypatch.setattr(stage, "settle_into_a_receipt", hand_back_the_binding)
+    broke = stage.the_paid_setup_a_dry_run_can_reach("advance_check_5")
+
+    assert ledger_holder.get("seen") is True
+    assert len(broke) == 1
+    assert "report row" in broke[0]
+    assert "not a receipt status" in broke[0]
+
+
+def test_a_ledger_that_will_not_open_is_still_reported_first(monkeypatch):
+    """The earlier defect's check is not lost to the newer one.
+
+    Both live in the same helper now, and a failure to open must not be
+    reported as a failure to build a row.
+    """
+
+    def refuse(*args, **kwargs):
+        raise TypeError("missing 1 required keyword-only argument: 'run_id'")
+
+    monkeypatch.setattr(stage, "open_the_ledger", refuse)
+    broke = stage.the_paid_setup_a_dry_run_can_reach("advance_check_5")
+
+    assert len(broke) == 1
+    assert "cost ledger cannot be opened" in broke[0]
+
+
+def test_the_paid_path_and_the_rehearsal_are_the_same_function():
+    """Two call sites, one function -- the reason the rehearsal means anything.
+
+    The same shape as ``open_the_ledger`` above it, and for the same reason:
+    the first paid run was certified by a dry run that executed a different
+    line.
+    """
+    assert STAGE_SOURCE.count("settle_into_a_receipt(") >= 3
+    assert "return bind_run_to_ledger(" not in STAGE_SOURCE
+
+
+def test_the_dry_run_says_it_reached_the_report_row():
+    """What the sentence claims has to be what was executed.
+
+    The sentence before this change named the ledger and stopped there, which
+    was accurate then. It would now understate what the job checked, and an
+    understated claim decays into an overstated one the next time the check
+    grows.
+    """
+    claimed = STAGE_SOURCE.split("Every condition ")[1][:600]
+
+    assert "receipt" in claimed
+    assert "report " in claimed
+    # And still says what it cannot reach, which is the larger half.
+    assert "It cannot reach the model." in STAGE_SOURCE


### PR DESCRIPTION
## 무슨 일이 있었나

두 번째 유료 `advance_check_5` 실행([34651982737](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/34651982737))이 V2 사상 **처음으로 모델에 도달**했습니다. 두 번 묻고 두 번 답을 받았고, 두 호출 모두 원장에 정산됐습니다. 그리고 다섯 과제 중 **첫 과제**에서 죽었습니다.

```
core.agentic_v2_run_report.ReportRowRefused: None is not a receipt status
  core/agentic_v2_run_report.py:127  in _receipt_status
  core/agentic_v2_run_report.py:155  in build_agentic_v2_metrics
  core/agentic_v2_run_driver.py:344
  scripts/run_agentic_v2_stage.py:963 in main
```

드라이버가 과제마다 요청하는 비용 콜백이 `bind_run_to_ledger`의 반환값을 돌려주고 있었습니다. 그 값은 **무엇을 썼는지에 대한 메모**(`task_id`, `bucket`, `settled_call_ids`)이지 영수증이 아니며 `status` 키가 없습니다. 보고서는 `status`를 묻고, 비용 상태를 말할 수 없는 행을 거부합니다. **거부는 옳았고, 건네진 객체가 틀렸습니다.**

전날 고친 원장 결함(#547)과 모양은 같지만 피해가 다릅니다.

| | #547 원장 생성자 | 이번 영수증 |
|---|---|---|
| 언제 터졌나 | 묻기 전 | 호출이 끝나고 과금된 뒤 |
| 비용 | 0원 | 2회 호출 (미가격) |
| 잃은 것 | 없음 | 실행 기록·산출물 전부 |
| mypy가 잡았나 | **예** (읽는 사람이 없었을 뿐) | **아니오** — 아래 참조 |

## 고친 것

`settle_into_a_receipt()` 하나를 두고 **유료 경로와 드라이런이 같이 부릅니다.** 바로 위 `open_the_ledger`와 같은 이유입니다 — 보증하는 코드와 보증받는 코드가 다른 줄이면 그건 보증이 아닙니다.

드라이런은 이제 조작된 turn으로 **원장 → 바인딩 → 영수증 → 지표 → 보고서 행**까지 끝까지 걸어봅니다. 성공한 과제 하나와, 첫 유료 과제가 실제로 끝난 방식(`capability_unavailable`, 호출 0회) 하나 — 뒤쪽이 `when_empty` 분기입니다. 출력 문장도 거기까지 갔다고만 말합니다.

`test_the_dry_run_would_have_caught_this_defect`가 이 리허설의 존재 이유를 고정합니다. 옛 반환값(바인딩)을 도로 끼우면 **무료 작업이 빨갛게 되어야** 합니다. 망가진 유료 경로로도 이 테스트가 통과한다면 리허설은 장식이고, 같은 모양의 다음 결함은 또 돈을 내고 발견하게 됩니다.

## 금액을 어떻게 말하는가

고정 배포 `gpt-5.4`는 커밋된 가격표에 없습니다. 그래서 **지금 모든 V2 호출은 `price_missing`으로 정산됩니다.**

- 호출이 있던 과제 → `status: partial`, `estimated_cost_usd: null`, `missing_reasons: ["price_missing"]`. **0달러가 아닙니다.** 토큰과 모델 이름은 남으므로 가격표가 채워지면 나중에 계산할 수 있습니다.
- 호출이 하나도 없던 과제 → `when_empty=unavailable`. `not_run`은 거짓입니다(과제는 돌았습니다). `complete`는 게스트가 떠 있었고 그 청구서를 이 프로세스가 읽을 수 없는 과제에 대해 **실측 0원을 주장하는 문장**이 됩니다.
- `usage_complete`는 금액을 모르는 동안 계속 `false`이고, journal의 `cost_settled`도 같은 시험을 씁니다.

## 전날의 교훈은 여기 적용되지 않습니다

#547의 결론은 "mypy가 잡고 있었는데 아무도 읽지 않는 출력에 있었다"였습니다. 이번은 다릅니다. **타입이 맞습니다.** `bind_run_to_ledger`는 `dict[str, Any]`를 돌려주고, 콜백은 `Mapping[str, Any] | None`을 요구합니다. 만족합니다.

수정 전 파일에 mypy를 직접 돌려 확인했습니다. 스크립트 오류 5건(409, 625, 726, 1006, 1025행), 전체 93건 — 수정 전후 동일하고 문제의 줄은 어느 쪽에도 없습니다. **분기를 실제로 실행하는 것 말고는 잡을 방법이 없었습니다.**

## 같이 들어가는 두 번째 결함 — 재개가 재개가 아니었습니다

`run_id` 입력은 "reuse an earlier one to resume it"이라고 적혀 있었지만 CI에서는 거짓이었습니다. journal과 원장은 `$GITHUB_WORKSPACE/agentic-v2-run/`에 쓰이고 업로드 artifact로만 남으며, 실행 전에 아무것도 되돌려받지 않았습니다.

게다가 journal은 `run_id`로 범위가 잡힙니다(`TaskJournal(path, run_id=..., task_ids=...)`). 그래서 **반쪽만 주는 두 경우가 결과적으로 같습니다.**

| 입력 | 무슨 일이 | 결과 |
|---|---|---|
| 둘 다 | 디렉터리 복원 + 같은 이름으로 읽음 | 진짜 재개 |
| 둘 다 없음 | 새 journal | 전부 실행 (의도한 것) |
| `run_id`만 | 복원이 없어 journal 파일이 없음 | **전액 재과금**, 로그는 재개처럼 읽힘 |
| `resume_from_github_run`만 | 복원됐지만 다른 이름으로 읽음 | **전액 재과금**, 증거가 디스크에 있고 읽히지 않음 |

둘 다 예외를 던지지 않습니다. 빈 journal에는 완료된 과제가 없고, 올바른 드라이버는 그걸 읽으면 전부 실행합니다. 그래서 유료 작업 안에서 막을 수 없고 시작 전에 막습니다.

- 무료 작업: 체크아웃 직후, `pip install` 전에 두 입력이 짝인지 검사(표준 라이브러리만 씁니다 — 테스트로 고정).
- 유료 작업: artifact를 `agentic-v2-run/`으로 복원하고, `journal.jsonl`이 오지 않았으면 거부. `download-artifact`는 이름이 안 맞아도 조용히 성공할 수 있습니다.
- `run_id` 설명에서 혼자서 재개를 약속하던 문장을 지웠습니다.

## 검증

- 무료 작업이 돌리는 목록 그대로 **456건 통과** (새 파일 둘 포함, 파이썬 3.10).
- 새 테스트 파일 둘은 모델도 네트워크도 건드리지 않습니다. 원장은 임시 디렉터리의 진짜 sqlite이고 turn만 조작입니다.
- 실제 정산 결과를 확인했습니다: 호출 있음 → `partial` / `null` / `price_missing`, 호출 없음 → `unavailable` / `ledger_absent`.

## 아직 열려 있는 것 (이 PR 밖)

- `RunWideCeilings()`가 전부 `None`으로 생성됩니다(`run_agentic_v2_stage.py:670`). 실행 **중** 총액 상한이 강제되지 않습니다.
- `cost_receipts.sqlite3`를 읽는 코드가 없습니다. 17샤드 원장 병합이 아직 없어 과제별 비용 합산은 오프라인 작업입니다.
- 가격표에 `gpt-5.4` 항목이 없습니다. 실행 중 가격표 변경은 금지되어 있고 A와 공유하는 파일이므로 별도로 다룹니다.
