### PR TITLE
가격표를 건네지 않은 원장이 모든 금액을 빈칸으로 만듭니다

### DIFF
--- a/.github/workflows/agentic-v2-stage-run.yml
+++ b/.github/workflows/agentic-v2-stage-run.yml
@@ -202,6 +202,16 @@ jobs:
       # dispatch; these check that the guard is still wired to the job and that
       # the paid job still restores what the guard assumes it restores. The two
       # defects before this one were both a correct function nobody called.
+      #
+      # The last two are the second paid dispatch and what was found looking
+      # for its siblings. One is a receipt: the report was handed the ledger's
+      # note of what it wrote, which has no `status`, and refused the row after
+      # both calls had been charged for. The other was never reached at all --
+      # the run record read a fingerprint off the Azure client in a block that
+      # runs after the `finally` that closes it, so the first run to finish its
+      # cohort would have lost the record of it. Both hold source order as well
+      # as behaviour, because the only runtime that reaches those lines is a
+      # paid one.
       - name: Test the runner
         run: |
           set -euo pipefail
@@ -217,7 +227,32 @@ jobs:
             tests/test_run_agentic_v2_stage.py \
             tests/test_the_dry_run_certified_a_path_it_never_reached.py \
             tests/test_a_resume_that_only_half_arrives_pays_twice.py \
-            tests/test_the_report_was_handed_a_binding_not_a_receipt.py
+            tests/test_the_report_was_handed_a_binding_not_a_receipt.py \
+            tests/test_the_record_was_written_after_the_client_was_shut.py
+
+      # mypy, on one file, because on this file it has already earned it: the
+      # constructor keyword that killed the first paid dispatch was reported at
+      # its exact line, and no job read the output. `backend-tests.yml` says in
+      # its own header why it does not gate on mypy -- the repository carries
+      # roughly ninety pre-existing errors and a whole-tree gate would be red
+      # on arrival. This is not that gate. It is one file, and that file is at
+      # zero as of this commit, which is what makes the check answerable.
+      #
+      # `--follow-imports=silent` keeps it that way: without it the imported
+      # modules bring their own errors in and the step fails for reasons that
+      # have nothing to do with the script being dispatched.
+      #
+      # Necessary and not sufficient, measured. The *second* paid dispatch died
+      # on a defect mypy cannot see -- a `dict[str, Any]` handed to a parameter
+      # typed `Mapping[str, Any] | None`, which is a legal call and a wrong
+      # object. That is what the dry run above is for. Neither check replaces
+      # the other and the paid path needs both.
+      - name: Type-check the stage runner
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          python -m mypy scripts/run_agentic_v2_stage.py \
+            --ignore-missing-imports --follow-imports=silent
 
       # No charge. The revision is the one the catalogue was built from and the
       # one every figure in the plan rests on; the binding hashes the wording it

--- a/batch-runner/scripts/run_agentic_v2_stage.py
+++ b/batch-runner/scripts/run_agentic_v2_stage.py
@@ -95,6 +95,7 @@ from core.agentic_v2_sharding import ShardRefused  # noqa: E402
 from core.agentic_v2_sharding import parse as parse_shard  # noqa: E402
 from core.agentic_v2_stage_one_budget import (  # noqa: E402
     STAGE_ONE_PLAN_PATH,
+    StagePricing,
     load_stage_one_plan,
     price_one_stage,
     run_stage_one_preflight,
@@ -380,7 +381,9 @@ def verdict_for(plan_path: Path):
     return plan, result, catalog
 
 
-def check_the_plan_priced_this_stage(plan: dict, stage: str, bound, catalog) -> list[str]:
+def check_the_plan_priced_this_stage(
+    plan: dict, stage: str, bound, catalog
+) -> tuple[StagePricing, list[str]]:
     """Whether the amounts approved describe the run about to happen.
 
     The plan prices each stage by name, and the figures are per-run rather than
@@ -429,10 +432,29 @@ def open_the_ledger(into: Path, *, run_id: str):
     executed -- not in CI, not in a test. A ``TypeError`` on a keyword argument
     is the cheapest possible version of that gap. The expensive version is the
     same gap one line further down, after the model has been asked.
-    """
-    from core.cost_receipts import CostReceiptLedger
 
-    return CostReceiptLedger(str(into / "cost_receipts.sqlite3"), run_id=run_id)
+    The ledger is given the price list. Without it every call settles
+    ``price_missing`` and every receipt reads ``partial`` with a null amount --
+    not because the model is unpriced, but because the ledger was never handed
+    the prices. ``azure:gpt-5.4`` is in the committed list at $2.50 and $15.00
+    per million, sourced from the Azure retail price API and last reviewed on
+    2026-08-29, so a run without this argument would have reported the whole
+    cohort as unaccounted for while the figures sat in the repository.
+
+    Two loaders read that same file and their names are close enough to swap by
+    accident. ``execution_envelope_cost.load_price_table`` returns prices keyed
+    by bare model name for the pre-run ceiling and for the voice;
+    ``cost_receipts.load_receipt_price_table`` returns the table the ledger
+    takes, keyed ``provider:model``, and fingerprints the file so a receipt can
+    name the exact bytes that priced it. The ledger wants the second.
+    """
+    from core.cost_receipts import CostReceiptLedger, load_receipt_price_table
+
+    return CostReceiptLedger(
+        str(into / "cost_receipts.sqlite3"),
+        run_id=run_id,
+        price_table=load_receipt_price_table(),
+    )
 
 
 def settle_into_a_receipt(ledger, *, task_id: str, model_turns) -> dict[str, Any]:
@@ -487,7 +509,21 @@ def the_paid_setup_a_dry_run_can_reach(stage: str) -> list[str]:
     from core.agentic_v2_cost_binding import ModelTurn
     from core.agentic_v2_run_report import build_agentic_v2_metrics, build_result_row
     from core.agentic_v2_task_journal import TaskStanding
-    from core.cost_receipts import CallUsage
+    from core.cost_receipts import REASON_PRICE_MISSING, CallUsage
+
+    # The name the plan pins, so the rehearsal prices the model the run will
+    # actually be billed for rather than a placeholder. A made-up name is not
+    # in the price list, settles `price_missing` like anything else unpriced,
+    # and would have let the defect below through: the ledger was being opened
+    # with no price list at all, so every call in every paid run settled
+    # `price_missing` and every receipt read `partial` with a null amount --
+    # for a model the repository prices exactly.
+    pinned_model = str(
+        (load_stage_one_plan(STAGE_ONE_PLAN_PATH).get("model") or {}).get(
+            "resolved_model"
+        )
+        or ""
+    )
 
     # A task that made a call and succeeded, and a task that made none and
     # ended the way the first paid task actually ended. The second is the
@@ -503,9 +539,9 @@ def the_paid_setup_a_dry_run_can_reach(stage: str) -> list[str]:
                     call_id="dry-run:a-task-that-called-the-model:1:call-1",
                     usage=CallUsage(input_tokens=100, output_tokens=10),
                     provider="azure",
-                    requested_model="dry-run-deployment",
+                    requested_model=pinned_model,
                     deployment="dry-run-deployment",
-                    resolved_model="dry-run-deployment",
+                    resolved_model=pinned_model,
                 ),
             ),
             {"success": True},
@@ -520,6 +556,14 @@ def the_paid_setup_a_dry_run_can_reach(stage: str) -> list[str]:
     )
 
     with tempfile.TemporaryDirectory(prefix=f"agentic-v2-{stage}-dry-") as scratch:
+        # Loaded on the paid path only, a few lines after the Azure client is
+        # built, and needing no identity of its own -- so the free job can read
+        # the same file the paid run will, and a price list that has stopped
+        # parsing is found here rather than after a deployment has been leased.
+        try:
+            load_price_table()
+        except Exception as broke:  # noqa: BLE001 - reported, not handled
+            return [f"the committed price list cannot be loaded: {broke!r}"]
         try:
             ledger = open_the_ledger(Path(scratch), run_id="dry-run")
         except Exception as broke:  # noqa: BLE001 - reported, not handled
@@ -565,6 +609,27 @@ def the_paid_setup_a_dry_run_can_reach(stage: str) -> list[str]:
                     return [
                         "a settled task cannot be turned into a report row: "
                         f"{broke!r}"
+                    ]
+
+                # Last, because shape comes before amount: a receipt of the
+                # wrong type has to be reported as that rather than as a
+                # missing price. This is the check the unpriced ledger walked
+                # past -- the receipt was well-formed, the row built, the run
+                # reported, and every amount in it was null. Right shape and
+                # absent amount look identical to everything above.
+                if not turns:
+                    continue
+                if REASON_PRICE_MISSING in (receipt.get("missing_reasons") or ()):
+                    return [
+                        f"a call against the pinned model {pinned_model!r} "
+                        "settles as unpriced; the ledger is not reading the "
+                        "committed price list"
+                    ]
+                if receipt.get("estimated_cost_usd") is None:
+                    return [
+                        "a settled call against the pinned model carries no "
+                        f"amount: {receipt.get('status')!r}, missing "
+                        f"{receipt.get('missing_reasons')!r}"
                     ]
         finally:
             ledger.close()
@@ -829,6 +894,8 @@ def main() -> int:
     # the same reason -- there is no route.
     rehearsing = RehearsalVoice() if args.rehearse else None
     managed = None
+    ledger = None
+    route_fingerprint: str | None = None
     prices: Any = {}
     if rehearsing is None:
         settings = AzureAIRouteSettings.from_env()
@@ -841,7 +908,7 @@ def main() -> int:
         prices = load_price_table()
 
     try:
-        if rehearsing is None:
+        if managed is not None:
             wrong_route = check_route_is_the_one_the_plan_fixed(
                 managed.route, connection, settings=settings
             )
@@ -851,6 +918,30 @@ def main() -> int:
                     "anything.\n\n  - " + "\n  - ".join(wrong_route)
                 )
                 return 1
+
+            # Read here, while the client is open, because the record that
+            # wants it is built after the `finally` below has closed it.
+            # `runtime_fingerprint` asks `_require_open()` first, so reading it
+            # down there raises `RuntimeError: managed Azure AI client is
+            # closed` and no run record is written at all.
+            #
+            # The journal, the deliverables and the ledger are written during
+            # the run and survive, so the outcomes, the files and the amounts
+            # are recoverable. What only the record holds is `reference_files`
+            # -- what each task was actually handed -- and `conversations`.
+            # Those are lost, for a run that had already succeeded.
+            #
+            # Nothing had ever reached that line. A rehearsal substitutes a
+            # disclaimer for it, the dry run returns hundreds of lines earlier,
+            # and both paid runs so far died before the tasks were done. The
+            # first run it would have hit is the first run that *finishes*,
+            # which is the most expensive moment available to fail at.
+            #
+            # Reading it early is not a workaround: the fingerprint is fixed
+            # when the lease is built and cannot change during the run, and it
+            # is read here immediately after the route it describes has been
+            # checked against the plan.
+            route_fingerprint = managed.runtime_fingerprint
 
         held = TaskConversations(ceilings, RunWideCeilings())
         attempts: dict[str, int] = {}
@@ -1106,6 +1197,18 @@ def main() -> int:
     finally:
         if managed is not None:
             managed.close()
+        # The dry run's rehearsal closes its ledger in a `finally` and this,
+        # the path the rehearsal exists to certify, did not close its own at
+        # all. The ledger is sqlite in WAL mode, so committed rows sit in a
+        # sidecar file until something checkpoints them. A process that exits
+        # normally checkpoints on the way out; a shard killed by its own
+        # `timeout-minutes` does not, and then the amounts are only readable by
+        # whoever remembers to carry the `-wal` file along with the database.
+        #
+        # The artifact upload takes the whole directory, so nothing has been
+        # lost so far. That is luck about a glob, not a property of this code.
+        if ledger is not None:
+            ledger.close()
 
     record = {
         "stage": args.stage,
@@ -1146,7 +1249,7 @@ def main() -> int:
         "route_fingerprint": (
             rehearsal_is_not_a_run()
             if rehearsing is not None
-            else managed.runtime_fingerprint
+            else route_fingerprint
         ),
         "chosen_settings": chosen.as_dict(),
         "conversations": held.as_dict(),

--- a/batch-runner/tests/test_the_record_was_written_after_the_client_was_shut.py
+++ b/batch-runner/tests/test_the_record_was_written_after_the_client_was_shut.py
@@ -1,0 +1,394 @@
+"""The run record was written after the client it describes had been shut.
+
+`main` closes the Azure client in a ``finally``, and then builds the run record
+below it. One field of that record was ``managed.runtime_fingerprint`` -- a
+property that calls ``_require_open()`` first and raises on a closed client::
+
+    RuntimeError: managed Azure AI client is closed
+
+So a paid run that got all the way through its cohort would die while writing
+the record of it, and `run_record.json` would not be written at all.
+
+How bad that is, stated exactly rather than dramatically. Three things are
+written during the run and survive: the journal, the collected deliverables and
+the cost ledger. So the outcome of every task, its files and their digests, and
+what each call is known to have cost are all still there, and the binding and
+the approved amounts are deterministic and can be worked out again. What exists
+nowhere else is what the record alone holds: `reference_files` -- which files
+each task was actually handed, per attempt, which the record's own comment says
+a result is read against -- and `conversations`, the per-task budget and turn
+state. Those two are gone, and the assembled account has to be rebuilt by hand
+from three files for a run that had already succeeded.
+
+Nothing had ever executed the line. A rehearsal substitutes a disclaimer for it,
+the dry run returns several hundred lines earlier, and the two paid runs so far
+died before their tasks were done -- one on a constructor keyword, one on a
+receipt shape. The first run this would have hit is the first run that
+*finishes*, which is the most expensive moment available to fail at: the whole
+cohort paid for and no record of it.
+
+The fix reads the fingerprint while the client is open, immediately after the
+route it describes has been checked. It is fixed when the lease is built and
+cannot change during the run, so early and late are the same value -- the
+difference is only that one of them is readable.
+
+Nothing here opens a client, reaches Azure or spends anything.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.llm_client import ManagedAzureAIClient  # noqa: E402
+
+RUNNER_PATH = BATCH_RUNNER_ROOT / "scripts" / "run_agentic_v2_stage.py"
+STAGE_SOURCE = RUNNER_PATH.read_text()
+
+
+def _load_runner():
+    """Import the script by path; it is not in a package.
+
+    Registered in ``sys.modules`` before execution for the same reason the
+    sibling stage test gives: a dataclass field's type is resolved by looking
+    the defining module up there.
+    """
+    spec = importlib.util.spec_from_file_location("run_agentic_v2_stage", RUNNER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+runner = _load_runner()
+
+
+class _Lease:
+    """Enough of a lease to build the real adapter around."""
+
+    runtime_fingerprint = "route:whatever-the-lease-was-built-with"
+    client = object()
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+# ── the property, against the real class ────────────────────────────────────
+
+
+def test_the_fingerprint_is_readable_while_the_client_is_open():
+    managed = ManagedAzureAIClient(_Lease())
+
+    assert managed.runtime_fingerprint == "route:whatever-the-lease-was-built-with"
+
+    managed.close()
+
+
+def test_the_fingerprint_raises_once_the_client_is_closed():
+    """The whole defect in three lines, against the real adapter.
+
+    Not a double: a stand-in with a forgiving property is exactly how this
+    passed review. The refusal is deliberate and correct -- a closed client
+    should not answer questions about itself -- so the fix belongs at the call
+    site, not here.
+    """
+    managed = ManagedAzureAIClient(_Lease())
+    managed.close()
+
+    with pytest.raises(RuntimeError) as refused:
+        managed.runtime_fingerprint
+
+    assert "closed" in str(refused.value)
+
+
+def test_closing_twice_does_not_reopen_anything():
+    """`close` is idempotent, so nothing recovers by calling it again.
+
+    Worth pinning: "just close it later" and "close it twice" are both natural
+    guesses at a fix, and neither makes the property readable again.
+    """
+    lease = _Lease()
+    managed = ManagedAzureAIClient(lease)
+    managed.close()
+    managed.close()
+
+    assert lease.closed is True
+    with pytest.raises(RuntimeError):
+        managed.runtime_fingerprint
+
+
+# ── the call site, which is where the fix is ────────────────────────────────
+
+
+def test_the_fingerprint_is_read_before_the_client_is_closed():
+    """Order is the invariant, so order is what is asserted.
+
+    There is no cheap runtime test for this: reaching the record means an Azure
+    identity, a bound cohort and a finished run. The order of two lines in one
+    function is checkable for nothing, and it is the whole defect.
+    """
+    read = "route_fingerprint = managed.runtime_fingerprint"
+    assert read in STAGE_SOURCE, "the fingerprint is not captured anywhere"
+
+    assert STAGE_SOURCE.index(read) < STAGE_SOURCE.index("managed.close()")
+
+
+def test_the_record_does_not_reach_for_the_client():
+    """Everything after the record starts being built must be already-read data.
+
+    The record is assembled after the ``finally``, so any attribute read on the
+    client from there is the same defect under another name.
+    """
+    after_the_run = STAGE_SOURCE[STAGE_SOURCE.index("\n    record = {") :]
+
+    assert "managed." not in after_the_run
+
+
+def test_the_record_still_carries_the_fingerprint():
+    """Not reading it is not the fix; reading it earlier is.
+
+    A field quietly dropped to ``None`` would make the record claim the route
+    was unknown for a run that checked it.
+    """
+    after_the_run = STAGE_SOURCE[STAGE_SOURCE.index("\n    record = {") :]
+
+    assert '"route_fingerprint": (' in after_the_run
+    assert "else route_fingerprint" in after_the_run
+
+
+def test_a_rehearsal_still_refuses_to_name_a_route():
+    """The rehearsal branch is untouched and must stay that way.
+
+    A rehearsal asks nothing, so it has no route to fingerprint, and the record
+    it writes says so rather than carrying a plausible-looking string.
+    """
+    after_the_run = STAGE_SOURCE[STAGE_SOURCE.index("\n    record = {") :]
+
+    assert "rehearsal_is_not_a_run()" in after_the_run
+
+
+# ── the ledger the same block leaves open ───────────────────────────────────
+
+
+def test_the_ledger_is_closed_where_the_client_is():
+    """Found looking for siblings of the defect above, in the same `finally`.
+
+    The ledger is sqlite in WAL mode, so committed rows sit in a `-wal` sidecar
+    until something checkpoints them, and closing the connection is what does
+    it. A process that exits normally checkpoints anyway; a shard killed by its
+    own `timeout-minutes` does not.
+
+    Not data loss today -- the artifact upload takes the whole directory, so
+    the sidecar goes with it -- and stated that way in the comment rather than
+    dressed up. It is fixed because the rehearsal that certifies this path has
+    always closed its ledger and this path did not, which is the asymmetry the
+    rehearsal exists to prevent.
+    """
+    closing = STAGE_SOURCE[STAGE_SOURCE.index("\n    finally:") :]
+    closing = closing[: closing.index("\n    record = {")]
+
+    assert "managed.close()" in closing
+    assert "ledger.close()" in closing
+
+
+def test_the_ledger_exists_before_the_try_that_closes_it():
+    """Otherwise the `finally` raises `NameError` on every refused run.
+
+    The ledger is opened inside the `try` and only on the paid branch, so a run
+    refused before that line reaches the `finally` with the name unbound.
+
+    Scoped to `main`, because the dry-run rehearsal above it opens a ledger of
+    its own and an unscoped search finds that one first.
+    """
+    body = STAGE_SOURCE[STAGE_SOURCE.index("\ndef main()") :]
+
+    assert "\n    ledger = None\n" in body
+    assert body.index("\n    ledger = None\n") < body.index("ledger = open_the_ledger")
+
+
+# ── the price list, which the paid path reads and the free job now does ─────
+
+
+def test_the_free_job_reads_the_price_list_the_paid_run_will():
+    """Runs for real here, because unlike the route it needs no identity.
+
+    A price list that has stopped parsing is worth finding before a deployment
+    is leased rather than after.
+    """
+    assert runner.the_paid_setup_a_dry_run_can_reach("advance_check_5") == []
+
+
+def test_a_price_list_that_will_not_load_is_reported_and_not_raised(monkeypatch):
+    """The dry run returns problems; it does not crash on them."""
+
+    def refuse(*_args, **_kwargs):
+        raise ValueError("the price list is not yaml any more")
+
+    monkeypatch.setattr(runner, "load_price_table", refuse)
+    problems = runner.the_paid_setup_a_dry_run_can_reach("advance_check_5")
+
+    assert len(problems) == 1
+    assert "price list" in problems[0]
+
+
+def test_the_missing_price_for_this_model_is_not_what_that_check_fails_on():
+    """The pinned model is priced, and the free job now proves it end to end.
+
+    This is the correction to a belief that had been carried for two days: the
+    null amounts seen from the ledger were read as "`gpt-5.4` is absent from the
+    price table". It is not absent. ``azure:gpt-5.4`` is in the committed list
+    at $2.50 and $15.00 per million, sourced from the Azure retail price API and
+    last reviewed 2026-08-29. The nulls came from the ledger being opened with
+    no price table at all, which made every call in every paid run settle
+    `price_missing` regardless of what the file said.
+    """
+    from core.cost_receipts import load_receipt_price_table
+
+    pinned = str(
+        (runner.load_stage_one_plan(runner.STAGE_ONE_PLAN_PATH).get("model") or {}).get(
+            "resolved_model"
+        )
+        or ""
+    )
+
+    assert pinned, "the plan pins no model name"
+    assert load_receipt_price_table().lookup("azure", pinned) is not None
+
+
+def test_the_ledger_is_opened_with_the_price_list():
+    """A ledger without one prices nothing, and says so on every receipt.
+
+    Checked on the object rather than in the source, because the argument being
+    present is not the claim -- the claim is that the ledger this function
+    returns can price a call.
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as scratch:
+        ledger = runner.open_the_ledger(Path(scratch), run_id="a-test")
+        try:
+            assert ledger.price_table is not None
+        finally:
+            ledger.close()
+
+
+def test_a_priced_call_settles_complete_with_an_amount():
+    """The whole point of the price list, asserted as money.
+
+    Run against the real ledger and the real committed prices, on a fabricated
+    turn. 1,000,000 input and 1,000,000 output tokens against $2.50 and $15.00
+    per million is $17.50, so the arithmetic is checkable by eye and a silently
+    swapped rate would not survive it.
+    """
+    import tempfile
+
+    from core.agentic_v2_cost_binding import ModelTurn
+    from core.cost_receipts import CallUsage
+
+    pinned = str(
+        (runner.load_stage_one_plan(runner.STAGE_ONE_PLAN_PATH).get("model") or {}).get(
+            "resolved_model"
+        )
+        or ""
+    )
+
+    with tempfile.TemporaryDirectory() as scratch:
+        ledger = runner.open_the_ledger(Path(scratch), run_id="a-test")
+        try:
+            receipt = runner.settle_into_a_receipt(
+                ledger,
+                task_id="a-task",
+                model_turns=(
+                    ModelTurn(
+                        call_id="a-test:a-task:1:call-1",
+                        usage=CallUsage(input_tokens=1_000_000, output_tokens=1_000_000),
+                        provider="azure",
+                        requested_model=pinned,
+                        deployment="a-deployment",
+                        resolved_model=pinned,
+                    ),
+                ),
+            )
+        finally:
+            ledger.close()
+
+    assert receipt["status"] == "complete"
+    assert receipt["missing_reasons"] == []
+    assert receipt["estimated_cost_usd"] == pytest.approx(17.50)
+    assert receipt["price_table_sha256"] is not None
+
+
+def test_a_call_the_price_list_does_not_cover_is_still_partial_and_null():
+    """The fix does not invent an amount for a model nobody priced.
+
+    An unknown name settles `price_missing`, the receipt reads `partial`, and
+    `estimated_cost_usd` stays null. That was the right behaviour before this
+    change and it has to survive it -- otherwise the fix would have replaced
+    one wrong number with another.
+    """
+    import tempfile
+
+    from core.agentic_v2_cost_binding import ModelTurn
+    from core.cost_receipts import CallUsage
+
+    with tempfile.TemporaryDirectory() as scratch:
+        ledger = runner.open_the_ledger(Path(scratch), run_id="a-test")
+        try:
+            receipt = runner.settle_into_a_receipt(
+                ledger,
+                task_id="a-task",
+                model_turns=(
+                    ModelTurn(
+                        call_id="a-test:a-task:1:call-1",
+                        usage=CallUsage(input_tokens=100, output_tokens=10),
+                        provider="azure",
+                        requested_model="a-model-nobody-priced",
+                        deployment="a-deployment",
+                        resolved_model="a-model-nobody-priced",
+                    ),
+                ),
+            )
+        finally:
+            ledger.close()
+
+    assert receipt["status"] == "partial"
+    assert "price_missing" in receipt["missing_reasons"]
+    assert receipt["estimated_cost_usd"] is None
+
+
+def test_the_dry_run_would_have_caught_the_unpriced_ledger():
+    """The free job fails when the ledger is opened without a price list.
+
+    Proved by opening one that way, which is what the code did until this
+    change. Without this the fix is a line nobody would notice going back.
+    """
+    import tempfile
+
+    from core.cost_receipts import CostReceiptLedger
+
+    def unpriced(into, *, run_id):
+        return CostReceiptLedger(str(Path(into) / "cost_receipts.sqlite3"),
+                                 run_id=run_id)
+
+    with tempfile.TemporaryDirectory():
+        original = runner.open_the_ledger
+        runner.open_the_ledger = unpriced
+        try:
+            problems = runner.the_paid_setup_a_dry_run_can_reach("advance_check_5")
+        finally:
+            runner.open_the_ledger = original
+
+    assert len(problems) == 1
+    assert "unpriced" in problems[0]
+    assert "price list" in problems[0]

--- a/batch-runner/tests/test_the_report_was_handed_a_binding_not_a_receipt.py
+++ b/batch-runner/tests/test_the_report_was_handed_a_binding_not_a_receipt.py
@@ -25,9 +25,16 @@ Two things are held here beyond "it works now":
 * the paid path and the dry run go through **one** function, so the certifying
   path cannot drift from the certified one, and
 * a call this repo has no price for settles ``partial``, never a real ``$0``.
-  The pinned deployment is not in the committed price table, so every call the
-  V2 stage makes is currently unpriced. A receipt that rounded that to zero
-  would be the one number in the record that reads as a measurement.
+  A receipt that rounded an unknown amount to zero would be the one number in
+  the record that reads as a measurement.
+
+The second point was first written here with a wrong premise attached: that the
+pinned deployment was not in the committed price table, so every V2 call was
+unpriced by necessity. It is in the table. The nulls came from
+``open_the_ledger`` building the ledger without handing it that table, which
+marks every call ``price_missing`` whatever the file says. Corrected, with the
+fix and its own test, in the same change that added
+``test_the_pinned_model_is_priced_and_settles_complete`` below.
 
 Nothing here calls a model or reaches the network. The ledger is real and
 sqlite-backed in a temporary directory; the turns are fabricated.
@@ -66,8 +73,12 @@ from core.cost_receipts import (  # noqa: E402
 STAGE_SOURCE = (SCRIPTS / "run_agentic_v2_stage.py").read_text()
 
 
-def _turn(task_id: str, call: str = "call-1", **usage: int) -> ModelTurn:
-    """One model call, named the way the real run names them."""
+def _turn(task_id: str, call: str = "call-1", model: str = "gpt-5.4", **usage: int) -> ModelTurn:
+    """One model call, named the way the real run names them.
+
+    ``model`` defaults to the pinned name, which the committed price list
+    covers. Pass a name it does not cover to build a genuinely unpriced call.
+    """
     return ModelTurn(
         call_id=f"a-run:{task_id}:1:{call}",
         usage=CallUsage(
@@ -75,9 +86,9 @@ def _turn(task_id: str, call: str = "call-1", **usage: int) -> ModelTurn:
             output_tokens=usage.get("output_tokens", 22),
         ),
         provider="azure",
-        requested_model="gpt-5.4",
+        requested_model=model,
         deployment="gpt-5.4",
-        resolved_model="gpt-5.4",
+        resolved_model=model,
     )
 
 
@@ -201,18 +212,23 @@ def test_the_failed_task_the_run_actually_had_also_builds_a_row(tmp_path):
 
 
 def test_an_unpriced_call_is_partial_and_not_a_zero(tmp_path):
-    """The state every V2 call is in today, stated as the record must state it.
+    """An amount that is not known must not be published as a zero.
 
-    ``gpt-5.4`` has no entry in the committed price table, so the tokens are
-    known and the amount is not. ``partial`` with a null estimate is the true
-    sentence. A ``0.0`` here would be indistinguishable from a task that really
-    cost nothing, and the tokens that would let anyone recompute it later are
-    only kept because the status says the amount is missing.
+    Written first in the belief that this was the state of *every* V2 call --
+    that ``gpt-5.4`` had no entry in the committed price table. That was wrong
+    and the correction is in the test below: the entry exists, and the nulls
+    came from the ledger being opened without the table. The rule this test
+    holds is unchanged and still worth holding, so it is exercised here on a
+    model that genuinely has no price: the tokens are known, the amount is not,
+    and ``partial`` with a null estimate is the true sentence. A ``0.0`` would
+    be indistinguishable from a task that really cost nothing.
     """
     ledger = stage.open_the_ledger(tmp_path, run_id="a-run")
     try:
         receipt = stage.settle_into_a_receipt(
-            ledger, task_id="t1", model_turns=(_turn("t1"),)
+            ledger,
+            task_id="t1",
+            model_turns=(_turn("t1", model="a-model-nobody-priced"),),
         )
     finally:
         ledger.close()
@@ -225,6 +241,29 @@ def test_an_unpriced_call_is_partial_and_not_a_zero(tmp_path):
     assert receipt["usage"]["output_tokens"] == 22
 
 
+def test_the_pinned_model_is_priced_and_settles_complete(tmp_path):
+    """The correction, asserted rather than described.
+
+    ``azure:gpt-5.4`` is in the committed price list. Every V2 receipt read
+    ``partial`` anyway because ``open_the_ledger`` built the ledger without
+    handing it that list, and a ledger with no list marks every call
+    ``price_missing`` whatever the file says. Fixed in the same change as this
+    test; without this line the fix is silent and reversible.
+    """
+    ledger = stage.open_the_ledger(tmp_path, run_id="a-run")
+    try:
+        receipt = stage.settle_into_a_receipt(
+            ledger, task_id="t1", model_turns=(_turn("t1"),)
+        )
+    finally:
+        ledger.close()
+
+    assert receipt["status"] == STATUS_COMPLETE
+    assert receipt["missing_reasons"] == []
+    assert receipt["estimated_cost_usd"] is not None
+    assert receipt["estimated_cost_usd"] > 0
+
+
 def test_a_partial_receipt_does_not_mark_the_task_cost_accounted(tmp_path):
     """``usage_complete`` must stay false while the amount is unknown.
 
@@ -234,7 +273,9 @@ def test_a_partial_receipt_does_not_mark_the_task_cost_accounted(tmp_path):
     ledger = stage.open_the_ledger(tmp_path, run_id="a-run")
     try:
         receipt = stage.settle_into_a_receipt(
-            ledger, task_id="t1", model_turns=(_turn("t1"),)
+            ledger,
+            task_id="t1",
+            model_turns=(_turn("t1", model="a-model-nobody-priced"),),
         )
     finally:
         ledger.close()


### PR DESCRIPTION
유료 경로에서 **무료 작업이 한 번도 실행하지 않는 줄**을 두 개 더 찾았습니다.
#547(원장 생성자 인자), #548(영수증 대신 기록 쪽지)에 이은 네 번째·다섯 번째로,
같은 모양입니다. 모두 돈을 쓴 뒤에만 드러납니다.

---

## 1. 원장이 가격표 없이 열렸습니다 — 이 PR에서 제일 중요한 줄

`azure:gpt-5.4`는 커밋된 가격표에 **있습니다.**
`batch-runner/experiments/execution_envelope/model_price_table.json`,
100만 토큰당 입력 \$2.50 / 출력 \$15.00, 출처 Azure 소매 가격 API,
마지막 확인 2026-08-29.

그런데 `open_the_ledger`가 `CostReceiptLedger`를 만들면서 `price_table=`을
건네지 않았고, `core/cost_receipts.py:1421`은 표가 `None`이면 파일에 무엇이
적혀 있든 **모든 호출에 `price_missing`을 답니다.**

고치지 않았다면 5·30·220문제가 전부 이렇게 끝났을 것입니다.

| | 고치기 전 | 고친 뒤 |
|---|---|---|
| 영수증 상태 | `partial` | `complete` |
| `estimated_cost_usd` | `null` | 실제 금액 |
| `cost_is_fully_accounted` | false | true |

목표가 요구하는 **\"문제별 비용\"** 이, 돈을 이미 다 쓴 뒤에 답할 수 없게 되는
자리였습니다.

### 왜 눈에 안 띄었나 — 이름이 비슷한 적재 함수 두 개

같은 파일을 읽지만 서로 바꿔 쓸 수 없습니다.

| 함수 | 반환 | 키 | 쓰는 곳 |
|---|---|---|---|
| `execution_envelope_cost.load_price_table()` | `dict[str, ModelPrice]` | 모델 이름 | 사전 상한, 예행 문구 |
| `cost_receipts.load_receipt_price_table()` | `ReceiptPriceTable` | `provider:model` | **원장이 받는 유일한 것** |

### 정정

이 수정은 이틀 동안 들고 있던 **틀린 믿음**도 함께 정정합니다.
빈 금액을 \"이 모델은 가격표에 없다\"로 읽고 있었는데, 없는 것이 아니라
원장이 표를 못 받은 것이었습니다. 그 문장이 들어가 있던 이전 테스트
독스트링과 주석도 이 PR에서 같이 고쳤습니다.

---

## 2. 실행 기록을 이미 닫힌 클라이언트에게 물었습니다

`main`은 `finally`에서 Azure 클라이언트를 닫고, **그 아래에서** 실행 기록을
만듭니다. 그 기록의 한 칸이 `managed.runtime_fingerprint`인데, 이 속성은
`_require_open()`을 먼저 호출하므로 닫힌 클라이언트에서 이렇게 답합니다.

\`\`\`
RuntimeError: managed Azure AI client is closed
\`\`\`

즉 **과제를 다 끝낸 실행이 기록을 쓰다가 죽고, `run_record.json`은 아예 안
남습니다.**

지금까지 이 줄에 닿은 실행이 없습니다. 예행은 문구로 대신하고, 사전 점검은
수백 줄 전에 돌아가고, 유료 실행 둘은 과제가 끝나기 전에 죽었습니다
(하나는 생성자 인자, 하나는 영수증 모양). 이 줄에 처음 닿는 실행은 처음으로
**끝까지 가는** 실행 — 실패하기에 가장 비싼 순간입니다.

### 피해 범위는 부풀리지 않습니다

| | 어디에 있나 | 잃나 |
|---|---|---|
| 과제별 결과·사유 | 일지 | 아니오 |
| 결과물 파일·지문 | 수집 디렉터리 | 아니오 |
| 알려진 호출 금액 | 비용 원장 | 아니오 |
| `reference_files` (각 과제가 실제로 건네받은 파일) | **실행 기록에만** | **예** |
| `conversations` (과제별 예산·턴 상태) | **실행 기록에만** | **예** |

고침: 클라이언트가 열려 있는 동안, 그 경로를 확인한 직후에 읽습니다.
지문은 임차 시점에 정해져 실행 중 변하지 않으므로 이르게 읽으나 늦게 읽으나
같은 값이고, 차이는 읽을 수 있느냐뿐입니다.

---

## 3. 원장을 닫지 않았습니다 (정리 수준)

sqlite가 WAL 모드라 커밋된 행이 `-wal` 옆파일에 있다가 연결을 닫을 때 본체로
들어갑니다. 정상 종료하는 프로세스는 어차피 정리하지만, `timeout-minutes`에
잘린 분할 작업은 아닙니다.

**오늘 자료가 사라진 적은 없습니다** — 아티팩트 업로드가 디렉터리째 올리므로
옆파일도 같이 갑니다. 고치는 이유는 이 경로를 보증하는 예행이 늘 원장을 닫아
왔는데 이 경로만 안 닫았기 때문입니다. 예행이 막으라고 있는 바로 그 어긋남입니다.

---

## 4. mypy 한 파일 게이트

`scripts/run_agentic_v2_stage.py`를 오류 5개에서 0개로 줄이고 무료 작업에
단계로 넣었습니다 (`--follow-imports=silent`, 이 파일 하나).

다만 **mypy가 이 계열을 다 잡지는 못합니다.** #548의 결함은 수정 전후 mypy
출력이 완전히 동일했습니다 (`dict[str, Any]`가 `Mapping[str, Any]`를 만족).
그래서 진짜 방어선은 아래입니다.

---

## 무료 작업이 이제 어디까지 걸어가나

`the_paid_setup_a_dry_run_can_reach()`가 **고정 모델에 대해 지어낸 호출 하나**로
원장 → 정산 → 영수증 → 지표 → 보고 행까지 실제 함수로 갑니다. 모델은 안 부릅니다.

- 100만 입력 + 100만 출력 → **\$17.50** (눈으로 검산되는 값)
- 가격표에 없는 모델 → 그대로 `partial`에 빈 금액, **`\$0`이 아님**
- 원장을 가격표 없이 열면 → 무료 작업이 **실패합니다** (되돌림 방지)

---

## 아직 안 고친 것

따로 냅니다. 둘 다 동작을 바꾸는 변경이라 각자의 테스트가 필요합니다.

- `except DriverRefused: return 1`이 실행 기록을 안 씁니다. 드라이버는
  `core/agentic_v2_run_driver.py:213`에서 **실행 도중에도** 이 예외를 냅니다.
- `RunWideCeilings()`가 전부 `None`으로 만들어져 **실행 중** 전체 금액 상한이
  강제되지 않습니다.

---

## 테스트

- 전체: **11297 통과 / 18 건너뜀 / 46 제외**, 종료 코드 0
- mypy: `scripts/run_agentic_v2_stage.py` **오류 0**
- 새 파일 `test_the_record_was_written_after_the_client_was_shut.py` — 16개
- 각 수정마다 수정 전 소스에서 **실패하는지** 확인했습니다 (빈 테스트 아님)

네트워크 호출 없음, 이 PR에서 쓴 돈 없음.