### PR TITLE
24번 부르고 18번만 적었습니다

### DIFF
--- a/batch-runner/core/agentic_v2_conversation.py
+++ b/batch-runner/core/agentic_v2_conversation.py
@@ -558,6 +558,75 @@ class TurnRecord:
         }
 
 
+@dataclass
+class _BilledButUnanswered:
+    """A model reply that has been charged for and has no tool result yet.
+
+    The loop asks the model, is answered, and only builds a :class:`TurnRecord`
+    once the tool it asked for has run. Everything the ledger later charges for
+    is read out of those records, so every way the run can end in between --
+    and there are ten of them -- used to drop a call the provider had already
+    billed.
+
+    Measured on the first V2 stage that reached the model: 24 calls made, 18 in
+    the ledger. The six that vanished were the last turn of each conversation
+    that ended on a tool failure, and the receipts still read ``complete`` with
+    no missing reason, because a ledger cannot miss a row it was never offered.
+    A bill that is confidently 20% short is worse than one that says it is
+    short.
+
+    The event log already got this right -- ``model_replied`` is appended
+    before the run decides what to do about the reply, and the comment there
+    says why. This is the same rule applied to the record that carries the
+    money.
+
+    Mutable, unlike everything else kept here, and it never leaves the module:
+    it is filled in as the loop learns what the reply asked for, so that a run
+    ending after the tool was chosen still records which tool that was.
+
+    Built only for a reply that reported what it used. A reply that did not is
+    left out of ``turns`` entirely and counted in
+    :attr:`ConversationOutcome.model_calls_not_counted`; the comment at the
+    construction site says why a zero would be the worse answer.
+    """
+
+    turn: int
+    input_tokens: int
+    output_tokens: int
+    call_id: str = ""
+    tool_name: str = ""
+    argument_names: tuple[str, ...] = ()
+    stated_reason: str = ""
+
+    def as_turn(self, stop_reason: str) -> TurnRecord:
+        """The charged call, said as a turn that got no result.
+
+        ``ok`` is false and ``error_type`` is why the run stopped, so a reader
+        cannot mistake this for a tool that answered. The three hashes and the
+        byte count are the empty values because nothing came back -- a zero
+        here is the absence of a result, not a measurement of one.
+        """
+        return TurnRecord(
+            turn=self.turn,
+            # Unique within the conversation either way: the model's own id
+            # when it got far enough to name one, and the turn number when it
+            # did not. `model_turns_of` namespaces both by run, task and
+            # attempt before they reach the ledger.
+            call_id=self.call_id or f"turn-{self.turn}-no-tool-result",
+            tool_name=self.tool_name,
+            argument_names=self.argument_names,
+            stated_reason=self.stated_reason,
+            ok=False,
+            error_type=stop_reason,
+            request_sha256=None,
+            result_sha256=None,
+            result_bytes=0,
+            input_tokens=self.input_tokens,
+            output_tokens=self.output_tokens,
+            replayed=False,
+        )
+
+
 @dataclass(frozen=True)
 class LoopEvent:
     """One point the run passed through."""
@@ -595,12 +664,50 @@ class ConversationOutcome:
             1 for event in self.events if event.step is LoopStep.MODEL_ASKED
         )
 
+    @property
+    def tools_asked_for(self) -> tuple[str, ...]:
+        """Which tool each turn asked for, skipping the turns that asked none.
+
+        Every turn is in ``turns`` now, including the charged ones that ended
+        the run before a tool answered, and some of those stopped before the
+        model had named a tool at all. Those carry an empty name, which is a
+        true statement about the turn and a false entry in a list of tools —
+        so they are left out here rather than reported as a tool called ``""``.
+        A turn that *did* name a tool stays in whether or not the tool ran: the
+        model asked for it, and that is what this list is.
+        """
+        return tuple(
+            record.tool_name for record in self.turns if record.tool_name
+        )
+
+    @property
+    def model_calls_not_counted(self) -> int:
+        """Replies that arrived without usable token counts, so are unpriced.
+
+        Not a cost and not a zero — a number *about* the account rather than in
+        it. A reply the provider sent with no usage, or with a usage the voice
+        could not read, was still charged for, and this is how many of those a
+        run had. Anything above zero means ``turns`` is short by that much and
+        the receipt built from it is a floor.
+
+        Kept as a count rather than an estimate on purpose. Guessing what an
+        uncounted call would have cost is the one arithmetic this codebase does
+        not do.
+        """
+        return sum(
+            1
+            for event in self.events
+            if event.step is LoopStep.MODEL_REPLIED
+            and event.detail.get("counted") is False
+        )
+
     def as_dict(self) -> dict[str, Any]:
         return {
             "stop_reason": self.stop_reason.value,
             "detail": self.detail,
             "produced_an_answer": self.produced_an_answer,
             "model_turns_used": self.model_turns_used,
+            "model_calls_not_counted": self.model_calls_not_counted,
             "turns": [record.as_dict() for record in self.turns],
             "events": [event.as_dict() for event in self.events],
             "budget_after": (
@@ -639,8 +746,19 @@ def run_model_conversation(
     repeats: dict[str, int] = {}
     started_at = clock()
     turn = 0
+    # Set the moment a reply's usage is known, cleared the moment that turn is
+    # recorded. While it holds something, this run owes the ledger a call.
+    billed: Optional[_BilledButUnanswered] = None
 
     def finish(reason: StopReason, detail: str, **extra: Any) -> ConversationOutcome:
+        # Before the outcome is built, not after: a charged call that has no
+        # tool result is still a charged call, and this is the last place it
+        # can be written down. Ten paths between the reply arriving and the
+        # turn being recorded end here, and every one of them used to lose it.
+        nonlocal billed
+        if billed is not None:
+            turns.append(billed.as_turn(reason.value))
+            billed = None
         events.append(LoopEvent(
             step=LoopStep.STOPPED,
             turn=turn,
@@ -761,6 +879,55 @@ def run_model_conversation(
                 "and the run cannot be allowed to continue",
             )
         input_tokens, output_tokens = usage
+        # The provider has answered and will bill for it. From here until the
+        # turn is recorded, this run owes the ledger a call, and `finish` is
+        # what pays it if the run stops first.
+        #
+        # Unless the reply came back uncounted, which is what a zero input
+        # count means. No call to a model costs nothing on the way in: the task
+        # prompt alone is thousands of tokens, and every provider bills for it.
+        # A reply carrying zero input tokens therefore did not report its
+        # usage; something downstream filled the field in. The real voice does
+        # exactly that — when a response arrives with no `usage`, it walks away
+        # with a note saying so, and the walk-away's token fields default to
+        # zero.
+        #
+        # Such a call is not recorded, and that is deliberate. Filing it would
+        # put `0` in the ledger, and a zero settles to `$0.00` on a `complete`
+        # receipt: a measured-looking figure for a call nobody measured. That
+        # is worse than the gap it would paper over, because a gap can be seen.
+        # It is counted in `model_calls_not_counted` instead, which is a number
+        # about the account rather than in it.
+        #
+        # The same applies to the `usage is None` branch above, for the same
+        # reason. Both are the honest edge of a record written after the fact;
+        # closing them needs a reservation written *before* the call, which is
+        # a different change to a different object.
+        counted = input_tokens > 0
+        billed = (
+            _BilledButUnanswered(
+                turn=turn, input_tokens=input_tokens, output_tokens=output_tokens
+            )
+            if counted
+            else None
+        )
+        # What the charged call asked for, read here rather than after the
+        # ceilings below, so a turn stopped by one of them still records which
+        # tool the money was spent asking for. Three of the five tasks in the
+        # first paid stage ended on a tool the backend refuses, and "which
+        # tool" is the whole finding.
+        #
+        # Reading it decides nothing. `_readable_request` only looks at four
+        # attributes and has no side effects, and the refusal for a reply that
+        # is not a usable request stays exactly where it was — below the
+        # walk-away and both ceilings — so which stop wins an argument between
+        # them is unchanged.
+        asked = _readable_request(reply) if isinstance(reply, AskForTool) else None
+        if billed is not None and asked is not None:
+            billed.call_id = asked[0]
+            billed.tool_name = asked[1]
+            billed.argument_names = tuple(sorted(asked[2]))
+            billed.stated_reason = asked[3]
         # Recorded as having happened before the run decides what to do about
         # it, so that a trace read back afterwards shows the reply arriving
         # rather than seeming to vanish between the asking and the stopping.
@@ -771,6 +938,9 @@ def run_model_conversation(
                 "kind": type(reply).__name__,
                 "input_tokens": input_tokens,
                 "output_tokens": output_tokens,
+                # False means this reply is missing from the account below,
+                # and is the only place that says so.
+                "counted": counted,
             },
         ))
         try:
@@ -797,7 +967,8 @@ def run_model_conversation(
                 + _appended_note(reply.note),
             )
 
-        asked = _readable_request(reply)
+        # `asked` was read above, before the ceilings, and this is where it is
+        # acted on. A reply that walked away never reaches here.
         if asked is None:
             return finish(
                 StopReason.MODEL_REPLY_UNUSABLE,
@@ -870,6 +1041,10 @@ def run_model_conversation(
             output_tokens=output_tokens,
             replayed=outcome.replayed,
         ))
+        # Paid for and now recorded, so the debt `finish` would otherwise settle
+        # is cleared. Left set, the next stop would write the same turn twice
+        # and the ledger would be wrong in the other direction.
+        billed = None
         history.append(ToolExchange(
             call_id=call_id,
             tool_name=tool_name,

--- a/batch-runner/core/agentic_v2_stage_a_probe.py
+++ b/batch-runner/core/agentic_v2_stage_a_probe.py
@@ -279,7 +279,7 @@ def run_stage_a_probe(
         requested_deployment=deployment,
         resource=resource,
         tools_offered=tuple(tools),
-        tools_asked_for=tuple(record.tool_name for record in outcome.turns),
+        tools_asked_for=outcome.tools_asked_for,
         turns_taken=len(voice.calls),
         stop_reason=outcome.stop_reason.value,
         detail=outcome.detail,

--- a/batch-runner/core/agentic_v2_stage_d_probe.py
+++ b/batch-runner/core/agentic_v2_stage_d_probe.py
@@ -516,7 +516,7 @@ def run_stage_d_probe(
             requested_deployment=deployment,
             resource=resource,
             tools_offered=tuple(tools),
-            tools_asked_for=tuple(record.tool_name for record in outcome.turns),
+            tools_asked_for=outcome.tools_asked_for,
             turns_taken=len(voice.calls),
             stop_reason=outcome.stop_reason.value,
             detail=outcome.detail,

--- a/batch-runner/tests/test_agentic_v2_conversation.py
+++ b/batch-runner/tests/test_agentic_v2_conversation.py
@@ -471,7 +471,12 @@ def test_a_repeat_the_dispatcher_replayed_is_recorded_as_replayed():
 
     outcome = a_run(voice, desk, max_repeats_of_one_request=2)
 
+    # Two turns, not three. The walk-away is a third reply, but the stand-in
+    # sent it with no token counts, and an uncounted reply is left out of the
+    # account rather than filed as a zero -- see
+    # test_the_calls_the_run_was_billed_for_and_never_filed.py.
     assert [record.replayed for record in outcome.turns] == [False, True]
+    assert outcome.model_calls_not_counted == 1
 
 
 # ---------------------------------------------------------------------------

--- a/batch-runner/tests/test_the_calls_the_run_was_billed_for_and_never_filed.py
+++ b/batch-runner/tests/test_the_calls_the_run_was_billed_for_and_never_filed.py
@@ -1,0 +1,477 @@
+"""The model calls a run pays for and used to leave out of its own account.
+
+Measured, not supposed. The first Agentic Sandbox V2 stage that reached a real
+model made **24** model calls across its five tasks and put **18** of them in
+the cost ledger. The missing six carried 17,775 input and 292 output tokens —
+about 20% of what the stage actually cost — and every receipt still read
+``complete`` with an empty ``missing_reasons``. The account was not merely
+short; it was short *and* confident, which is the combination that makes a
+number unusable, because nothing in the output says to distrust it.
+
+The cause was structural rather than arithmetic. ``run_model_conversation``
+records a turn by appending a :class:`TurnRecord` *after* the tool desk has
+answered, and ten different stops sit between the model's reply arriving and
+that append. Each of those is a call the provider has already charged for and
+the record never mentions. The loop's own event log got this right from the
+start — ``MODEL_REPLIED`` is written the moment the reply lands — so the two
+halves of the same run disagreed, and only the half that carries the money was
+wrong.
+
+What is pinned here
+-------------------
+
+* every stop between the reply and the tool result still files the turn,
+* the turn says which tool the money was spent asking for, where the run got
+  far enough to know,
+* a turn is filed exactly once, never twice,
+* the calls that genuinely cannot be filed — a reply that never said what it
+  used, and a reply whose counts came back zero — are left out and counted as
+  uncounted, rather than filed as zeros that would settle to ``$0.00``,
+* what reaches the ledger, through ``model_turns_of``, matches what was asked.
+
+Nothing here spends anything: the model is a stand-in and the tool desk is a
+list written in advance.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.agentic_v2_conversation import (
+    AskForTool,
+    ConversationOutcome,
+    GaveUp,
+    LoopLimits,
+    LoopStep,
+    ScriptedToolDesk,
+    ScriptedVoice,
+    StopReason,
+    ToolOutcome,
+    run_model_conversation,
+)
+from core.agentic_v2_conversation_runner import model_turns_of
+from core.agentic_v2_stage_one_budget import StageOneBudget
+
+
+INPUT_TOKENS = 100
+OUTPUT_TOKENS = 20
+
+
+def a_budget(**changes) -> StageOneBudget:
+    settings = {
+        "max_model_calls": 16,
+        "max_input_tokens": 1_000_000,
+        "max_output_tokens": 200_000,
+    }
+    settings.update(changes)
+    return StageOneBudget(**settings)
+
+
+def limits(**changes) -> LoopLimits:
+    settings = {
+        "max_model_turns": 6,
+        "max_written_tokens_per_turn": 2048,
+        "max_seconds": 60.0,
+        "max_repeats_of_one_request": 2,
+        "budget": a_budget(),
+    }
+    settings.update(changes)
+    return LoopLimits(**settings)
+
+
+def ask(call_id: str, tool_name: str, /, **arguments) -> AskForTool:
+    return AskForTool(
+        call_id=call_id,
+        tool_name=tool_name,
+        arguments=arguments,
+        why=f"stand-in model asked for {tool_name}",
+        input_tokens=INPUT_TOKENS,
+        output_tokens=OUTPUT_TOKENS,
+    )
+
+
+def look_around(call_id: str = "call-1") -> AskForTool:
+    return ask(call_id, "capabilities_query", kind="commands")
+
+
+def browse(call_id: str = "call-1") -> AskForTool:
+    return ask(call_id, "browser_run", url="https://example.invalid", action="open")
+
+
+def commit(call_id: str = "call-9") -> AskForTool:
+    return ask(call_id, "finalize", deliverables=["report.txt"], summary="done")
+
+
+def a_run(voice, desk, **limit_changes) -> ConversationOutcome:
+    changes = dict(limit_changes)
+    cancel = changes.pop("cancel_requested", None)
+    clock = changes.pop("clock", None)
+    extra = {}
+    if cancel is not None:
+        extra["cancel_requested"] = cancel
+    if clock is not None:
+        extra["clock"] = clock
+    return run_model_conversation(
+        task_prompt="write a short report",
+        voice=voice,
+        desk=desk,
+        limits=limits(**changes),
+        **extra,
+    )
+
+
+def calls_the_model_answered(outcome: ConversationOutcome) -> int:
+    """How many replies the provider sent, straight off the event log.
+
+    The event log is the half of the record that was already right, so it is
+    the reference the account is checked against rather than a second opinion.
+    """
+    return sum(
+        1 for event in outcome.events if event.step is LoopStep.MODEL_REPLIED
+    )
+
+
+# ---------------------------------------------------------------------------
+# The shape that was measured
+# ---------------------------------------------------------------------------
+
+
+class ARaisingDesk:
+    """A tool desk that falls over, which is one of the ten lost paths."""
+
+    def run_one(self, *, call_id, tool_name, arguments):
+        raise RuntimeError("the desk fell over")
+
+
+class ADeskThatAnswersWithRubbish:
+    def run_one(self, *, call_id, tool_name, arguments):
+        return {"ok": True}
+
+
+def a_clock_that_runs_away():
+    """Zero on the first look, well past any ceiling afterwards."""
+    ticks = iter([0.0, 0.0, 0.0, 10_000.0, 10_000.0, 10_000.0])
+
+    def clock() -> float:
+        try:
+            return next(ticks)
+        except StopIteration:
+            return 10_000.0
+
+    return clock
+
+
+STOPS_BETWEEN_THE_REPLY_AND_THE_TOOL_RESULT = [
+    pytest.param(
+        ScriptedVoice(replies=[GaveUp(note="I cannot", input_tokens=INPUT_TOKENS,
+                                      output_tokens=OUTPUT_TOKENS)]),
+        ScriptedToolDesk(),
+        {},
+        StopReason.MODEL_STOPPED_WITHOUT_FINISHING,
+        "",
+        id="the model walked away",
+    ),
+    pytest.param(
+        ScriptedVoice(replies=[look_around()]),
+        ScriptedToolDesk(),
+        {"max_written_tokens_per_turn": OUTPUT_TOKENS - 1},
+        StopReason.WRITING_LIMIT_REACHED,
+        "capabilities_query",
+        id="it wrote past the per-turn ceiling",
+    ),
+    pytest.param(
+        ScriptedVoice(replies=[look_around()]),
+        ScriptedToolDesk(),
+        {"budget": a_budget(max_output_tokens=OUTPUT_TOKENS - 1)},
+        StopReason.COST_LIMIT_REACHED,
+        "capabilities_query",
+        id="the budget refused the reply it had already been sent",
+    ),
+    pytest.param(
+        ScriptedVoice(replies=[ask("", "capabilities_query", kind="commands")]),
+        ScriptedToolDesk(),
+        {},
+        StopReason.MODEL_REPLY_UNUSABLE,
+        "",
+        id="the reply was not a usable request",
+    ),
+    pytest.param(
+        ScriptedVoice(replies=[look_around(), look_around(), look_around()]),
+        ScriptedToolDesk(
+            answers=[ToolOutcome.refused("capability_unavailable")] * 3
+        ),
+        {"max_repeats_of_one_request": 1},
+        StopReason.REPEATED_REQUEST,
+        "capabilities_query",
+        id="it went in circles",
+    ),
+    pytest.param(
+        ScriptedVoice(replies=[look_around()]),
+        ARaisingDesk(),
+        {},
+        StopReason.TOOL_DESK_BROKE,
+        "capabilities_query",
+        id="the tool desk fell over",
+    ),
+    pytest.param(
+        ScriptedVoice(replies=[look_around()]),
+        ADeskThatAnswersWithRubbish(),
+        {},
+        StopReason.TOOL_DESK_BROKE,
+        "capabilities_query",
+        id="the tool desk answered with something else",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "voice,desk,changes,expected_stop,expected_tool",
+    STOPS_BETWEEN_THE_REPLY_AND_THE_TOOL_RESULT,
+)
+def test_every_stop_after_the_reply_still_files_the_call(
+    voice, desk, changes, expected_stop, expected_tool
+):
+    outcome = a_run(voice, desk, **changes)
+
+    assert outcome.stop_reason is expected_stop
+    answered = calls_the_model_answered(outcome)
+    assert answered >= 1
+    assert len(outcome.turns) == answered, (
+        f"{answered} reply(ies) arrived and {len(outcome.turns)} were filed; "
+        "the difference is money the run spent and did not write down"
+    )
+    last = outcome.turns[-1]
+    assert last.input_tokens == INPUT_TOKENS
+    assert last.output_tokens == OUTPUT_TOKENS
+    assert last.tool_name == expected_tool
+    assert last.ok is False
+    assert last.error_type == expected_stop.value
+
+
+def test_a_cancelled_run_still_files_the_reply_it_paid_for():
+    """Cancellation is the stop most likely to be read as costing nothing."""
+    stops = iter([False, True])
+    outcome = a_run(
+        ScriptedVoice(replies=[look_around()]),
+        ScriptedToolDesk(),
+        cancel_requested=lambda: next(stops, True),
+    )
+
+    assert outcome.stop_reason is StopReason.CANCELLED
+    assert len(outcome.turns) == calls_the_model_answered(outcome) == 1
+    assert outcome.turns[0].output_tokens == OUTPUT_TOKENS
+    assert outcome.turns[0].error_type == StopReason.CANCELLED.value
+
+
+def test_running_out_of_time_mid_turn_still_files_the_reply():
+    outcome = a_run(
+        ScriptedVoice(replies=[look_around()]),
+        ScriptedToolDesk(),
+        clock=a_clock_that_runs_away(),
+    )
+
+    assert outcome.stop_reason is StopReason.TIME_LIMIT_REACHED
+    assert len(outcome.turns) == calls_the_model_answered(outcome) == 1
+    assert outcome.turns[0].tool_name == "capabilities_query"
+
+
+def test_the_filed_turn_names_the_tool_the_money_was_spent_asking_for():
+    """Three of the five tasks in the first paid stage died on ``browser_run``.
+
+    Which tool is the whole finding there — a stage that reports six anonymous
+    charged turns says the run was expensive, and a stage that reports six
+    charged ``browser_run`` requests says the backend has no browser.
+    """
+    outcome = a_run(ScriptedVoice(replies=[browse()]), ARaisingDesk())
+
+    assert outcome.turns[-1].tool_name == "browser_run"
+    assert outcome.turns[-1].argument_names == ("action", "url")
+    assert outcome.turns[-1].call_id == "call-1"
+    assert outcome.tools_asked_for == ("browser_run",)
+
+
+def test_a_turn_that_never_named_a_tool_is_not_reported_as_one():
+    """It is still filed — the money is real — but it is not a tool call."""
+    outcome = a_run(
+        ScriptedVoice(replies=[GaveUp(note="", input_tokens=INPUT_TOKENS,
+                                      output_tokens=OUTPUT_TOKENS)]),
+        ScriptedToolDesk(),
+    )
+
+    assert len(outcome.turns) == 1
+    assert outcome.turns[0].tool_name == ""
+    assert outcome.turns[0].call_id == "turn-1-no-tool-result"
+    assert outcome.tools_asked_for == ()
+
+
+# ---------------------------------------------------------------------------
+# The other direction: never twice
+# ---------------------------------------------------------------------------
+
+
+def test_a_turn_the_tool_answered_is_filed_once_and_only_once():
+    """A flush that did not clear itself would double-bill the last turn."""
+    desk = ScriptedToolDesk(
+        answers=[
+            ToolOutcome.worked(commands=[]),
+            ToolOutcome.worked(commands=[]),
+        ]
+    )
+    outcome = a_run(
+        ScriptedVoice(replies=[look_around("call-1"), look_around("call-2")]),
+        desk,
+        max_model_turns=2,
+    )
+
+    assert outcome.stop_reason is StopReason.TURN_LIMIT_REACHED
+    assert len(outcome.turns) == calls_the_model_answered(outcome) == 2
+    assert [record.call_id for record in outcome.turns] == ["call-1", "call-2"]
+    assert [record.ok for record in outcome.turns] == [True, True]
+
+
+def test_a_run_that_finishes_normally_files_exactly_its_replies():
+    desk = ScriptedToolDesk(
+        answers=[
+            ToolOutcome.worked(commands=[]),
+            ToolOutcome.committed({"deliverables": ["report.txt"]}),
+        ]
+    )
+    outcome = a_run(
+        ScriptedVoice(replies=[look_around("call-1"), commit("call-2")]), desk
+    )
+
+    assert outcome.stop_reason is StopReason.FINISHED_NORMALLY
+    assert len(outcome.turns) == calls_the_model_answered(outcome) == 2
+    assert outcome.tools_asked_for == ("capabilities_query", "finalize")
+
+
+def test_a_run_refused_before_the_model_was_asked_files_nothing():
+    """Nothing was sent, so there is nothing to charge and nothing to file."""
+    outcome = run_model_conversation(
+        task_prompt="write a short report",
+        voice=ScriptedVoice(replies=[look_around()]),
+        desk=ScriptedToolDesk(),
+        limits=limits(max_model_turns=None),
+    )
+
+    assert outcome.stop_reason is StopReason.LIMIT_MISSING
+    assert outcome.turns == ()
+    assert calls_the_model_answered(outcome) == 0
+
+
+# ---------------------------------------------------------------------------
+# The one gap that stays a gap
+# ---------------------------------------------------------------------------
+
+
+class AVoiceThatDoesNotSayWhatItUsed:
+    makes_paid_calls = False
+
+    def next_turn(self, request):
+        return AskForTool(
+            call_id="call-1",
+            tool_name="capabilities_query",
+            arguments={"kind": "commands"},
+            why="no counts",
+            input_tokens=-1,
+            output_tokens=OUTPUT_TOKENS,
+        )
+
+
+def test_a_reply_that_never_said_what_it_used_is_left_out_not_zeroed():
+    """The honest gap, kept open on purpose.
+
+    A reply with no usable counts was charged for like any other, and the run
+    has no figure for it. Filing it with zeros would put the one number in the
+    account that reads as a measurement, so it is left out and the stop reason
+    says why. Closing this properly needs a reservation written before the call
+    rather than a record written after it, which is a different change.
+    """
+    outcome = a_run(AVoiceThatDoesNotSayWhatItUsed(), ScriptedToolDesk())
+
+    assert outcome.stop_reason is StopReason.MODEL_REPLY_UNUSABLE
+    assert outcome.turns == ()
+    assert calls_the_model_answered(outcome) == 0
+    assert "how much it used" in outcome.detail
+
+
+def test_a_reply_reporting_no_input_tokens_is_counted_but_not_priced():
+    """The other half of the same gap, and the one that nearly became a zero.
+
+    The real voice walks away when a response arrives with no ``usage``, and a
+    walk-away's token fields default to zero. Nothing calls a model for nothing
+    on the way in — the task prompt alone is thousands of tokens — so a zero
+    input count is a reply that was never counted, not a reply that was free.
+    Filing it would settle to ``$0.00`` on a ``complete`` receipt, which reads
+    as a measurement of a call nobody measured.
+    """
+    outcome = a_run(
+        ScriptedVoice(replies=[GaveUp(note="the model answered without saying "
+                                           "what it used")]),
+        ScriptedToolDesk(),
+    )
+
+    assert outcome.stop_reason is StopReason.MODEL_STOPPED_WITHOUT_FINISHING
+    assert outcome.turns == ()
+    assert a_ledger_entry_per_turn(outcome) == ()
+    # The reply is not lost, only unpriced: it is visible here and nowhere else.
+    assert outcome.model_calls_not_counted == 1
+    assert calls_the_model_answered(outcome) == 1
+    assert outcome.as_dict()["model_calls_not_counted"] == 1
+
+
+def test_a_counted_reply_does_not_show_up_as_uncounted():
+    outcome = a_run(ScriptedVoice(replies=[browse()]), ARaisingDesk())
+
+    assert outcome.model_calls_not_counted == 0
+    assert len(outcome.turns) == 1
+
+
+# ---------------------------------------------------------------------------
+# What actually reaches the ledger
+# ---------------------------------------------------------------------------
+
+
+def a_ledger_entry_per_turn(outcome: ConversationOutcome):
+    return model_turns_of(
+        outcome,
+        run_id="run-1",
+        task_id="task-1",
+        attempt=1,
+        provider="azure",
+        requested_model="gpt-5.4",
+        deployment="gpt-5.4",
+        api_version="2025-04-01-preview",
+        resolved_model="gpt-5.4",
+    )
+
+
+def test_the_ledger_gets_one_entry_for_every_call_the_model_answered():
+    """The 24-vs-18 shape, in miniature and in the object that carries money."""
+    outcome = a_run(ScriptedVoice(replies=[browse()]), ARaisingDesk())
+
+    entries = a_ledger_entry_per_turn(outcome)
+    assert len(entries) == calls_the_model_answered(outcome) == 1
+    assert entries[0].usage.input_tokens == INPUT_TOKENS
+    assert entries[0].usage.output_tokens == OUTPUT_TOKENS
+    assert entries[0].call_id == "run-1:task-1:1:call-1"
+
+
+def test_no_two_ledger_entries_from_one_run_share_a_call_id():
+    """Call ids are the ledger's primary key, including the invented ones."""
+    desk = ScriptedToolDesk(answers=[ToolOutcome.worked(commands=[])])
+    outcome = a_run(
+        ScriptedVoice(
+            replies=[
+                look_around("call-1"),
+                GaveUp(note="", input_tokens=INPUT_TOKENS,
+                       output_tokens=OUTPUT_TOKENS),
+            ]
+        ),
+        desk,
+    )
+
+    assert outcome.stop_reason is StopReason.MODEL_STOPPED_WITHOUT_FINISHING
+    entries = a_ledger_entry_per_turn(outcome)
+    assert len(entries) == calls_the_model_answered(outcome) == 2
+    assert len({entry.call_id for entry in entries}) == 2


### PR DESCRIPTION
첫 유료 Agentic Sandbox V2 스테이지(run 34660739834, 과제 5개)는 모델을 **24번** 불렀고,
비용 원장에는 **18번**만 들어갔습니다. 빠진 6번은 입력 17,775 · 출력 292 토큰,
그 스테이지가 실제로 쓴 돈의 약 20%입니다. 그런데 영수증 5장은 전부
`status: complete`, `missing_reasons: []`였습니다.

부족한 것보다 **부족한데 확신에 차 있는 것**이 문제입니다. 출력 어디에도
"이 숫자를 믿지 말라"는 표시가 없어서, 20% 적은 값이 그대로 전체 비용으로 읽힙니다.

## 원인

산술이 아니라 구조입니다. `run_model_conversation`은 **도구 책상이 답한 뒤에**
`TurnRecord`를 append 합니다. 모델 응답이 도착한 시점과 그 append 사이에
중단 지점이 **열 개** 있습니다.

- 모델이 그냥 포기함 (`MODEL_STOPPED_WITHOUT_FINISHING`)
- 턴당 출력 상한 초과 (`WRITING_LIMIT_REACHED`)
- 예산이 이미 받은 응답을 거절 (`COST_LIMIT_REACHED`)
- 요청 형태가 못 쓸 것 (`MODEL_REPLY_UNUSABLE`)
- 같은 요청 반복 (`REPEATED_REQUEST`)
- 도구 책상이 예외로 죽음 / 엉뚱한 것을 반환 (`TOOL_DESK_BROKE`)
- 취소 (`CANCELLED`)
- 시간 초과 (`TIME_LIMIT_REACHED`)

전부 **제공자가 이미 청구한 호출**이고, 전부 기록에서 사라졌습니다.
같은 루프의 이벤트 로그는 처음부터 맞았습니다 — `MODEL_REPLIED`는 응답이
도착하는 즉시 쓰입니다. 그래서 같은 실행의 두 기록이 서로 다른 값을 말했고,
**틀린 쪽이 돈을 들고 있는 쪽**이었습니다.

## 고친 것

`finish()`가 결과를 만들기 **전에**, 아직 정산되지 않은 유료 호출을 먼저
기록합니다. 열 개 경로가 모두 `finish()`로 모이므로 한 곳에서 닫힙니다.

- 청구된 턴은 어느 경로로 끝나든 `turns`에 남습니다.
- 그 턴은 **어느 도구를 부르려다 쓴 돈인지** 말합니다. 상한 검사보다 먼저
  요청을 읽도록 옮겼습니다(중단 우선순위는 그대로). 익명의 유료 턴 6개는
  "비쌌다"는 뜻이지만, `browser_run` 유료 요청 6개는 "백엔드에 브라우저가
  없다"는 뜻입니다 — 이번 스테이지에서 실제로 후자였습니다.
- 성공한 턴 뒤에는 플래그를 지웁니다. 안 지우면 반대 방향으로, 마지막 턴이
  두 번 청구됩니다.

## 일부러 안 닫은 구멍

토큰 수를 못 받은 응답은 **기록에 넣지 않고 세기만 합니다.**

실제 voice는 Azure 응답에 `usage`가 없으면 `GaveUp`으로 물러나는데, 그
`GaveUp`의 토큰 필드 기본값이 0입니다. 들어가는 쪽이 0인 모델 호출은
없습니다 — 과제 프롬프트만 해도 수천 토큰입니다. 그러니 입력 0은 **공짜였던
호출이 아니라 세지 못한 호출**입니다. 이걸 그냥 넣으면 `complete` 영수증에
`$0.00`이 찍히고, 그건 아무도 재지 않은 호출에 대한 측정값처럼 읽힙니다.

그래서 `ConversationOutcome.model_calls_not_counted`로 **개수만** 냅니다.
금액이 아니라 계정에 *대한* 숫자입니다. 세지 못한 호출의 비용을 추정하는
산술은 이 저장소가 하지 않는 유일한 산술입니다. 제대로 닫으려면 호출
*이전에* 예약을 쓰는 방식이어야 하고, 그건 다른 객체를 건드리는 다른 변경입니다.

## 확인 범위

새 테스트 19개(`test_the_calls_the_run_was_billed_for_and_never_filed.py`).
모델은 대역이고 도구 책상은 미리 쓴 목록이라 **아무것도 쓰지 않습니다.**

- 응답과 도구 결과 사이의 중단 7종을 매개변수로 돌려, 매번 이벤트 로그의
  응답 수와 `turns` 길이가 같은지 봅니다.
- 취소·시간 초과는 따로 봅니다. "취소는 공짜"로 읽히기 가장 쉬운 중단이라서입니다.
- 반대 방향(두 번 기록), call_id 충돌, `model_turns_of`를 통해 원장에 실제로
  도달하는 행 수까지 봅니다.

기존 `test_agentic_v2_conversation.py`의 한 테스트는 기대값이 바뀌었습니다.
대역 모델이 토큰 수 없이 보낸 세 번째 응답이 이제 **0으로 기록되지 않고**
세어지기 때문입니다. 주석에 이유를 적었습니다.

프로베 두 곳은 새로 생긴 `outcome.tools_asked_for`를 쓰도록 한 줄씩 바꿨습니다
(도구 이름이 없는 턴을 빈 문자열로 흘리지 않습니다).

해시 체인 증적은 별도 객체(`agentic_v2_provenance.py`)이고
`verify_agentic_v2_result`는 그쪽만 읽으므로, `turns`가 늘어도 검증은 영향받지 않습니다.

## 이 PR이 하지 않는 것

- 유료 실행을 하지 않습니다. 이 수정에는 필요 없습니다.
- 가격표를 건드리지 않습니다. A와 공유하는 파일이고 실행 중에는 바꾸지 않습니다.
- 이미 끝난 스테이지의 영수증을 소급해서 고치지 않습니다. 그 실행의 6번은
  여전히 세지 못한 채로 남고, 실제 비용은 기록된 $0.19367이 아니라
  원장 자체 가격표 기준 약 $0.24249입니다.
