### PR TITLE
원장은 쌓였는데 아무도 읽지 않았습니다

### DIFF
--- a/.github/workflows/agentic-v2-stage-run.yml
+++ b/.github/workflows/agentic-v2-stage-run.yml
@@ -228,15 +228,18 @@ jobs:
             tests/test_the_dry_run_certified_a_path_it_never_reached.py \
             tests/test_a_resume_that_only_half_arrives_pays_twice.py \
             tests/test_the_report_was_handed_a_binding_not_a_receipt.py \
-            tests/test_the_record_was_written_after_the_client_was_shut.py
+            tests/test_the_record_was_written_after_the_client_was_shut.py \
+            tests/test_nothing_read_the_ledger_the_run_wrote.py
 
-      # mypy, on one file, because on this file it has already earned it: the
-      # constructor keyword that killed the first paid dispatch was reported at
-      # its exact line, and no job read the output. `backend-tests.yml` says in
-      # its own header why it does not gate on mypy -- the repository carries
-      # roughly ninety pre-existing errors and a whole-tree gate would be red
-      # on arrival. This is not that gate. It is one file, and that file is at
-      # zero as of this commit, which is what makes the check answerable.
+      # mypy, on the paid path's own scripts, because on these it has already
+      # earned it: the constructor keyword that killed the first paid dispatch
+      # was reported at its exact line, and no job read the output.
+      # `backend-tests.yml` says in its own header why it does not gate on
+      # mypy -- the repository carries roughly ninety pre-existing errors and a
+      # whole-tree gate would be red on arrival. This is not that gate. It is
+      # the script a paid stage runs and the script that reads its bill
+      # afterwards, and both are at zero as of this commit, which is what
+      # makes the check answerable.
       #
       # `--follow-imports=silent` keeps it that way: without it the imported
       # modules bring their own errors in and the step fails for reasons that
@@ -247,11 +250,12 @@ jobs:
       # typed `Mapping[str, Any] | None`, which is a legal call and a wrong
       # object. That is what the dry run above is for. Neither check replaces
       # the other and the paid path needs both.
-      - name: Type-check the stage runner
+      - name: Type-check the stage runner and the cost roll-up
         run: |
           set -euo pipefail
           cd batch-runner
           python -m mypy scripts/run_agentic_v2_stage.py \
+            scripts/roll_up_agentic_v2_cost.py \
             --ignore-missing-imports --follow-imports=silent
 
       # No charge. The revision is the one the catalogue was built from and the
@@ -673,9 +677,49 @@ jobs:
           pattern: agentic-v2-${{ inputs.stage }}-shard-*
           path: shard-records
 
+      # Before the coverage verdict, not after it. A stage that ran badly is
+      # exactly the stage whose bill someone needs, and the coverage check
+      # below is designed to fail -- putting the reading after it would lose
+      # the account for every run that was worth accounting for. This step
+      # fails only when two shards settle the same call differently, which
+      # makes any total arbitrary; a partial, unpriced or half-finished stage
+      # is written out and says so.
+      - name: Read what the stage spent
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          python scripts/roll_up_agentic_v2_cost.py \
+            --records ../shard-records \
+            --stage "${{ inputs.stage }}" \
+            --out ../cost-rollup/cost_rollup.json | tee ../cost-rollup.txt
+          {
+            echo '### What this stage spent'
+            echo
+            echo '```'
+            cat ../cost-rollup.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # `always()` because the coverage check below fails on purpose and the
+      # bill must outlive that failure.
+      - name: Keep the cost roll-up
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: agentic-v2-${{ inputs.stage }}-cost
+          path: cost-rollup/
+          if-no-files-found: warn
+
       # Fails when the stage did not run, which includes the case where every
       # shard was green and one task was missed. A count would have passed that.
+      #
+      # `always()` because this is the step that decides whether the stage ran
+      # and nothing above it may take that decision away. The roll-up before it
+      # can exit non-zero -- two shards settling the same call differently --
+      # and without this the coverage verdict would silently not be reached on
+      # exactly the runs that most need it.
       - name: Check coverage and halts
+        if: ${{ always() }}
         run: |
           set -euo pipefail
           cd batch-runner

--- a/.gitignore
+++ b/.gitignore
@@ -232,6 +232,16 @@ batch-runner/scripts/*
 # two strings and makes no network call.
 !batch-runner/scripts/check_agentic_v2_resume_inputs.py
 
+# Reads the per-call cost ledger every paid shard writes and nothing until now
+# opened. Turns it into what each task cost and what the stage cost, keeping
+# apart the three populations a single number would hide: tasks the ledger has
+# rows for, tasks a shard was given and never reached, and tasks no shard
+# claimed at all. Committed because "문제별 비용" is a deliverable of the run
+# rather than a convenience, and because a stage whose money cannot be split by
+# task has to be reported as one figure or none. Opens sqlite files that are
+# already on disk; calls no model and makes no network call.
+!batch-runner/scripts/roll_up_agentic_v2_cost.py
+
 # Measures the one thing standing between a stage that runs and a stage whose
 # results mean something: the reference files a task names are not yet present
 # where the model can open them. Committed because the shape of that gap -- how

--- a/batch-runner/scripts/roll_up_agentic_v2_cost.py
+++ b/batch-runner/scripts/roll_up_agentic_v2_cost.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""Turn a finished V2 stage's shard ledgers into a per-task cost table.
+
+Every paid shard writes ``cost_receipts.sqlite3`` beside its record, and the
+collect job downloads all of them. Until this script, nothing read them. The
+run therefore had a complete, per-call, append-only account of what it spent
+and no way to answer the question the account exists for::
+
+    what did each task cost, and what did the stage cost
+
+That is the deliverable, not a nicety. A stage whose money cannot be split by
+task has to be reported as one number or none, and "none" is where a 220-task
+run ends up when the reading step was never written.
+
+What this does
+--------------
+
+Merges the shards into one ledger and reads it. Nothing is recomputed: the
+merge is :meth:`CostReceiptLedger.import_jsonl`, which is keyed on ``call_id``
+and so is idempotent, and the amounts come from
+:meth:`CostReceiptLedger.receipt_for` and :func:`summarise_receipts` — the same
+functions the run itself used. A task that appears in two shards' ledgers is
+one task here, and a shard re-uploaded twice changes nothing.
+
+Three populations, kept apart
+-----------------------------
+
+A stage's tasks fall into three groups and collapsing them is how a cost
+report starts lying:
+
+``in the ledger``
+    Something was reserved or settled against this task. Its receipt says what
+    that is worth, or why it cannot be said.
+``assigned but never reached``
+    A shard was told to run it and the ledger has no row for it. It is
+    ``not_run`` — not free. A shard killed by its own timeout leaves tasks
+    here, and counting them as ``$0`` would make a half-finished stage look
+    cheap rather than incomplete.
+``never assigned to any shard``
+    A shard's record is missing entirely. This is a coverage hole, reported
+    here and decided by ``check_agentic_v2_stage_coverage.py``, which is the
+    tool that owns pass/fail for a stage.
+
+What the exit code means
+------------------------
+
+This tool produces the number; it is not a second gate on the run. It exits
+non-zero only when the merge itself cannot be trusted — two shards claiming
+different settlements for the same ``call_id``, which
+:class:`LedgerIntegrityError` raises and which would make any total arbitrary.
+A stage that ran badly, ran partly, or could not be priced still exits 0 and
+says so in the file, because "the run went wrong" is the coverage check's
+sentence to pass, not this one's.
+
+What it will not do
+-------------------
+
+Write a zero it did not measure. ``estimated_cost_usd`` is populated only on a
+``complete`` receipt; everywhere else it is null and ``known_cost_usd`` stands
+beside it as a **floor**, which is a different claim and is labelled as one.
+An unpriced call is ``partial``. A task that ran and made no call at all is
+``unavailable``. A task that never ran is ``not_run``. Four different
+sentences, none of them "$0.00".
+
+Nothing here calls a model, reads a credential or touches the network.
+
+    cd batch-runner
+    python scripts/roll_up_agentic_v2_cost.py \
+        --records ../shard-records --stage advance_check_5
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from core.cost_receipts import (  # noqa: E402
+    BUCKET_PROBLEM_SOLVING,
+    STATUS_COMPLETE,
+    STATUS_UNAVAILABLE,
+    CostReceipt,
+    CostReceiptLedger,
+    LedgerIntegrityError,
+    summarise_receipts,
+)
+
+ROLLUP_SCHEMA_VERSION = 1
+
+LEDGER_NAME = "cost_receipts.sqlite3"
+RECORD_NAME = "run_record.json"
+
+
+class MergeRefused(RuntimeError):
+    """The shards cannot be added up, so no total may be published."""
+
+
+def find_ledgers(records: Path) -> list[Path]:
+    """Every shard ledger under a downloaded artifact tree, in a stable order.
+
+    ``download-artifact`` with a pattern puts each shard in its own directory,
+    so the ledgers sit one level down. Searched recursively rather than by a
+    fixed depth, because a single-shard run and a re-downloaded tree nest
+    differently and neither is wrong.
+    """
+    return sorted(records.rglob(LEDGER_NAME))
+
+
+def read_records(records: Path) -> list[dict[str, Any]]:
+    """Every shard's ``run_record.json``, skipping what will not parse.
+
+    A record that cannot be read is reported rather than raised on: the
+    ledgers are the source of the money, and losing a record costs us the
+    cohort list for that shard, not the amounts.
+    """
+    found: list[dict[str, Any]] = []
+    for path in sorted(records.rglob(RECORD_NAME)):
+        try:
+            payload = json.loads(path.read_text())
+        except (OSError, ValueError):
+            continue
+        if isinstance(payload, dict):
+            payload["_source"] = str(path)
+            found.append(payload)
+    return found
+
+
+def _ids(payload: Any, key: str) -> list[str]:
+    section = payload if isinstance(payload, dict) else {}
+    value = section.get(key)
+    return [str(entry) for entry in value] if isinstance(value, list) else []
+
+
+def cohort_and_assignment(
+    records: list[dict[str, Any]]
+) -> tuple[list[str], list[str], list[str]]:
+    """The stage's whole cohort, what the shards were given, and disagreements.
+
+    The binding is the stage; the shard is this process's slice of it. Both are
+    in every record, so a single surviving record is enough to know the whole
+    cohort — which is what lets a stage that lost a shard still report how many
+    tasks are missing rather than shrinking its own denominator to fit.
+    """
+    cohorts: dict[str, list[str]] = {}
+    assigned: list[str] = []
+    for record in records:
+        cohort = _ids(record.get("binding"), "task_ids")
+        if cohort:
+            cohorts[",".join(cohort)] = cohort
+        assigned.extend(_ids(record.get("shard"), "task_ids"))
+
+    problems: list[str] = []
+    if len(cohorts) > 1:
+        problems.append(
+            f"the shards do not agree on the cohort: {len(cohorts)} different "
+            "task lists are claimed, so the denominator below is the union"
+        )
+    union: list[str] = []
+    for cohort in cohorts.values():
+        for task_id in cohort:
+            if task_id not in union:
+                union.append(task_id)
+    return union, sorted(set(assigned)), problems
+
+
+def merge_ledgers(
+    ledgers: list[Path], *, into: Path, run_id: str
+) -> tuple[CostReceiptLedger, list[str]]:
+    """Fold every shard's rows into one ledger and say what came from where.
+
+    Uses the ledger's own export/import rather than touching SQL, because the
+    import is where double-counting is prevented: ``call_id`` is the primary
+    key, re-importing a row already present is a no-op, and re-importing it
+    with *different* numbers raises rather than picking one.
+
+    Opened deliberately **without** a price table, and this is not the
+    oversight it looks like. ``settle`` prices a call when the reply arrives
+    and stores the amount and the table's fingerprint on the row;
+    :func:`build_receipt` reads the rows' own fingerprints and uses a caller's
+    only as a fallback. Handing today's committed table to a ledger full of
+    rows settled days ago would put today's fingerprint on money computed under
+    another file — which is the one thing the fingerprint exists to make
+    impossible. Nothing here re-prices anything.
+    """
+    merged = CostReceiptLedger(into, run_id=run_id)
+    notes: list[str] = []
+    with tempfile.TemporaryDirectory() as scratch:
+        for index, path in enumerate(ledgers):
+            shard = CostReceiptLedger(path, run_id=run_id)
+            try:
+                exported = Path(scratch) / f"shard-{index}.jsonl"
+                digest = shard.export_jsonl(exported)
+                calls = shard.call_count()
+            finally:
+                shard.close()
+            try:
+                new_rows = merged.import_jsonl(exported)
+            except LedgerIntegrityError as clash:
+                merged.close()
+                raise MergeRefused(
+                    f"{path}: two shards settle the same call differently "
+                    f"({clash}). No total can be published from these."
+                ) from clash
+            notes.append(
+                f"{path}: {calls} call(s), {new_rows} new to the merge, "
+                f"sha256={digest[:16]}"
+            )
+    return merged, notes
+
+
+def _task_row(task_id: str, receipt: CostReceipt) -> dict[str, Any]:
+    payload = receipt.as_dict()
+    return {
+        "task_id": task_id,
+        "status": payload["status"],
+        # Null unless `complete`. `known_cost_usd` beside it is a floor.
+        "estimated_cost_usd": payload["estimated_cost_usd"],
+        "known_cost_usd": payload["known_cost_usd"],
+        "known_cost_is_a_floor_not_a_total": payload["status"] != STATUS_COMPLETE,
+        "model_cost_usd": payload["model_cost_usd"],
+        "runtime_cost_usd": payload["runtime_cost_usd"],
+        "model_calls": payload["model_calls"],
+        "usage": payload["usage"],
+        "missing_reasons": payload["missing_reasons"],
+        "price_table_sha256": payload["price_table_sha256"],
+    }
+
+
+def roll_up(records_dir: Path, *, stage: str, merged_into: Path) -> dict[str, Any]:
+    """Everything the collect job needs to state what this stage cost."""
+    ledgers = find_ledgers(records_dir)
+    records = read_records(records_dir)
+    cohort, assigned, problems = cohort_and_assignment(records)
+
+    run_ids = sorted({str(r.get("run_id")) for r in records if r.get("run_id")})
+    if len(run_ids) > 1:
+        problems.append(
+            "the shards carry different run ids "
+            f"({', '.join(run_ids)}); their call ids are namespaced by run, so "
+            "nothing is double counted, but this is not one run"
+        )
+    run_id = run_ids[0] if run_ids else f"{stage}-rollup"
+
+    if not ledgers:
+        problems.append(
+            f"no {LEDGER_NAME} under {records_dir}: this stage published no "
+            "account of its spending. That is not the same as having spent "
+            "nothing -- if any shard reached the model, it was billed"
+        )
+
+    rows: list[dict[str, Any]] = []
+    receipts: list[CostReceipt] = []
+    in_ledger: list[str] = []
+    notes: list[str] = []
+
+    if ledgers:
+        merged, notes = merge_ledgers(ledgers, into=merged_into, run_id=run_id)
+        try:
+            in_ledger = merged.task_ids()
+            for task_id in in_ledger:
+                receipt = merged.receipt_for(
+                    task_id,
+                    BUCKET_PROBLEM_SOLVING,
+                    # It is in the ledger, so it ran. An empty
+                    # problem-solving bucket means nothing could be priced
+                    # here, which is `unavailable` -- never `not_run`, and
+                    # never a measured zero.
+                    when_empty=STATUS_UNAVAILABLE,
+                )
+                receipts.append(receipt)
+                rows.append(_task_row(task_id, receipt))
+        finally:
+            merged.close()
+
+    never_reached = [task_id for task_id in assigned if task_id not in in_ledger]
+    for task_id in never_reached:
+        receipt = CostReceipt.not_run()
+        receipts.append(receipt)
+        rows.append(_task_row(task_id, receipt))
+
+    never_assigned = [task_id for task_id in cohort if task_id not in assigned]
+    if never_assigned:
+        problems.append(
+            f"{len(never_assigned)} task(s) of the {len(cohort)} in this stage "
+            "are in no shard record at all; a shard's artifact is missing. "
+            "check_agentic_v2_stage_coverage.py owns that verdict"
+        )
+
+    total = summarise_receipts(receipts)
+    complete = [row for row in rows if row["status"] == STATUS_COMPLETE]
+
+    return {
+        "schema_version": ROLLUP_SCHEMA_VERSION,
+        "stage": stage,
+        "run_id": run_id,
+        "read_from": {
+            "records_dir": str(records_dir),
+            "ledgers": notes,
+            "shard_records": len(records),
+        },
+        "population": {
+            "cohort_size": len(cohort),
+            "assigned_to_a_shard": len(assigned),
+            "in_the_ledger": len(in_ledger),
+            "assigned_but_never_reached_the_ledger": never_reached,
+            "never_assigned_to_any_shard": never_assigned,
+        },
+        "tasks": sorted(rows, key=lambda row: row["task_id"]),
+        "stage_total": total.as_dict(),
+        "accounting": {
+            "tasks_with_a_complete_receipt": len(complete),
+            "tasks_accounted_for": len(rows),
+            "cost_is_fully_accounted": (
+                bool(rows) and len(complete) == len(rows)
+            ),
+            "what_the_total_is": (
+                "a total"
+                if total.status == STATUS_COMPLETE
+                else "a floor: known_cost_usd only, estimated_cost_usd is null"
+            ),
+        },
+        "problems": problems,
+    }
+
+
+def describe(rollup: dict[str, Any]) -> str:
+    """The same thing in sentences, for whoever is reading the job log."""
+    population = rollup["population"]
+    total = rollup["stage_total"]
+    lines = [
+        f"stage {rollup['stage']}, run {rollup['run_id']}",
+        (
+            f"  {population['in_the_ledger']} task(s) in the ledger, "
+            f"{len(population['assigned_but_never_reached_the_ledger'])} "
+            f"assigned and never reached, cohort {population['cohort_size']}"
+        ),
+        (
+            f"  stage total: {total['status']}, "
+            f"estimated {total['estimated_cost_usd']}, "
+            f"known {total['known_cost_usd']} "
+            f"({rollup['accounting']['what_the_total_is']})"
+        ),
+        (
+            f"  {rollup['accounting']['tasks_with_a_complete_receipt']} of "
+            f"{rollup['accounting']['tasks_accounted_for']} task(s) carry a "
+            "complete receipt"
+        ),
+    ]
+    if total["missing_reasons"]:
+        lines.append(f"  why not complete: {', '.join(total['missing_reasons'])}")
+    for problem in rollup["problems"]:
+        lines.append(f"  ! {problem}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--records",
+        required=True,
+        type=Path,
+        help="the directory every shard's artifact was downloaded into",
+    )
+    parser.add_argument("--stage", required=True)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="where to write cost_rollup.json (default: beside --records)",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="print the roll-up to stdout too"
+    )
+    args = parser.parse_args(argv)
+
+    out = args.out or (args.records / "cost_rollup.json")
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        rollup = roll_up(
+            args.records,
+            stage=args.stage,
+            merged_into=out.parent / "cost_receipts_merged.sqlite3",
+        )
+    except MergeRefused as refused:
+        print(f"cost roll-up refused: {refused}", file=sys.stderr)
+        return 1
+
+    out.write_text(json.dumps(rollup, indent=2, sort_keys=True))
+    print(describe(rollup))
+    print(f"written: {out}")
+    if args.json:
+        print(json.dumps(rollup, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/batch-runner/tests/test_nothing_read_the_ledger_the_run_wrote.py
+++ b/batch-runner/tests/test_nothing_read_the_ledger_the_run_wrote.py
@@ -1,0 +1,741 @@
+"""Nothing read the ledger the paid run spent all that care writing.
+
+Every paid V2 shard writes ``cost_receipts.sqlite3`` — one row per call,
+written before the request goes out and updated when the reply comes back —
+and the collect job downloads all of them. No code opened them. So the stage
+that the goal asks for a **per-task cost** from had a complete account of its
+spending and no reader, which is the same as having none at the moment someone
+asks what task 17 cost.
+
+``scripts/roll_up_agentic_v2_cost.py`` is that reader. These tests hold the
+four things it would be easy to get wrong and expensive to notice:
+
+* **A task that never ran is not a free task.** It settles ``not_run`` with a
+  null amount, and a stage that finished a third of its cohort must not read
+  as cheap.
+* **Two shards are added up once.** A re-uploaded artifact, or a task retried
+  in a second shard, must not bill the run twice — and two shards that
+  disagree about the same call must refuse to produce a total rather than
+  pick one.
+* **The fingerprint comes from the rows, not from today's price file.** The
+  merged ledger is opened with no price table on purpose. Rows carry the
+  fingerprint of the table they were settled under; handing the merge today's
+  file would stamp today's fingerprint on older money.
+* **A floor is not a total.** Anything short of ``complete`` leaves
+  ``estimated_cost_usd`` null and says out loud that ``known_cost_usd`` is a
+  floor.
+
+Nothing here calls a model or reaches the network. The ledgers are real and
+sqlite-backed in a temporary directory; the calls are fabricated.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.cost_receipts import (  # noqa: E402
+    STAGE_GENERATION,
+    CallUsage,
+    CostReceiptLedger,
+    load_receipt_price_table,
+)
+
+ROLLUP_PATH = BATCH_RUNNER_ROOT / "scripts" / "roll_up_agentic_v2_cost.py"
+
+
+def _load():
+    """Import the script by path; ``scripts`` is not a package."""
+    spec = importlib.util.spec_from_file_location("roll_up_agentic_v2_cost", ROLLUP_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+rollup = _load()
+
+PINNED = "gpt-5.4"
+
+
+def _shard(
+    root: Path,
+    name: str,
+    *,
+    calls: dict[str, list[tuple[str, int, int, str]]],
+    assigned: list[str],
+    cohort: list[str],
+    run_id: str = "a-run",
+) -> Path:
+    """One downloaded shard artifact: a ledger and a record beside it.
+
+    ``calls`` maps task id to ``(call_id, input, output, model)`` tuples. The
+    ledger is opened **with** the committed price table, the way a real shard
+    opens it, so the rows carry real amounts and a real fingerprint.
+    """
+    shard_dir = root / name
+    shard_dir.mkdir(parents=True, exist_ok=True)
+
+    ledger = CostReceiptLedger(
+        shard_dir / "cost_receipts.sqlite3",
+        run_id=run_id,
+        price_table=load_receipt_price_table(),
+    )
+    try:
+        for task_id, entries in calls.items():
+            for call_id, tokens_in, tokens_out, model in entries:
+                ledger.reserve(
+                    call_id=call_id,
+                    task_id=task_id,
+                    stage=STAGE_GENERATION,
+                    retry_kind="none",
+                    provider="azure",
+                    requested_model=model,
+                    deployment="a-deployment",
+                )
+                ledger.settle(
+                    call_id,
+                    usage=CallUsage(input_tokens=tokens_in, output_tokens=tokens_out),
+                    resolved_model=model,
+                )
+    finally:
+        ledger.close()
+
+    (shard_dir / "run_record.json").write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "stage": "advance_check_5",
+                "binding": {"task_ids": cohort},
+                "shard": {"task_ids": assigned, "cohort_size": len(cohort)},
+            }
+        )
+    )
+    return shard_dir
+
+
+def _roll(records: Path, tmp_path: Path) -> dict:
+    return rollup.roll_up(
+        records,
+        stage="advance_check_5",
+        merged_into=tmp_path / "merged.sqlite3",
+    )
+
+
+def _row(result: dict, task_id: str) -> dict:
+    for entry in result["tasks"]:
+        if entry["task_id"] == task_id:
+            return entry
+    raise AssertionError(f"{task_id} is not in the roll-up")
+
+
+# ── the number the goal asks for ────────────────────────────────────────────
+
+
+def test_each_task_gets_its_own_amount(tmp_path):
+    """The whole point: money split by task, not one lump for the stage.
+
+    Two tasks with deliberately different token counts, so a roll-up that
+    accidentally reported the stage total per task would not survive.
+    """
+    records = tmp_path / "records"
+    _shard(
+        records,
+        "shard-1",
+        calls={
+            "t1": [("a-run:t1:1:c1", 1_000_000, 1_000_000, PINNED)],
+            "t2": [("a-run:t2:1:c1", 2_000_000, 2_000_000, PINNED)],
+        },
+        assigned=["t1", "t2"],
+        cohort=["t1", "t2"],
+    )
+
+    result = _roll(records, tmp_path)
+
+    # $2.50 in + $15.00 out per million.
+    assert _row(result, "t1")["estimated_cost_usd"] == pytest.approx(17.50)
+    assert _row(result, "t2")["estimated_cost_usd"] == pytest.approx(35.00)
+    assert result["stage_total"]["estimated_cost_usd"] == pytest.approx(52.50)
+    assert result["accounting"]["cost_is_fully_accounted"] is True
+
+
+def test_two_shards_are_added_up(tmp_path):
+    """A stage runs as up to 17 shards; the total has to cross them."""
+    records = tmp_path / "records"
+    _shard(
+        records,
+        "shard-1",
+        calls={"t1": [("a-run:t1:1:c1", 1_000_000, 1_000_000, PINNED)]},
+        assigned=["t1"],
+        cohort=["t1", "t2"],
+    )
+    _shard(
+        records,
+        "shard-2",
+        calls={"t2": [("a-run:t2:1:c1", 1_000_000, 1_000_000, PINNED)]},
+        assigned=["t2"],
+        cohort=["t1", "t2"],
+    )
+
+    result = _roll(records, tmp_path)
+
+    assert result["population"]["in_the_ledger"] == 2
+    assert result["stage_total"]["estimated_cost_usd"] == pytest.approx(35.00)
+    assert result["problems"] == []
+
+
+def test_a_shard_uploaded_twice_is_not_billed_twice(tmp_path):
+    """The failure mode that would silently double a 220-task bill.
+
+    Re-running a shard's upload, or re-downloading its artifact into a second
+    directory, must not change the total. The ledger's primary key on
+    ``call_id`` is what prevents it, which is why the merge goes through
+    ``import_jsonl`` rather than reading the tables directly.
+    """
+    records = tmp_path / "records"
+    for name in ("shard-1", "shard-1-again"):
+        _shard(
+            records,
+            name,
+            calls={"t1": [("a-run:t1:1:c1", 1_000_000, 1_000_000, PINNED)]},
+            assigned=["t1"],
+            cohort=["t1"],
+        )
+
+    result = _roll(records, tmp_path)
+
+    assert len(result["read_from"]["ledgers"]) == 2
+    assert _row(result, "t1")["model_calls"] == 1
+    assert result["stage_total"]["estimated_cost_usd"] == pytest.approx(17.50)
+
+
+def test_a_retried_task_pays_for_both_attempts(tmp_path):
+    """The mirror of the test above, and the way over-eager dedup would show.
+
+    Collapsing by task instead of by ``call_id`` would make this read $17.50
+    and look like a fix for double billing. A task retried once cost both
+    attempts, and the run is charged for both.
+    """
+    records = tmp_path / "records"
+    _shard(
+        records,
+        "shard-1",
+        calls={
+            "t1": [
+                ("a-run:t1:1:c1", 1_000_000, 1_000_000, PINNED),
+                ("a-run:t1:2:c1", 1_000_000, 1_000_000, PINNED),
+            ]
+        },
+        assigned=["t1"],
+        cohort=["t1"],
+    )
+
+    result = _roll(records, tmp_path)
+
+    assert _row(result, "t1")["model_calls"] == 2
+    assert _row(result, "t1")["estimated_cost_usd"] == pytest.approx(35.00)
+
+
+def test_shards_that_disagree_about_a_call_refuse_to_produce_a_total(tmp_path):
+    """Two answers for one call means no answer, not the first one seen.
+
+    The ledger already raises here. What this pins is that the roll-up lets it
+    become a refusal instead of catching it and publishing one of the two.
+    """
+    records = tmp_path / "records"
+    _shard(
+        records,
+        "shard-1",
+        calls={"t1": [("a-run:t1:1:c1", 1_000_000, 1_000_000, PINNED)]},
+        assigned=["t1"],
+        cohort=["t1"],
+    )
+    _shard(
+        records,
+        "shard-2",
+        calls={"t1": [("a-run:t1:1:c1", 9_000_000, 9_000_000, PINNED)]},
+        assigned=["t1"],
+        cohort=["t1"],
+    )
+
+    with pytest.raises(rollup.MergeRefused) as refused:
+        _roll(records, tmp_path)
+
+    assert "differently" in str(refused.value)
+
+
+def test_a_refused_merge_exits_non_zero_and_writes_nothing(tmp_path):
+    """The one case that is worth a red job: a total that cannot be trusted."""
+    records = tmp_path / "records"
+    for name, tokens in (("shard-1", 1_000_000), ("shard-2", 9_000_000)):
+        _shard(
+            records,
+            name,
+            calls={"t1": [("a-run:t1:1:c1", tokens, tokens, PINNED)]},
+            assigned=["t1"],
+            cohort=["t1"],
+        )
+    out = tmp_path / "cost_rollup.json"
+
+    code = rollup.main(
+        ["--records", str(records), "--stage", "advance_check_5", "--out", str(out)]
+    )
+
+    assert code == 1
+    assert not out.exists()
+
+
+# ── what a task that did not run is allowed to say ──────────────────────────
+
+
+def test_a_task_that_never_reached_the_ledger_is_not_free(tmp_path):
+    """The reading that would make a half-finished 220 look cheap.
+
+    Run ``34651982737`` is exactly this shape: five tasks assigned, the first
+    one killed the process, four never reached the ledger. Reporting those four
+    at ``$0.00`` would turn "the stage did not finish" into "the stage was
+    inexpensive".
+    """
+    records = tmp_path / "records"
+    _shard(
+        records,
+        "shard-1",
+        calls={"t1": [("a-run:t1:1:c1", 1_000_000, 1_000_000, PINNED)]},
+        assigned=["t1", "t2", "t3", "t4", "t5"],
+        cohort=["t1", "t2", "t3", "t4", "t5"],
+    )
+
+    result = _roll(records, tmp_path)
+
+    assert result["population"]["assigned_but_never_reached_the_ledger"] == [
+        "t2",
+        "t3",
+        "t4",
+        "t5",
+    ]
+    for task_id in ("t2", "t3", "t4", "t5"):
+        row = _row(result, task_id)
+        assert row["status"] == "not_run"
+        assert row["estimated_cost_usd"] is None
+        assert row["model_calls"] == 0
+
+    # And the tasks that did not happen do not drag the total off `complete`:
+    # `not_run` is excluded from the summary, so the one task that ran still
+    # has a real amount. What says the stage is unfinished is the population
+    # block, not a poisoned total.
+    assert result["stage_total"]["estimated_cost_usd"] == pytest.approx(17.50)
+    assert result["accounting"]["tasks_with_a_complete_receipt"] == 1
+    assert result["accounting"]["tasks_accounted_for"] == 5
+    assert result["accounting"]["cost_is_fully_accounted"] is False
+
+
+def test_a_cohort_task_no_shard_reported_is_a_named_hole(tmp_path):
+    """A missing artifact must not shrink the denominator to fit."""
+    records = tmp_path / "records"
+    _shard(
+        records,
+        "shard-1",
+        calls={"t1": [("a-run:t1:1:c1", 1_000, 100, PINNED)]},
+        assigned=["t1"],
+        cohort=["t1", "t2", "t3"],
+    )
+
+    result = _roll(records, tmp_path)
+
+    assert result["population"]["cohort_size"] == 3
+    assert result["population"]["never_assigned_to_any_shard"] == ["t2", "t3"]
+    assert any("no shard record" in problem for problem in result["problems"])
+
+
+def test_nothing_at_all_is_reported_as_no_account_not_as_no_spending(tmp_path):
+    """An empty download is the loudest thing this tool can find.
+
+    A paid stage that published no ledger did not necessarily spend nothing —
+    if a shard reached the model it was billed, and the account is what is
+    missing, not the money.
+    """
+    records = tmp_path / "records"
+    records.mkdir()
+
+    result = _roll(records, tmp_path)
+
+    assert result["stage_total"]["status"] == "not_run"
+    assert result["stage_total"]["estimated_cost_usd"] is None
+    assert result["accounting"]["cost_is_fully_accounted"] is False
+    assert any("spent nothing" in problem for problem in result["problems"])
+
+
+# ── a floor is not a total ──────────────────────────────────────────────────
+
+
+def test_an_unpriced_call_leaves_a_floor_and_says_so(tmp_path):
+    """``known_cost_usd`` is real; it is just not the answer to "how much".
+
+    One priced task and one unpriced one. The stage keeps a floor — what is
+    confirmed — and refuses to present it as a total.
+    """
+    records = tmp_path / "records"
+    _shard(
+        records,
+        "shard-1",
+        calls={
+            "t1": [("a-run:t1:1:c1", 1_000_000, 1_000_000, PINNED)],
+            "t2": [("a-run:t2:1:c1", 1_000_000, 1_000_000, "a-model-nobody-priced")],
+        },
+        assigned=["t1", "t2"],
+        cohort=["t1", "t2"],
+    )
+
+    result = _roll(records, tmp_path)
+
+    unpriced = _row(result, "t2")
+    assert unpriced["status"] == "partial"
+    assert unpriced["estimated_cost_usd"] is None
+    assert unpriced["known_cost_is_a_floor_not_a_total"] is True
+    assert "price_missing" in unpriced["missing_reasons"]
+
+    total = result["stage_total"]
+    assert total["status"] == "partial"
+    assert total["estimated_cost_usd"] is None
+    assert total["known_cost_usd"] == pytest.approx(17.50)
+    assert "floor" in result["accounting"]["what_the_total_is"]
+    assert result["accounting"]["cost_is_fully_accounted"] is False
+
+
+def test_a_complete_stage_is_allowed_to_call_its_total_a_total(tmp_path):
+    """The rule cuts both ways, or it is just pessimism."""
+    records = tmp_path / "records"
+    _shard(
+        records,
+        "shard-1",
+        calls={"t1": [("a-run:t1:1:c1", 1_000_000, 1_000_000, PINNED)]},
+        assigned=["t1"],
+        cohort=["t1"],
+    )
+
+    result = _roll(records, tmp_path)
+
+    assert result["accounting"]["what_the_total_is"] == "a total"
+    assert _row(result, "t1")["known_cost_is_a_floor_not_a_total"] is False
+
+
+def test_a_call_that_left_and_never_came_back_holds_the_stage_partial(tmp_path):
+    """A reservation with no settlement may still have been billed.
+
+    This is the state a shard killed by its own ``timeout-minutes`` leaves
+    behind, and it is not the same as the task not running.
+    """
+    records = tmp_path / "records"
+    shard_dir = records / "shard-1"
+    shard_dir.mkdir(parents=True)
+    ledger = CostReceiptLedger(
+        shard_dir / "cost_receipts.sqlite3",
+        run_id="a-run",
+        price_table=load_receipt_price_table(),
+    )
+    try:
+        ledger.reserve(
+            call_id="a-run:t1:1:c1",
+            task_id="t1",
+            stage=STAGE_GENERATION,
+            retry_kind="none",
+            provider="azure",
+            requested_model=PINNED,
+        )
+    finally:
+        ledger.close()
+    (shard_dir / "run_record.json").write_text(
+        json.dumps(
+            {
+                "run_id": "a-run",
+                "binding": {"task_ids": ["t1"]},
+                "shard": {"task_ids": ["t1"], "cohort_size": 1},
+            }
+        )
+    )
+
+    result = _roll(records, tmp_path)
+
+    row = _row(result, "t1")
+    assert row["status"] == "partial"
+    assert row["estimated_cost_usd"] is None
+    assert "call_reachability_unknown" in row["missing_reasons"]
+
+
+# ── the fingerprint has to come from the rows ───────────────────────────────
+
+
+def test_the_merge_keeps_the_table_the_calls_were_settled_under(tmp_path):
+    """The merged ledger holds no price table, and must not need one.
+
+    Rows carry the fingerprint of the table that priced them. If the roll-up
+    opened the merge with today's committed file, a run settled last week would
+    come back stamped with this week's fingerprint — a claim nobody could
+    check and everybody would believe.
+    """
+    records = tmp_path / "records"
+    _shard(
+        records,
+        "shard-1",
+        calls={"t1": [("a-run:t1:1:c1", 1_000, 100, PINNED)]},
+        assigned=["t1"],
+        cohort=["t1"],
+    )
+
+    result = _roll(records, tmp_path)
+
+    assert _row(result, "t1")["price_table_sha256"] == load_receipt_price_table().sha256
+    assert result["stage_total"]["price_table_sha256"] is not None
+
+
+def test_the_merged_ledger_is_opened_without_a_price_table(tmp_path):
+    """Stated on the object, so a later "helpful" edit fails here.
+
+    Passing the committed table would look like an improvement and would
+    quietly re-stamp old money.
+    """
+    records = tmp_path / "records"
+    _shard(
+        records,
+        "shard-1",
+        calls={"t1": [("a-run:t1:1:c1", 1_000, 100, PINNED)]},
+        assigned=["t1"],
+        cohort=["t1"],
+    )
+    seen = {}
+
+    original = rollup.CostReceiptLedger
+
+    def watch(path, **kwargs):
+        seen.setdefault("price_table", kwargs.get("price_table"))
+        return original(path, **kwargs)
+
+    rollup.CostReceiptLedger = watch
+    try:
+        _roll(records, tmp_path)
+    finally:
+        rollup.CostReceiptLedger = original
+
+    assert seen["price_table"] is None
+
+
+# ── the shape of the file, and the sentence in the job log ──────────────────
+
+
+def test_main_writes_the_file_and_exits_zero_on_an_unfinished_stage(tmp_path):
+    """A stage that went badly still produces its account.
+
+    This tool is not a second gate. ``check_agentic_v2_stage_coverage.py`` owns
+    pass/fail for a stage; a red mark here on an already-red run would only
+    make the real reason harder to find.
+    """
+    records = tmp_path / "records"
+    _shard(
+        records,
+        "shard-1",
+        calls={"t1": [("a-run:t1:1:c1", 1_000, 100, "a-model-nobody-priced")]},
+        assigned=["t1", "t2"],
+        cohort=["t1", "t2"],
+    )
+    out = tmp_path / "cost_rollup.json"
+
+    code = rollup.main(
+        ["--records", str(records), "--stage", "advance_check_5", "--out", str(out)]
+    )
+
+    assert code == 0
+    written = json.loads(out.read_text())
+    assert written["schema_version"] == rollup.ROLLUP_SCHEMA_VERSION
+    assert written["stage"] == "advance_check_5"
+    assert written["run_id"] == "a-run"
+    assert [row["task_id"] for row in written["tasks"]] == ["t1", "t2"]
+
+
+def test_the_log_line_names_the_floor_rather_than_a_bare_number(tmp_path):
+    """Whoever reads the job log reads this and nothing else."""
+    records = tmp_path / "records"
+    _shard(
+        records,
+        "shard-1",
+        calls={"t1": [("a-run:t1:1:c1", 1_000, 100, "a-model-nobody-priced")]},
+        assigned=["t1"],
+        cohort=["t1"],
+    )
+
+    said = rollup.describe(_roll(records, tmp_path))
+
+    assert "floor" in said
+    assert "price_missing" in said
+
+
+def test_shards_from_different_runs_are_named_as_such(tmp_path):
+    """Two runs merged by accident would produce a real-looking wrong total.
+
+    Call ids are namespaced by run, so nothing is double counted — but the
+    result is not one run's bill and the file has to say so.
+    """
+    records = tmp_path / "records"
+    _shard(
+        records,
+        "shard-1",
+        calls={"t1": [("run-a:t1:1:c1", 1_000, 100, PINNED)]},
+        assigned=["t1"],
+        cohort=["t1"],
+        run_id="run-a",
+    )
+    _shard(
+        records,
+        "shard-2",
+        calls={"t2": [("run-b:t2:1:c1", 1_000, 100, PINNED)]},
+        assigned=["t2"],
+        cohort=["t2"],
+        run_id="run-b",
+    )
+
+    result = _roll(records, tmp_path)
+
+    assert any("different run ids" in problem for problem in result["problems"])
+
+
+def test_nothing_in_the_roll_up_is_a_zero_that_was_not_measured(tmp_path):
+    """The rule the whole file exists for, asserted across every row.
+
+    Any row whose status is not ``complete`` must carry a null estimate. A
+    ``0.0`` there would be the one number in the account that reads as a
+    measurement.
+    """
+    records = tmp_path / "records"
+    _shard(
+        records,
+        "shard-1",
+        calls={
+            "t1": [("a-run:t1:1:c1", 1_000, 100, PINNED)],
+            "t2": [("a-run:t2:1:c1", 1_000, 100, "a-model-nobody-priced")],
+        },
+        assigned=["t1", "t2", "t3"],
+        cohort=["t1", "t2", "t3"],
+    )
+
+    result = _roll(records, tmp_path)
+
+    for row in result["tasks"]:
+        if row["status"] != "complete":
+            assert row["estimated_cost_usd"] is None, row["task_id"]
+
+
+# ── a reader nothing calls is the defect this file was written about ────────
+
+
+def _collect_steps() -> list[dict]:
+    import yaml
+
+    workflow = yaml.safe_load(
+        (
+            BATCH_RUNNER_ROOT.parent
+            / ".github"
+            / "workflows"
+            / "agentic-v2-stage-run.yml"
+        ).read_text()
+    )
+    return workflow["jobs"]["collect"]["steps"]
+
+
+def test_the_collect_job_actually_calls_the_roll_up():
+    """The whole point, and the thing that was missing before.
+
+    A cost reader that no job runs is the same defect as the ledger nothing
+    read: the capability exists, the tests pass, and no run produces the file.
+    ``coverage_problems`` sat uncalled in this repository for days behind
+    exactly this gap.
+    """
+    called = [
+        step
+        for step in _collect_steps()
+        if "roll_up_agentic_v2_cost.py" in (step.get("run") or "")
+    ]
+
+    assert len(called) == 1
+    assert "--stage" in called[0]["run"]
+    assert "../shard-records" in called[0]["run"]
+
+
+def test_the_bill_is_read_before_the_verdict_that_fails_the_job():
+    """Order matters here, and it is the opposite of the obvious one.
+
+    ``check_agentic_v2_stage_coverage.py`` is built to fail a stage that did
+    not run. A stage that did not run is precisely the one whose bill has to
+    be recoverable -- run 34651982737 spent money on two model calls and left
+    no account at all. Reading after the verdict would lose the account on
+    every run worth accounting for.
+    """
+    names = [
+        step.get("name", "")
+        for step in _collect_steps()
+        if step.get("run") or step.get("uses")
+    ]
+    read = next(i for i, n in enumerate(names) if n == "Read what the stage spent")
+    verdict = next(i for i, n in enumerate(names) if n == "Check coverage and halts")
+
+    assert read < verdict
+
+
+def test_the_coverage_verdict_survives_a_refused_roll_up():
+    """The roll-up may fail the job; it may not replace the gate.
+
+    ``MergeRefused`` exits non-zero, and a failing step normally skips every
+    step after it. Without ``always()`` here, two shards disagreeing about one
+    call would mean the stage's coverage was never checked -- a cost problem
+    silently swallowing the answer to "did the stage run".
+    """
+    verdict = next(
+        step
+        for step in _collect_steps()
+        if step.get("name") == "Check coverage and halts"
+    )
+
+    assert "always()" in str(verdict.get("if", ""))
+
+
+def test_the_roll_up_is_kept_even_when_the_stage_is_judged_a_failure():
+    """The artifact outlives the verdict, for the same reason."""
+    keep = next(
+        step for step in _collect_steps() if step.get("name") == "Keep the cost roll-up"
+    )
+
+    assert "always()" in str(keep.get("if", ""))
+    assert keep["with"]["path"] == "cost-rollup/"
+    # Its own artifact, not folded into the shard pattern the collect job
+    # downloads -- that would make the next run's download recursive.
+    assert "shard" not in keep["with"]["name"]
+
+
+def test_the_free_job_runs_these_tests():
+    """A test file no workflow names is a test file that rots.
+
+    The stage workflow lists its tests one by one rather than running the
+    suite, so a new file is invisible until it is added to that list.
+    """
+    import yaml
+
+    workflow = (
+        BATCH_RUNNER_ROOT.parent / ".github" / "workflows" / "agentic-v2-stage-run.yml"
+    ).read_text()
+
+    assert Path(__file__).name in workflow
+    # And mypy sees the script, which is how the first paid dispatch's defect
+    # was reported at its exact line.
+    free = yaml.safe_load(workflow)["jobs"]["free"]["steps"]
+    checked = [
+        step for step in free if "roll_up_agentic_v2_cost.py" in (step.get("run") or "")
+    ]
+    assert len(checked) == 1
+    assert "mypy" in checked[0]["run"]


### PR DESCRIPTION
## 무엇이 비어 있었나

유료 shard는 모두 `cost_receipts.sqlite3`를 기록하고, `collect` 작업은 그
파일들을 전부 내려받습니다. **그 파일을 여는 코드가 저장소 어디에도
없었습니다.** 호출 단위 원장이 쌓이는데 "이 과제는 얼마였나"를 답할 수단이
없는 상태였고, 그 답은 이 실행의 부수적 편의가 아니라 목표가 요구하는
산출물입니다.

`check_agentic_v2_stage_coverage.py`에는 비용 처리가 없고,
`verify_cost_ledger.py`는 채점 실행 전용입니다. 220문제를 다 돌린 뒤에
과제별 비용을 물으면, 돈을 쓴 다음에야 답이 없다는 걸 알게 되는
배치였습니다.

## 무엇을 추가했나

`batch-runner/scripts/roll_up_agentic_v2_cost.py` — shard 원장을 하나로
합쳐 과제별 금액과 단계 합계를 냅니다.

**아무것도 다시 계산하지 않습니다.** 병합은 원장 자신의
`export_jsonl`/`import_jsonl`이고 `call_id`가 기본키라 두 번 올라온 shard는
한 번만 셉니다. 금액은 실행이 쓴 `receipt_for` / `summarise_receipts`를
그대로 다시 부른 값입니다.

### 세 모집단을 섞지 않습니다

| 상태 | 뜻 |
|---|---|
| 원장에 행이 있음 | receipt가 말하는 값, 또는 왜 말할 수 없는지 |
| shard가 맡았는데 닿지 못함 | `not_run`. **$0이 아닙니다** — 시간 초과로 죽은 shard가 여기 남고, 이걸 0으로 세면 반만 끝난 단계가 싸 보입니다 |
| 어느 shard도 맡지 않음 | 구멍으로 적고, 합격/불합격 판정은 coverage 검사가 합니다 |

### 합친 원장은 일부러 가격표 없이 엽니다

빠뜨린 게 아닙니다. `settle`이 응답 시점에 금액과 **가격표 지문을 행에**
박고, `build_receipt`는 행이 가진 지문을 먼저 읽고 호출자 것은 대체값으로만
씁니다. 며칠 전에 결제된 행이 가득한 원장에 오늘 커밋된 표를 건네면, 다른
파일로 계산된 돈에 오늘 지문이 찍힙니다. 지문이 막으려던 바로 그 일입니다.

## collect 작업 배선

- **비용 읽기를 coverage 판정보다 앞에** 뒀습니다. coverage는 실패하라고
  만든 검사이고, 잘못 돌아간 단계야말로 청구서가 필요한 단계입니다. 뒤에
  두면 계산할 값어치가 있는 모든 실행에서 장부를 잃습니다.
- coverage 판정에 `always()`를 붙였습니다. 병합 거부(non-zero)가 "단계가
  돌았는가"의 답을 삼키면 안 됩니다.
- 비용 결과는 `agentic-v2-<stage>-cost` artifact로 따로 보존하고, 요약은
  작업 요약 화면에 그대로 출력합니다.
- mypy 게이트에 이 스크립트를 추가했습니다(두 파일 모두 0건).

## exit code는 두 번째 관문이 아닙니다

두 shard가 같은 `call_id`를 서로 다르게 결제해 **합계 자체를 믿을 수 없을
때만** 1입니다. 부분·미가격·중단된 단계는 0으로 끝내고 파일에 그렇게
적습니다. "실행이 잘못됐다"는 coverage 검사가 내릴 문장이지 이쪽 문장이
아닙니다.

측정하지 않은 0은 쓰지 않습니다. `estimated_cost_usd`는 `complete`에서만
채워지고, 그 옆의 `known_cost_usd`는 **하한**이며 그렇게 이름 붙여
내보냅니다. 미가격 호출은 `partial`, 호출이 없던 과제는 `unavailable`,
실행되지 않은 과제는 `not_run` — 서로 다른 네 문장이고 어느 것도
"\$0.00"이 아닙니다.

## 검증

- 새 테스트 23개 통과. 실제 sqlite 원장을 만들어 검사하며 모델 호출도
  네트워크 접근도 없습니다.
- 실패했던 실행 `34651982737`의 실제 모양(5문제 중 0문제 도달)을 고정한
  테스트가 들어 있습니다.
- `mypy scripts/run_agentic_v2_stage.py scripts/roll_up_agentic_v2_cost.py`
  → 0건.
- 워크플로 배선 자체를 검사하는 테스트 5개. **아무도 부르지 않는 읽기
  코드는 아무도 읽지 않은 원장과 같은 결함**이고, 이 저장소에서
  `coverage_problems`가 정확히 그 상태로 며칠 있었습니다.