### PR TITLE
실행 기록이 적은 숫자 두 가지가 틀렸습니다 — 가격표와 0으로만 나오던 지표

### DIFF
--- a/batch-runner/core/agentic_v2_provenance.py
+++ b/batch-runner/core/agentic_v2_provenance.py
@@ -37,8 +37,17 @@ _FOUNDATION_MODULES = (
     "agentic_v2_runner.py",
     "agentic_v2_tools.py",
 )
+#: The event kind that carries a redacted tool result in the public trace.
+#:
+#: Named because a reader outside this module has to filter on it, and the one
+#: that did filtered on a literal it had got wrong -- it looked for a
+#: ``tool_name`` on the event, which :func:`verify_trace_pair` forbids at that
+#: level, and so read every V2 run as having made no tool calls. A shared
+#: constant means the filter and the validator move together.
+EVENT_TOOL_PUBLIC = "tool_result_public"
+
 _EVENT_KINDS = frozenset({
-    "started", "tool_result", "tool_result_public", "failure"
+    "started", "tool_result", EVENT_TOOL_PUBLIC, "failure"
 })
 _PUBLIC_COMMITMENT_FIELDS = (
     "call_id",
@@ -412,7 +421,7 @@ def verify_event_chain(events: Any, expected_head_sha256: str) -> None:
             tool_event_kind = kind
         elif kind != tool_event_kind:
             raise ValueError("agentic v2 event trace classification is mixed")
-        if kind in {"tool_result", "tool_result_public"} and isinstance(
+        if kind in {"tool_result", EVENT_TOOL_PUBLIC} and isinstance(
             last_tool_result, Mapping
         ) and (
             last_tool_result.get("ok") is False
@@ -472,7 +481,7 @@ def verify_event_chain(events: Any, expected_head_sha256: str) -> None:
                 })
                 if request_sha256 != result.get("request_sha256"):
                     raise ValueError("agentic v2 tool request hash mismatch")
-        if kind == "tool_result_public":
+        if kind == EVENT_TOOL_PUBLIC:
             if not isinstance(payload, dict) or set(payload) != {
                 "result_commitment", "replayed"
             } or not isinstance(payload.get("replayed"), bool):
@@ -557,7 +566,7 @@ def verify_trace_pair(
             continue
         if (
             private_event.get("kind") != "tool_result"
-            or public_event.get("kind") != "tool_result_public"
+            or public_event.get("kind") != EVENT_TOOL_PUBLIC
         ):
             raise ValueError("agentic v2 trace pair kind mismatch")
         private_payload = private_event["payload"]

--- a/batch-runner/core/agentic_v2_run_driver.py
+++ b/batch-runner/core/agentic_v2_run_driver.py
@@ -59,6 +59,7 @@ from core.agentic_v2_deliverable_collection import (
     collect_deliverables,
 )
 from core.agentic_v2_preregistration import STOP_RULES
+from core.agentic_v2_provenance import EVENT_TOOL_PUBLIC
 from core.agentic_v2_run_report import (
     build_agentic_v2_metrics,
     build_result_row,
@@ -341,11 +342,14 @@ def run_manifest(
             )
 
             standing = journal.standing(task_id)
+            input_tokens, output_tokens = _tokens_of(receipt)
             metrics = build_agentic_v2_metrics(
                 result,
                 standing=standing,
                 tool_calls=_tool_calls_of(result),
-                model_api_calls=_model_calls_of(result),
+                model_api_calls=_model_calls_of(receipt),
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
                 task_wall_time_ms=elapsed_ms,
                 receipt=receipt,
             )
@@ -435,6 +439,21 @@ def _tool_calls_of(result: Mapping[str, Any]) -> Sequence[Mapping[str, Any]]:
 
     The private audit is not read here on purpose: a report is a public
     artefact and should be built from the trace that was redacted for one.
+
+    This used to look for ``tool_name`` on the event itself and always found
+    nothing, so every V2 run reported an empty tool breakdown. The name is two
+    levels in. A public event is ``{"result_commitment": ..., "replayed": ...}``
+    and the commitment is where the redacted fields live --
+    ``core.agentic_v2_provenance`` rejects a public payload with any other key
+    set, so the shape the old filter was looking for is one the verifier could
+    never have admitted. What is returned here is the commitment rather than
+    the event, because the commitment is the part
+    :func:`~core.agentic_v2_run_report._tool_counts` reads a name off.
+
+    A replayed call is counted. The desk answers a repeated identical request
+    from what it stored, but the model still asked, and a model that sends the
+    same oversized request three times is the case this count exists to make
+    visible rather than hide.
     """
     block = result.get("agentic_v2")
     if not isinstance(block, Mapping):
@@ -445,18 +464,60 @@ def _tool_calls_of(result: Mapping[str, Any]) -> Sequence[Mapping[str, Any]]:
     events = trace.get("events")
     if not isinstance(events, Sequence):
         return ()
-    return [
-        event
-        for event in events
-        if isinstance(event, Mapping) and event.get("tool_name")
-    ]
+    calls: list[Mapping[str, Any]] = []
+    for event in events:
+        if not isinstance(event, Mapping) or event.get("kind") != EVENT_TOOL_PUBLIC:
+            continue
+        payload = event.get("payload")
+        if not isinstance(payload, Mapping):
+            continue
+        commitment = payload.get("result_commitment")
+        if isinstance(commitment, Mapping) and commitment.get("tool_name"):
+            calls.append(commitment)
+    return calls
 
 
-def _model_calls_of(result: Mapping[str, Any]) -> int:
-    block = result.get("agentic_v2")
-    if not isinstance(block, Mapping):
+def _model_calls_of(receipt: Mapping[str, Any] | None) -> int:
+    """How many calls to the model this task was billed for.
+
+    Read off the receipt, because the receipt is the only thing that knows. It
+    used to be read off ``result["agentic_v2"]["model_api_calls"]``, which is a
+    key nothing writes and nothing may write: ``verify_agentic_v2_metadata``
+    compares that block against an exact key set, so a run that carried the
+    field would be refused as invalid. The reader was looking for a number the
+    schema forbids, and returned 0 for every task of every run.
+
+    Zero is still returned when there is no receipt, and that is a floor rather
+    than a measurement. The row says so beside it --
+    ``agentic_v2_cost_receipt_status`` reads ``not_run`` and ``usage_complete``
+    reads false -- which is the same pairing the cost fields already use.
+    """
+    if not isinstance(receipt, Mapping):
         return 0
-    count = block.get("model_api_calls")
+    count = receipt.get("model_calls")
     if type(count) is int and count >= 0:
         return count
     return 0
+
+
+def _tokens_of(receipt: Mapping[str, Any] | None) -> tuple[int | None, int | None]:
+    """The task's token counts, or ``None`` where none were recorded.
+
+    ``None`` and ``0`` are different answers and the report treats them
+    differently: ``build_agentic_v2_metrics`` omits the key entirely for
+    ``None``, and an absent key claims nothing, where a zero claims the model
+    read and wrote nothing. No V2 task has ever had a zero-token call -- the
+    task prompt alone is thousands of tokens -- so a zero here would always be
+    the wrong one of the two.
+    """
+    if not isinstance(receipt, Mapping):
+        return (None, None)
+    usage = receipt.get("usage")
+    if not isinstance(usage, Mapping):
+        return (None, None)
+
+    def _count(name: str) -> int | None:
+        value = usage.get(name)
+        return value if type(value) is int and value >= 0 else None
+
+    return (_count("input_tokens"), _count("output_tokens"))

--- a/batch-runner/core/agentic_v2_run_report.py
+++ b/batch-runner/core/agentic_v2_run_report.py
@@ -63,9 +63,10 @@ STATUS_ERROR = "error"
 
 #: The tool names ``step6_report._compute_agentic_metrics`` buckets calls under.
 #:
-#: Copied here so the mismatch with V2 can be asserted rather than described.
-#: If the report ever learns V2's vocabulary this constant stops matching it and
-#: the test that guards it fails, which is the point.
+#: V1's vocabulary, and for a long time the whole of what the report could
+#: name. Kept as its own constant because the V1 names have to stay in the
+#: breakdown and in that order -- a V1 run's report must not change shape
+#: because V2 arrived.
 TOOL_NAMES_THE_REPORT_KNOWS = (
     "inspect_workspace",
     "inspect_environment",
@@ -80,11 +81,9 @@ TOOL_NAMES_V2_USES = TOOL_NAMES
 
 #: The one name both vocabularies share.
 #:
-#: ``finalize`` means the same thing in both, so its count *will* appear in the
-#: report's existing breakdown. Every other V2 tool will not, and a reader who
-#: sees a lone non-zero ``finalize`` beside five zeros would reasonably conclude
-#: the model used one tool. Naming the overlap is what makes that conclusion
-#: checkable instead of surprising.
+#: ``finalize`` means the same thing in both, so a count under it is a sum
+#: across two different runners and cannot be attributed to either. Naming the
+#: overlap is what makes that checkable instead of surprising.
 SHARED_TOOL_NAMES = tuple(
     name for name in TOOL_NAMES_V2_USES if name in TOOL_NAMES_THE_REPORT_KNOWS
 )
@@ -94,6 +93,25 @@ if set(SHARED_TOOL_NAMES) != {"finalize"}:  # pragma: no cover - import guard
         "the report's tool vocabulary and V2's now overlap differently than "
         f"recorded: {sorted(SHARED_TOOL_NAMES)}"
     )
+
+#: Every bucket the report's tool breakdown offers, both vocabularies.
+#:
+#: The report used to offer only the six above. A V2 row carries counts under
+#: all eight of V2's names, seven of which were not in that list, so seven of
+#: them were dropped on the way into the summary and the breakdown showed a
+#: lone non-zero ``finalize`` beside five zeros -- which reads as a model that
+#: used one tool, for a run in which it used several.
+#:
+#: ``browser_run`` is why this is worth the widening rather than a footnote.
+#: Three of the five tasks in the first paid stage ended on it, and it was the
+#: single most informative thing that run produced. It was also one of the
+#: seven names with nowhere to land.
+#:
+#: V1's names come first and keep their order, so an existing report's
+#: breakdown gains keys and does not reorder or lose any.
+TOOL_NAMES_THE_REPORT_BUCKETS = TOOL_NAMES_THE_REPORT_KNOWS + tuple(
+    name for name in TOOL_NAMES_V2_USES if name not in TOOL_NAMES_THE_REPORT_KNOWS
+)
 
 
 class ReportRowRefused(RuntimeError):

--- a/batch-runner/core/execution_envelope_cost.py
+++ b/batch-runner/core/execution_envelope_cost.py
@@ -43,6 +43,19 @@ PRICE_TABLE_SCHEMA_VERSION = "execution-envelope-price-table-v1"
 
 TOKENS_PER_MILLION = Decimal(1_000_000)
 
+#: Whose published rates a voice prices its own calls with.
+#:
+#: Every paid run in this repository speaks to Azure, so this is a statement
+#: about the client that gets built rather than a setting anyone chooses. It is
+#: named because the price list holds two blocks and they disagree: the
+#: ``models`` block understates 5.4 by half on input and two thirds on output
+#: and carries no source, and the ``providers`` block keyed ``azure:`` carries
+#: the retail meter names and the date they were read. The cost ledger has
+#: always used the second. Until this constant existed every voice used the
+#: first, so the same calls were reported at two prices in two files written by
+#: the same run, and nothing said which to believe.
+PAID_VOICE_PRICE_PROVIDER = "azure"
+
 # How much of one reference file may reach the model's prompt. The module that
 # decides this is core/file_preview.py, which every run place goes through —
 # not core/file_reader.py, whose 50,000-character cut is only reachable through
@@ -97,6 +110,96 @@ def load_price_table(path: str | Path | None = None) -> dict[str, ModelPrice]:
         )
     if not prices:
         raise ValueError("the price list names no model")
+    return prices
+
+
+def load_provider_price_table(
+    provider: str, path: str | Path | None = None
+) -> dict[str, ModelPrice]:
+    """One provider's prices, keyed by bare model name.
+
+    The same file holds two price lists and they do not agree. The ``models``
+    block above prices a plan before it runs; the ``providers`` block prices a
+    call after it. For ``gpt-5.4`` the first says $1.25 in and $5.00 out and
+    carries no source, and the second says $2.50 and $15.00 and carries the
+    Azure retail meter names, the API it was read from, and the date it was
+    read. The file's own note records that on 2026-08-29 not one figure in the
+    ``models`` block matched a published meter.
+
+    Anything pricing a call that really happened wants the second, and until
+    this existed the only reader of the ``providers`` block was the cost
+    ledger. The voice priced each call it made from the first, so a run record
+    and the ledger beside it reported roughly half and a whole bill for the
+    same calls, and nothing said which to believe.
+
+    Keyed by bare model name because that is what a caller holds: the model
+    name comes back in the reply, and the provider is a property of the client
+    that was built, not of the answer. ``ModelPrice`` has no cached-input rate
+    and no caller measures cached tokens, so every input token is priced at the
+    full rate. That is the upper bound of the two, and it is the same
+    arithmetic the ledger does on the same token counts, so the two agree
+    exactly rather than approximately.
+
+    A model with no entry for this provider is left out rather than filled in
+    from the ``models`` block. A caller that cannot find a price reports the
+    call unpriced, and the run total goes to ``None`` -- missing is partial,
+    never zero. Silently substituting an unsourced figure would turn that
+    refusal into a number, which is the defect this function exists to close.
+    """
+    wanted = str(provider).strip()
+    if not wanted or ":" in wanted:
+        raise ValueError(
+            f"{provider!r} is not a provider name; it names the client that "
+            "was built, such as 'azure'"
+        )
+    target = Path(path) if path is not None else PRICE_TABLE_PATH
+    if not target.is_file():
+        raise ValueError(f"the price list is missing at {target}")
+    raw = json.loads(target.read_text(encoding="utf-8"))
+    # The ledger's own constant rather than a second copy of the string. The
+    # two blocks in this file are versioned separately and the loader that
+    # reads one must move with it, not with the other.
+    from core.cost_receipts import (
+        PRICE_TABLE_SCHEMA_VERSION as PROVIDER_BLOCK_SCHEMA_VERSION,
+    )
+
+    if raw.get("cost_receipt_schema_version") != PROVIDER_BLOCK_SCHEMA_VERSION:
+        raise ValueError(
+            "the provider price list was written for "
+            f"{raw.get('cost_receipt_schema_version')!r}, but this code reads "
+            f"{PROVIDER_BLOCK_SCHEMA_VERSION!r}"
+        )
+    prices: dict[str, ModelPrice] = {}
+    for key, entry in dict(raw.get("providers") or {}).items():
+        if not isinstance(entry, Mapping):
+            raise ValueError(f"the price entry for {key} is not a block")
+        named, _, model = str(key).partition(":")
+        if not named or not model:
+            raise ValueError(
+                f"the price key {key!r} must name both a provider and a model, "
+                "written as provider:model"
+            )
+        if named != wanted:
+            continue
+        # The same two fields the receipt loader insists on. A rate with no
+        # source and no review date is the thing that went wrong in the block
+        # this function exists to stop reading.
+        for required in ("source", "last_reviewed"):
+            if not str(entry.get(required) or "").strip():
+                raise ValueError(
+                    f"the price entry for {key} has no {required}; a rate "
+                    "nobody can trace is not a price"
+                )
+        for required in ("input_usd_per_million", "output_usd_per_million"):
+            if entry.get(required) in (None, ""):
+                raise ValueError(f"the price entry for {key} has no {required}")
+        prices[model] = ModelPrice(
+            model=model,
+            input_usd_per_million=Decimal(str(entry["input_usd_per_million"])),
+            output_usd_per_million=Decimal(str(entry["output_usd_per_million"])),
+        )
+    if not prices:
+        raise ValueError(f"the price list names no model for {wanted!r}")
     return prices
 
 

--- a/batch-runner/scripts/run_agentic_stage_a_probe.py
+++ b/batch-runner/scripts/run_agentic_stage_a_probe.py
@@ -58,8 +58,9 @@ from core.agentic_v2_stage_one_budget import (  # noqa: E402
     run_stage_one_preflight,
 )
 from core.execution_envelope_cost import (  # noqa: E402
+    PAID_VOICE_PRICE_PROVIDER,
     CostAssumptions,
-    load_price_table,
+    load_provider_price_table,
 )
 from core.execution_envelope_preflight import load_plan  # noqa: E402
 from core.execution_envelope_tasks import (  # noqa: E402
@@ -331,7 +332,7 @@ def main() -> int:
             max_output_tokens_per_turn=verdict.max_output_tokens_per_turn,
             max_tool_calls=verdict.tool_calls_per_attempt,
             max_seconds=float(plan["fixed_settings"]["per_task_timeout_seconds"]),
-            prices=load_price_table(),
+            prices=load_provider_price_table(PAID_VOICE_PRICE_PROVIDER),
             tools=PROBE_TOOLS,
         )
         fingerprint = managed.runtime_fingerprint

--- a/batch-runner/scripts/run_agentic_stage_d_probe.py
+++ b/batch-runner/scripts/run_agentic_stage_d_probe.py
@@ -77,7 +77,10 @@ from core.agentic_v2_stage_d_probe import (  # noqa: E402
 )
 from core.agentic_v2_stage_one_budget import STAGE_ONE_PLAN_PATH  # noqa: E402
 from core.agentic_v2_substrate import AgenticV2SubstrateManifest  # noqa: E402
-from core.execution_envelope_cost import load_price_table  # noqa: E402
+from core.execution_envelope_cost import (  # noqa: E402
+    PAID_VOICE_PRICE_PROVIDER,
+    load_provider_price_table,
+)
 from core.execution_envelope_tasks import DATASET_REVISION  # noqa: E402
 
 #: Where C2 leaves the artefact this refuses to run without.
@@ -319,7 +322,10 @@ def the_paid_setup_a_dry_run_can_reach() -> list[str]:
     problems: list[str] = []
     for reading, load in (
         ("the substrate manifest", lambda: AgenticV2SubstrateManifest.load(SUBSTRATE_MANIFEST)),
-        ("the price table", load_price_table),
+        (
+            "the price table",
+            lambda: load_provider_price_table(PAID_VOICE_PRICE_PROVIDER),
+        ),
     ):
         try:
             load()
@@ -489,7 +495,7 @@ def main(argv: list[str] | None = None) -> int:
             max_seconds=seconds,
             max_tool_calls=args.max_tool_calls,
             collect_outputs_into=workspace / "collected",
-            prices=load_price_table(),
+            prices=load_provider_price_table(PAID_VOICE_PRICE_PROVIDER),
             tools=PROBE_TOOLS,
         )
         fingerprint = managed.runtime_fingerprint

--- a/batch-runner/scripts/run_agentic_v2_stage.py
+++ b/batch-runner/scripts/run_agentic_v2_stage.py
@@ -105,8 +105,9 @@ from core.cost_receipts import (  # noqa: E402
     STATUS_UNAVAILABLE,
 )
 from core.execution_envelope_cost import (  # noqa: E402
+    PAID_VOICE_PRICE_PROVIDER,
     CostAssumptions,
-    load_price_table,
+    load_provider_price_table,
 )
 from core.execution_envelope_preflight import load_plan  # noqa: E402
 from core.execution_envelope_tasks import (  # noqa: E402
@@ -254,8 +255,17 @@ def model_calls_record(
     The sqlite ledger beside this is the bill. This is the evidence the bill
     was made from, and it is kept because the two are computed from different
     things and disagreement between them is worth being able to see: the
-    ledger prices from the committed price list, and the voice prices from the
-    same list keyed by the name the reply gave.
+    ledger prices from the committed list keyed ``provider:model``, and the
+    voice prices from the same provider's entries keyed by the name the reply
+    gave. Same rates, same token counts, two arrivals at the figure.
+
+    That was not true until ``PAID_VOICE_PRICE_PROVIDER`` existed. The voice
+    read the ``models`` block, which prices a plan rather than a call, carries
+    no source, and states $1.25 and $5.00 per million where the meters say
+    $2.50 and $15.00. So the disagreement this record exists to expose was
+    guaranteed instead of diagnostic -- always a factor of two on input and
+    three on output, whatever the run did, which is the one thing a difference
+    meant to be read cannot be.
 
     ``resolved_model`` is the point of it. A deployment is an alias, and what
     answers behind it can change without the alias changing -- so "which model
@@ -441,12 +451,18 @@ def open_the_ledger(into: Path, *, run_id: str):
     2026-08-29, so a run without this argument would have reported the whole
     cohort as unaccounted for while the figures sat in the repository.
 
-    Two loaders read that same file and their names are close enough to swap by
-    accident. ``execution_envelope_cost.load_price_table`` returns prices keyed
-    by bare model name for the pre-run ceiling and for the voice;
-    ``cost_receipts.load_receipt_price_table`` returns the table the ledger
-    takes, keyed ``provider:model``, and fingerprints the file so a receipt can
-    name the exact bytes that priced it. The ledger wants the second.
+    Three loaders read that same file and their names are close enough to swap
+    by accident. ``execution_envelope_cost.load_price_table`` returns the
+    ``models`` block keyed by bare model name, which is the pre-run ceiling and
+    nothing else; ``load_provider_price_table`` returns one provider's entries
+    out of the ``providers`` block, also keyed by bare model name, which is
+    what the voice prices its calls with; ``cost_receipts.load_receipt_price_table``
+    returns the whole ``providers`` block keyed ``provider:model`` and
+    fingerprints the file, so a receipt can name the exact bytes that priced
+    it. The ledger wants the third. The first two read *different blocks* and
+    the blocks disagree -- the voice used to read the ceiling's block, and the
+    run record it wrote reported half of what the ledger beside it reported for
+    the same calls.
     """
     from core.cost_receipts import CostReceiptLedger, load_receipt_price_table
 
@@ -561,7 +577,7 @@ def the_paid_setup_a_dry_run_can_reach(stage: str) -> list[str]:
         # the same file the paid run will, and a price list that has stopped
         # parsing is found here rather than after a deployment has been leased.
         try:
-            load_price_table()
+            load_provider_price_table(PAID_VOICE_PRICE_PROVIDER)
         except Exception as broke:  # noqa: BLE001 - reported, not handled
             return [f"the committed price list cannot be loaded: {broke!r}"]
         try:
@@ -905,7 +921,7 @@ def main() -> int:
             settings=settings,
             timeout=float(plan["fixed_settings"]["per_task_timeout_seconds"]),
         )
-        prices = load_price_table()
+        prices = load_provider_price_table(PAID_VOICE_PRICE_PROVIDER)
 
     try:
         if managed is not None:

--- a/batch-runner/step6_report.py
+++ b/batch-runner/step6_report.py
@@ -45,6 +45,9 @@ from core.cost_projection import (  # noqa: E402
     verify_cost_ledger,
 )
 from core.execution_metrics import bounded_count, bounded_duration_ms  # noqa: E402
+from core.agentic_v2_run_report import (  # noqa: E402
+    TOOL_NAMES_THE_REPORT_BUCKETS,
+)
 from core.measurement_display import render_measured  # noqa: E402
 from core.prepared_fingerprint import FINGERPRINT_RE  # noqa: E402
 from core.result_fingerprint import RESULT_FINGERPRINT_RE  # noqa: E402
@@ -360,10 +363,7 @@ def _compute_agentic_metrics(data: dict) -> dict | None:
         if result.get("status") == "success"
         and raw.get("recovered_after_tool_error") is True
     )
-    tool_names = (
-        "inspect_workspace", "inspect_environment", "run_python",
-        "run_ffmpeg", "inspect_artifacts", "finalize",
-    )
+    tool_names = TOOL_NAMES_THE_REPORT_BUCKETS
     calls_by_name = {name: 0 for name in tool_names}
     terminal_categories: dict[str, int] = {}
     conservative_cost = 0.0

--- a/batch-runner/tests/test_agentic_v2_run_driver.py
+++ b/batch-runner/tests/test_agentic_v2_run_driver.py
@@ -41,14 +41,40 @@ def _tasks(count=3):
 
 
 def _success(task_id, *, calls=("exec_run", "finalize")):
+    """A result shaped the way the runner shapes one, minus the hashes.
+
+    The nesting is not decoration. A public event's payload is checked against
+    an exact key set, and the tool name lives on the commitment inside it, two
+    levels down -- so a stand-in with the name on the event is a shape no run
+    can produce and no verifier would admit. It was, for a while, and the
+    driver read the trace the same wrong way, which is how V2 came to report
+    zero tool calls for every task of every run without a test going red.
+
+    ``model_api_calls`` is not here for the same reason: the metadata is
+    compared against an exact key set that does not include it. The count comes
+    from the cost receipt, which is the only object that knows it.
+
+    Kept honest by
+    ``test_the_metrics_block_that_always_read_zero.py::test_the_drivers_stand_in_result_is_shaped_like_a_real_one``,
+    which boots the real fixture backend and compares this shape against the
+    record it writes.
+    """
     return {
         "success": True,
         "deliverable_text": f"answer for {task_id}",
         "files": [{"filename": "report.xlsx", "content": b"payload"}],
         "agentic_v2": {
-            "model_api_calls": 2,
             "public_trace": {
-                "events": [{"tool_name": name} for name in calls]
+                "events": [
+                    {
+                        "kind": "tool_result_public",
+                        "payload": {
+                            "result_commitment": {"tool_name": name},
+                            "replayed": False,
+                        },
+                    }
+                    for name in calls
+                ]
             },
         },
     }
@@ -190,10 +216,15 @@ def test_the_files_reach_the_submission_layout(tmp_path):
 
 
 def test_v2_tool_calls_are_counted_from_the_public_trace(tmp_path):
-    outcome, _ = _run(tmp_path, _tasks(1), _success)
+    def receipt_for(task, attempt):
+        return {"status": STATUS_COMPLETE, "model_calls": 2}
+
+    outcome, _ = _run(tmp_path, _tasks(1), _success, receipt_for=receipt_for)
     metrics = outcome.rows[0]["observability"]["agentic_metrics"]
     assert metrics["tool_calls"] == 2
     assert metrics["tool_calls_by_name"]["exec_run"] == 1
+    # From the receipt, not the result: the metadata verifier rejects a record
+    # that carries a call count, so the result cannot be asked for one.
     assert metrics["model_api_calls"] == 2
 
 

--- a/batch-runner/tests/test_agentic_v2_run_report.py
+++ b/batch-runner/tests/test_agentic_v2_run_report.py
@@ -4,7 +4,8 @@ Most of these tests are about the things that would be easy to state wrongly: a
 zero where a number is unknown, a graded count where nothing was graded, a
 deliverable list that came from the model rather than from the disk. The
 mismatch between V1's tool names and V2's is asserted here rather than merely
-noted, so that fixing the report later breaks this file on purpose.
+noted: the summary now offers a bucket for both vocabularies, and these tests
+are what stops the two lists drifting apart again.
 """
 
 from __future__ import annotations
@@ -17,6 +18,7 @@ from core.agentic_v2_run_report import (
     SHARED_TOOL_NAMES,
     STATUS_ERROR,
     STATUS_SUCCESS,
+    TOOL_NAMES_THE_REPORT_BUCKETS,
     TOOL_NAMES_THE_REPORT_KNOWS,
     ReportRowRefused,
     build_agentic_v2_metrics,
@@ -94,6 +96,48 @@ def test_the_report_s_tool_names_and_v2_s_share_only_finalize():
     overlap = set(TOOL_NAMES) & set(TOOL_NAMES_THE_REPORT_KNOWS)
     assert overlap == {"finalize"}
     assert SHARED_TOOL_NAMES == ("finalize",)
+
+
+def test_the_breakdown_has_a_bucket_for_every_name_either_runner_uses():
+    """Seven of V2's eight had nowhere to land, so they were dropped.
+
+    Including ``browser_run``, which three of the five tasks in the first paid
+    stage ended on. The summary showed a lone non-zero ``finalize``.
+    """
+    assert set(TOOL_NAMES_THE_REPORT_BUCKETS) == set(TOOL_NAMES) | set(
+        TOOL_NAMES_THE_REPORT_KNOWS
+    )
+    assert len(TOOL_NAMES_THE_REPORT_BUCKETS) == len(
+        set(TOOL_NAMES_THE_REPORT_BUCKETS)
+    )
+    # V1's order, unchanged, at the front: an existing report's breakdown gains
+    # keys rather than reordering.
+    assert (
+        TOOL_NAMES_THE_REPORT_BUCKETS[: len(TOOL_NAMES_THE_REPORT_KNOWS)]
+        == TOOL_NAMES_THE_REPORT_KNOWS
+    )
+
+
+def test_the_report_buckets_under_exactly_these_names():
+    """The constant and the summary that reads it, checked against each other.
+
+    ``step6_report`` used to hold its own copy of the list. A copy is how the
+    two came to disagree in the first place.
+    """
+    import step6_report
+
+    row = {
+        "task_wall_time_ms": 1.0,
+        "tool_calls": 2,
+        "tool_calls_by_name": {"browser_run": 1, "finalize": 1},
+    }
+    summary = step6_report._compute_agentic_metrics(
+        {"results": [{"observability": {"agentic_metrics": row}}]}
+    )
+
+    assert set(summary["tool_calls_by_name"]) == set(TOOL_NAMES_THE_REPORT_BUCKETS)
+    assert summary["tool_calls_by_name"]["browser_run"] == 1
+    assert summary["total_tool_calls"] == 2
 
 
 def test_every_v2_tool_gets_a_bucket_even_when_unused():

--- a/batch-runner/tests/test_step6_v2_fields.py
+++ b/batch-runner/tests/test_step6_v2_fields.py
@@ -979,6 +979,9 @@ def test_generate_report_adds_agentic_metrics_only_when_measured(monkeypatch, tm
     assert metrics["usage_complete_tasks"] == 1
     assert metrics["usage_coverage_pct"] == 50.0
     assert metrics["conservative_cost_usd"] == 0.75
+    # V1's six keep their counts. The seven V2-only names are present and zero:
+    # this fixture is a V1 run, and a bucket with nothing in it is the right
+    # answer for a tool that run could not have called.
     assert metrics["tool_calls_by_name"] == {
         "inspect_workspace": 1,
         "inspect_environment": 1,
@@ -986,6 +989,13 @@ def test_generate_report_adds_agentic_metrics_only_when_measured(monkeypatch, tm
         "run_ffmpeg": 1,
         "inspect_artifacts": 1,
         "finalize": 1,
+        "capabilities_query": 0,
+        "workspace_apply": 0,
+        "exec_run": 0,
+        "environment_resolve": 0,
+        "environment_activate": 0,
+        "browser_run": 0,
+        "verify_public": 0,
     }
     assert metrics["terminal_error_categories"] == {"capability_missing": 1}
     assert rd["task_results"][0]["observability"]["agentic_metrics"][

--- a/batch-runner/tests/test_the_metrics_block_that_always_read_zero.py
+++ b/batch-runner/tests/test_the_metrics_block_that_always_read_zero.py
@@ -1,0 +1,355 @@
+"""Every V2 task reported no tool calls and no model calls, in every run.
+
+Not a bad run. A shape mismatch, in both directions, that no run could avoid.
+
+**The tool breakdown.** ``_tool_calls_of`` filtered the public trace for events
+with a ``tool_name`` on them. A public event has ``kind``, ``payload`` and the
+chain fields, and its payload is exactly ``{"result_commitment", "replayed"}``
+-- ``verify_trace_pair`` raises for any other key set. The tool name is two
+levels in, on the commitment. So the filter matched nothing a verifier would
+admit, and ``tool_calls`` and ``tool_calls_by_name`` were empty for every task
+of every run.
+
+**The model-call count.** ``_model_calls_of`` read
+``result["agentic_v2"]["model_api_calls"]``. That block is checked against an
+*exact* key set by ``verify_agentic_v2_metadata``, and ``model_api_calls`` is
+not in it -- so a run that carried the field would be refused as invalid. The
+reader was looking for a number the schema forbids, and got 0 every time.
+
+**The tokens.** ``build_agentic_v2_metrics`` accepts ``input_tokens`` and
+``output_tokens`` and omits the keys when they are ``None``. The driver never
+passed either, so they were absent from every V2 metrics block ever written.
+
+Why this survived review: the driver's own test builds a stand-in result in the
+shape the reader was looking for, complete with a top-level ``tool_name`` and a
+``model_api_calls`` field. Stand-in and reader agreed with each other and
+neither agreed with the runner. So the tests below run the *real* runner against
+the *real* fixture backend and read the record it actually produces. One of them
+then checks the stand-in against that record, so the two cannot drift apart
+again without something going red.
+
+What the fix reads instead: the commitment, for tool names; and the cost
+receipt, for the call count and the tokens -- the receipt being the only object
+in the system that knows how many calls a task was billed for.
+
+Nothing here calls a model, reaches a network or spends anything.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.agentic_v2_fixture_backend import AgenticV2FixtureBackend  # noqa: E402
+from core.agentic_v2_provenance import (  # noqa: E402
+    EVENT_TOOL_PUBLIC,
+    verify_agentic_v2_metadata,
+    verify_agentic_v2_result,
+)
+from core.agentic_v2_run_driver import (  # noqa: E402
+    _model_calls_of,
+    _tokens_of,
+    _tool_calls_of,
+)
+from core.agentic_v2_run_report import build_agentic_v2_metrics  # noqa: E402
+from core.agentic_v2_runner import AgenticV2ScriptedRunner  # noqa: E402
+from core.agentic_v2_task_journal import TaskStanding  # noqa: E402
+from core.cost_receipts import STATUS_COMPLETE  # noqa: E402
+
+PROFILE = {
+    "tool_contract_version": "2.0",
+    "policy_profile_id": "offline-full-v1",
+    "foundation_only": True,
+}
+
+WRITE_THEN_FINALIZE = [
+    {
+        "call_id": "write-1",
+        "name": "workspace_apply",
+        "arguments": {
+            "operation": "write",
+            "path": "report.txt",
+            "content": "done",
+        },
+    },
+    {
+        "call_id": "final-1",
+        "name": "finalize",
+        "arguments": {"deliverables": ["report.txt"], "summary": "done"},
+    },
+]
+
+
+@pytest.fixture
+def real_result(tmp_path):
+    """A run record the verifier accepts, from the runner that writes them."""
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=list(WRITE_THEN_FINALIZE),
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+    verify_agentic_v2_result(result)
+    return result
+
+
+def a_receipt(**changes):
+    receipt = {
+        "status": STATUS_COMPLETE,
+        "model_calls": 4,
+        "usage": {
+            "input_tokens": 17_775,
+            "cached_input_tokens": 0,
+            "output_tokens": 292,
+            "reasoning_tokens": 0,
+        },
+        "estimated_cost_usd": 0.24249,
+        "missing_reasons": [],
+    }
+    receipt.update(changes)
+    return receipt
+
+
+def a_standing(*, fully_accounted=True):
+    """A journal standing, made unaccounted the way a real one becomes so.
+
+    ``cost_is_fully_accounted`` is derived, not stored -- it is false when an
+    attempt was opened and never closed. So the unaccounted case here is an
+    abandoned attempt rather than a flag, which is the state a run actually
+    reaches when a task dies mid-call.
+    """
+    return TaskStanding(
+        task_id="task-1",
+        attempts=1 if fully_accounted else 2,
+        abandoned_attempts=0 if fully_accounted else 1,
+        last_closed=None,
+        decision="run",
+        reason="",
+    )
+
+
+# ---------------------------------------------------------------------------
+# The measurement: what the old filters found in a real record
+# ---------------------------------------------------------------------------
+
+
+def test_the_real_record_has_no_tool_name_where_the_old_filter_looked(real_result):
+    """The defect, as a property of a record the verifier accepted."""
+    events = real_result["agentic_v2"]["public_trace"]["events"]
+
+    assert events, "the fixture produced no public events at all"
+    assert [event for event in events if event.get("tool_name")] == []
+
+
+def test_the_real_record_has_no_model_api_calls_field(real_result):
+    assert "model_api_calls" not in real_result["agentic_v2"]
+
+
+def test_a_record_carrying_that_field_would_be_refused(real_result):
+    """So the old reader could not have been satisfied by any valid run.
+
+    This is the part that makes it a schema mismatch rather than an omission.
+    Writing the field the reader wanted is not a fix available to anyone: the
+    metadata is compared against an exact key set, and the record stops
+    verifying the moment the field is there.
+    """
+    metadata = dict(real_result["agentic_v2"])
+    verify_agentic_v2_metadata(metadata)
+
+    metadata["model_api_calls"] = 2
+    with pytest.raises(ValueError, match="metadata is invalid"):
+        verify_agentic_v2_metadata(metadata)
+
+
+# ---------------------------------------------------------------------------
+# What the fixed readers find in the same record
+# ---------------------------------------------------------------------------
+
+
+def test_the_tool_calls_are_found_where_the_runner_writes_them(real_result):
+    calls = _tool_calls_of(real_result)
+
+    assert [call["tool_name"] for call in calls] == ["workspace_apply", "finalize"]
+
+
+def test_the_calls_come_from_public_events_and_carry_no_arguments(real_result):
+    """The public trace is the one a report may be built from.
+
+    Each returned item is the redacted commitment -- hashes and a verdict, no
+    request body. A reader that reached into the private audit for a nicer
+    field would be putting unredacted material into a public artefact.
+    """
+    events = real_result["agentic_v2"]["public_trace"]["events"]
+    public = [event for event in events if event.get("kind") == EVENT_TOOL_PUBLIC]
+
+    assert len(public) == len(_tool_calls_of(real_result))
+    for call in _tool_calls_of(real_result):
+        assert "arguments" not in call
+        assert "data" not in call
+        assert set(call) == {
+            "call_id",
+            "tool_name",
+            "request_sha256",
+            "result_sha256",
+            "ok",
+            "error_type",
+            "usage_delta",
+            "state_before_sha256",
+            "state_after_sha256",
+        }
+
+
+def test_the_started_event_is_not_counted_as_a_tool_call(real_result):
+    """Filtering by kind rather than by "has a name" is the point.
+
+    The chain opens with a ``started`` event and may close with a ``failure``
+    one. Neither is a call, and a looser filter that happened to work today
+    would count them the first time either grew a name-shaped field.
+    """
+    events = real_result["agentic_v2"]["public_trace"]["events"]
+
+    assert events[0]["kind"] == "started"
+    assert len(_tool_calls_of(real_result)) == len(events) - 1
+
+
+def test_the_metrics_block_now_names_the_tools_that_ran(real_result):
+    metrics = build_agentic_v2_metrics(
+        real_result,
+        standing=a_standing(),
+        tool_calls=_tool_calls_of(real_result),
+        model_api_calls=_model_calls_of(a_receipt()),
+        task_wall_time_ms=1234.0,
+        receipt=a_receipt(),
+    )
+
+    assert metrics["tool_calls"] == 2
+    assert metrics["tool_calls_by_name"]["workspace_apply"] == 1
+    assert metrics["tool_calls_by_name"]["finalize"] == 1
+    assert metrics["tool_calls_by_name"]["browser_run"] == 0
+
+
+# ---------------------------------------------------------------------------
+# The count and the tokens, read off the only thing that knows them
+# ---------------------------------------------------------------------------
+
+
+def test_the_model_call_count_comes_from_the_receipt():
+    assert _model_calls_of(a_receipt(model_calls=6)) == 6
+
+
+def test_no_receipt_is_a_floor_and_the_row_says_so(real_result):
+    """Zero with no receipt, and two other fields that stop it reading as a fact.
+
+    There is no better answer available -- nothing else in the system counts
+    model calls -- so the honest handling is the one the cost fields already
+    use: report what is known and mark it as not the whole story.
+    """
+    assert _model_calls_of(None) == 0
+
+    metrics = build_agentic_v2_metrics(
+        real_result,
+        standing=a_standing(fully_accounted=False),
+        tool_calls=_tool_calls_of(real_result),
+        model_api_calls=_model_calls_of(None),
+        task_wall_time_ms=1234.0,
+        receipt=None,
+    )
+
+    assert metrics["model_api_calls"] == 0
+    assert metrics["usage_complete"] is False
+    assert metrics["agentic_v2_cost_receipt_status"] == "not_run"
+
+
+def test_a_receipt_with_no_usable_count_is_not_read_as_none_made():
+    for broken in (a_receipt(model_calls=None), a_receipt(model_calls=-1)):
+        assert _model_calls_of(broken) == 0
+
+
+def test_the_tokens_come_from_the_receipts_usage():
+    assert _tokens_of(a_receipt()) == (17_775, 292)
+
+
+def test_missing_tokens_stay_missing_rather_than_becoming_zero():
+    """``None`` and ``0`` are different claims and only one of them is true.
+
+    No V2 call has ever carried zero input tokens -- the task prompt alone is
+    thousands -- so a zero written here would say the model read nothing, which
+    is never what happened. The builder omits the key for ``None``.
+    """
+    assert _tokens_of(None) == (None, None)
+    assert _tokens_of({"status": STATUS_COMPLETE}) == (None, None)
+    assert _tokens_of(a_receipt(usage={"output_tokens": 292})) == (None, 292)
+
+
+@pytest.mark.parametrize(
+    "receipt, present",
+    [
+        (a_receipt(), True),
+        (None, False),
+    ],
+)
+def test_the_token_keys_are_written_only_when_they_are_known(
+    real_result, receipt, present
+):
+    input_tokens, output_tokens = _tokens_of(receipt)
+    metrics = build_agentic_v2_metrics(
+        real_result,
+        standing=a_standing(fully_accounted=present),
+        tool_calls=_tool_calls_of(real_result),
+        model_api_calls=_model_calls_of(receipt),
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        task_wall_time_ms=1234.0,
+        receipt=receipt,
+    )
+
+    assert ("input_tokens" in metrics) is present
+    assert ("output_tokens" in metrics) is present
+
+
+# ---------------------------------------------------------------------------
+# The stand-in that agreed with the reader instead of with the runner
+# ---------------------------------------------------------------------------
+
+
+def test_the_drivers_stand_in_result_is_shaped_like_a_real_one(real_result):
+    """The guard that would have caught this, and now does.
+
+    ``tests/test_agentic_v2_run_driver.py`` fabricates a result rather than
+    booting a backend, which is the right trade for what it tests. What made
+    the defect invisible is that the fabrication was written from the reader
+    rather than from the writer, so reader and stand-in matched and the runner
+    matched neither.
+
+    Checked structurally, not by equality: the stand-in has one tool call and
+    no chain hashes, and demanding a byte-identical record would mean booting a
+    backend in every driver test.
+    """
+    from tests import test_agentic_v2_run_driver as driver_test
+
+    stand_in = driver_test._success("task-0001")["agentic_v2"]
+    real = real_result["agentic_v2"]
+
+    assert "model_api_calls" not in stand_in, (
+        "the stand-in carries a field the metadata verifier forbids; a run "
+        "record cannot look like this"
+    )
+    for event in stand_in["public_trace"]["events"]:
+        assert event["kind"] == EVENT_TOOL_PUBLIC
+        assert set(event["payload"]) == {"result_commitment", "replayed"}
+        assert "tool_name" not in event
+
+    real_event = next(
+        event
+        for event in real["public_trace"]["events"]
+        if event["kind"] == EVENT_TOOL_PUBLIC
+    )
+    stand_in_event = stand_in["public_trace"]["events"][0]
+    assert set(stand_in_event["payload"]) == set(real_event["payload"])

--- a/batch-runner/tests/test_the_record_was_written_after_the_client_was_shut.py
+++ b/batch-runner/tests/test_the_record_was_written_after_the_client_was_shut.py
@@ -235,7 +235,7 @@ def test_a_price_list_that_will_not_load_is_reported_and_not_raised(monkeypatch)
     def refuse(*_args, **_kwargs):
         raise ValueError("the price list is not yaml any more")
 
-    monkeypatch.setattr(runner, "load_price_table", refuse)
+    monkeypatch.setattr(runner, "load_provider_price_table", refuse)
     problems = runner.the_paid_setup_a_dry_run_can_reach("advance_check_5")
 
     assert len(problems) == 1

--- a/batch-runner/tests/test_two_price_lists_in_one_file.py
+++ b/batch-runner/tests/test_two_price_lists_in_one_file.py
@@ -1,0 +1,375 @@
+"""One file, two price lists, and the voice was reading the wrong one.
+
+Measured, not supposed. ``experiments/execution_envelope/model_price_table.json``
+holds two blocks of rates for the same models:
+
+* ``models.gpt-5.4`` — $1.25 in, $5.00 out per million. No source, no review
+  date. The file's own note records that on 2026-08-29 every figure in this
+  block was checked against the Azure Retail Prices API and **none of them
+  matched a published meter**.
+* ``providers.azure:gpt-5.4`` — $2.50 in, $15.00 out per million, with the
+  three meter names it was read from, the API it was read from, and the date.
+
+The cost ledger has always read the second. The voice read the first, so the
+run record and the sqlite ledger written by the same run priced the same calls
+at two different rates — a factor of two on input and three on output.
+
+Neither figure was marked as doubtful, and the run record's docstring said the
+two were computed from "the same list", differing only in the key. Same file,
+different block.
+
+The fix is a loader, not an edit to the price list. The list is shared and its
+bytes are fingerprinted into receipts, so changing it would invalidate the
+provenance of records that are already written. ``load_provider_price_table``
+reads the sourced block and keys it the way the voice looks things up.
+
+Three scripts build a paid Azure client and price what they spend — the V2
+stage and the two probes — and all three read the unsourced block. The swap is
+applied to all three, and the constant naming the provider lives beside the
+loader rather than being copied into each.
+
+What is *not* swapped, deliberately: ``estimate_cost_ceiling``. That is a
+pre-run figure and the planning block is what the pre-registration's approved
+amounts were computed from. Moving it would move a number that has already been
+approved, which is a different decision from fixing what a run reports about
+calls it has already made.
+
+What is pinned here
+-------------------
+
+* the sourced rates are what the voice's loader returns,
+* the two blocks really do disagree, so this is a measurement and not a story,
+* the voice and the ledger now reach the *same* figure on the same tokens,
+* a rate with no source or no review date is refused,
+* a model this provider does not price is left out rather than borrowed from
+  the unsourced block — missing stays partial and never becomes a number,
+* all three paid voices moved, and the ceiling did not.
+
+Nothing here calls a model or opens a network connection.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+SCRIPTS = BATCH_RUNNER_ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import run_agentic_v2_stage as stage  # noqa: E402
+from core.cost_receipts import (  # noqa: E402
+    CallUsage,
+    load_receipt_price_table,
+    price_call,
+)
+from core.execution_envelope_cost import (  # noqa: E402
+    PRICE_TABLE_PATH,
+    load_price_table,
+    load_provider_price_table,
+)
+
+# What the six calls the first paid stage never filed actually carried.
+UNFILED_INPUT_TOKENS = 17_775
+UNFILED_OUTPUT_TOKENS = 292
+
+PINNED_MODEL = "gpt-5.4"
+
+#: Every script that builds a paid client and prices what it spends.
+#:
+#: All three had the same line. The defect was found reading the first.
+PAID_VOICES = (
+    "run_agentic_v2_stage.py",
+    "run_agentic_stage_a_probe.py",
+    "run_agentic_stage_d_probe.py",
+)
+
+
+def a_price_list(tmp_path: Path, providers: dict) -> Path:
+    """A committed-shaped file holding only what a case needs."""
+    document = {
+        "schema_version": "execution-envelope-price-table-v1",
+        "currency": "USD",
+        "unit": "per 1,000,000 tokens",
+        "models": {
+            "a-model": {
+                "input_usd_per_million": "1.00",
+                "output_usd_per_million": "2.00",
+            }
+        },
+        "cost_receipt_schema_version": "cost-receipt-price-table-v1",
+        "providers": providers,
+    }
+    target = tmp_path / "model_price_table.json"
+    target.write_text(json.dumps(document), encoding="utf-8")
+    return target
+
+
+def a_sourced_entry(**changes) -> dict:
+    entry = {
+        "input_usd_per_million": "2.50",
+        "cached_input_usd_per_million": "0.25",
+        "output_usd_per_million": "15.00",
+        "reasoning_billed_as": "output",
+        "source": "https://prices.azure.com/api/retail/prices",
+        "last_reviewed": "2026-08-29",
+        "currency": "USD",
+        "unit": "per 1,000,000 tokens",
+    }
+    entry.update(changes)
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# The two blocks, as committed
+# ---------------------------------------------------------------------------
+
+
+def test_the_voices_price_list_is_the_one_with_a_source():
+    prices = load_provider_price_table("azure")
+
+    assert PINNED_MODEL in prices
+    assert prices[PINNED_MODEL].input_usd_per_million == Decimal("2.50")
+    assert prices[PINNED_MODEL].output_usd_per_million == Decimal("15.00")
+
+
+def test_the_sourced_rates_are_the_ones_in_the_committed_file():
+    """Read straight out of the file, so this cannot pass on a stale constant."""
+    document = json.loads(PRICE_TABLE_PATH.read_text(encoding="utf-8"))
+    entry = document["providers"][f"azure:{PINNED_MODEL}"]
+
+    assert entry["source"].startswith("https://prices.azure.com/")
+    assert entry["last_reviewed"]
+    assert set(entry["meters"]) == {"input", "cached_input", "output"}
+
+    prices = load_provider_price_table("azure")
+    assert prices[PINNED_MODEL].input_usd_per_million == Decimal(
+        entry["input_usd_per_million"]
+    )
+
+
+def test_the_two_blocks_in_the_one_file_disagree():
+    """The measurement the rest of this file rests on.
+
+    If these ever come to agree the disagreement is over and several of the
+    comments in this repository need rewriting -- so this test failing would be
+    good news that still has to be read.
+    """
+    planning = load_price_table()[PINNED_MODEL]
+    sourced = load_provider_price_table("azure")[PINNED_MODEL]
+
+    assert planning.input_usd_per_million == Decimal("1.25")
+    assert planning.output_usd_per_million == Decimal("5.00")
+    assert sourced.input_usd_per_million == planning.input_usd_per_million * 2
+    assert sourced.output_usd_per_million == planning.output_usd_per_million * 3
+
+
+# ---------------------------------------------------------------------------
+# What the two records now say about the same calls
+# ---------------------------------------------------------------------------
+
+
+def test_the_voice_and_the_ledger_reach_the_same_figure():
+    """Two separate paths, same tokens, same amount.
+
+    The voice multiplies through ``ModelPrice.cost_of``; the ledger goes
+    through ``price_call``, which slices cached and audio tokens out first.
+    The V2 voice reports neither, so the slices are empty and the two
+    arithmetics have to land on the same Decimal -- not on a rounding of it.
+    """
+    usage = CallUsage(
+        input_tokens=UNFILED_INPUT_TOKENS, output_tokens=UNFILED_OUTPUT_TOKENS
+    )
+
+    by_the_voice = load_provider_price_table("azure")[PINNED_MODEL].cost_of(
+        input_tokens=usage.input_tokens, output_tokens=usage.output_tokens
+    )
+    by_the_ledger = price_call(
+        load_receipt_price_table().lookup("azure", PINNED_MODEL), usage
+    )
+
+    assert by_the_ledger.missing_reasons == ()
+    assert by_the_ledger.cost_usd == by_the_voice
+
+
+def test_the_old_list_would_have_reached_a_different_one():
+    """What the disagreement was worth, on the tokens that were measured."""
+    usage = CallUsage(
+        input_tokens=UNFILED_INPUT_TOKENS, output_tokens=UNFILED_OUTPUT_TOKENS
+    )
+    by_the_ledger = price_call(
+        load_receipt_price_table().lookup("azure", PINNED_MODEL), usage
+    ).cost_usd
+    by_the_planning_block = load_price_table()[PINNED_MODEL].cost_of(
+        input_tokens=usage.input_tokens, output_tokens=usage.output_tokens
+    )
+
+    assert by_the_planning_block < by_the_ledger
+    # Stated rather than asserted to a rounded literal: the ratio moves if the
+    # token mix moves, and the point is the direction and the order.
+    assert by_the_ledger > by_the_planning_block * Decimal("1.9")
+
+
+# ---------------------------------------------------------------------------
+# What the loader refuses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("missing", ["source", "last_reviewed"])
+def test_a_rate_nobody_can_trace_is_refused(tmp_path, missing):
+    path = a_price_list(
+        tmp_path, {f"azure:{PINNED_MODEL}": a_sourced_entry(**{missing: ""})}
+    )
+
+    with pytest.raises(ValueError) as refusal:
+        load_provider_price_table("azure", path)
+
+    assert missing in str(refusal.value)
+
+
+@pytest.mark.parametrize("field", ["input_usd_per_million", "output_usd_per_million"])
+def test_a_rate_with_a_side_missing_is_refused(tmp_path, field):
+    entry = a_sourced_entry()
+    del entry[field]
+    path = a_price_list(tmp_path, {f"azure:{PINNED_MODEL}": entry})
+
+    with pytest.raises(ValueError) as refusal:
+        load_provider_price_table("azure", path)
+
+    assert field in str(refusal.value)
+
+
+def test_a_provider_nobody_priced_is_refused_rather_than_guessed(tmp_path):
+    path = a_price_list(tmp_path, {f"azure:{PINNED_MODEL}": a_sourced_entry()})
+
+    with pytest.raises(ValueError) as refusal:
+        load_provider_price_table("some-other-cloud", path)
+
+    assert "some-other-cloud" in str(refusal.value)
+
+
+def test_a_model_this_provider_does_not_price_is_left_out_not_borrowed(tmp_path):
+    """The important negative: no fallback to the unsourced block.
+
+    ``a-model`` is in the planning block of the stand-in file and in no
+    provider's. Filling it in from there would turn a call this repository
+    cannot price into a number, which is the whole defect wearing a different
+    hat.
+    """
+    path = a_price_list(tmp_path, {f"azure:{PINNED_MODEL}": a_sourced_entry()})
+
+    prices = load_provider_price_table("azure", path)
+
+    assert "a-model" in load_price_table(path)
+    assert "a-model" not in prices
+
+
+def test_a_key_that_names_no_provider_is_refused(tmp_path):
+    path = a_price_list(tmp_path, {PINNED_MODEL: a_sourced_entry()})
+
+    with pytest.raises(ValueError) as refusal:
+        load_provider_price_table("azure", path)
+
+    assert "provider:model" in str(refusal.value)
+
+
+@pytest.mark.parametrize("bad", ["", "  ", "azure:gpt-5.4"])
+def test_the_argument_names_a_provider_not_a_price_key(bad):
+    with pytest.raises(ValueError) as refusal:
+        load_provider_price_table(bad)
+
+    assert "provider" in str(refusal.value)
+
+
+def test_a_file_written_for_another_schema_is_refused(tmp_path):
+    document = json.loads(
+        a_price_list(
+            tmp_path, {f"azure:{PINNED_MODEL}": a_sourced_entry()}
+        ).read_text(encoding="utf-8")
+    )
+    document["cost_receipt_schema_version"] = "something-else-v9"
+    target = tmp_path / "wrong_schema.json"
+    target.write_text(json.dumps(document), encoding="utf-8")
+
+    with pytest.raises(ValueError) as refusal:
+        load_provider_price_table("azure", target)
+
+    assert "something-else-v9" in str(refusal.value)
+
+
+# ---------------------------------------------------------------------------
+# That the paid stage is the thing that changed
+# ---------------------------------------------------------------------------
+
+
+def test_the_paid_stage_names_the_provider_it_is_billed_by():
+    assert stage.PAID_VOICE_PRICE_PROVIDER == "azure"
+    assert (
+        stage.PAID_VOICE_PRICE_PROVIDER
+        in load_receipt_price_table().models[f"azure:{PINNED_MODEL}"].key
+    )
+
+
+def test_the_constant_lives_beside_the_loader_and_is_not_copied():
+    """One definition, imported by three scripts.
+
+    It was a local in the V2 stage first. Two more scripts build the same Azure
+    client and price their own calls, so a second and third copy of the string
+    was the obvious next step and the wrong one: a copy is something that can
+    disagree, which is the defect this whole file is about.
+    """
+    from core import execution_envelope_cost
+
+    for script in PAID_VOICES:
+        source = (SCRIPTS / script).read_text(encoding="utf-8")
+        assert (
+            'PAID_VOICE_PRICE_PROVIDER = "' not in source
+        ), f"{script} defines its own copy of the constant"
+
+    assert execution_envelope_cost.PAID_VOICE_PRICE_PROVIDER == "azure"
+
+
+@pytest.mark.parametrize("script", PAID_VOICES)
+def test_a_paid_voice_reads_the_sourced_block_and_not_the_planning_one(script):
+    """A regression guard on the swap, not on the loader.
+
+    The two loaders' names are close enough to swap back by accident -- the
+    module docstring at the call site says so -- and the free job and the paid
+    run have to move together, or the dry run certifies a loader the paid run
+    does not use.
+
+    Parametrised over all three because the defect was found in one of them and
+    the other two had the same line. A fix applied to only the script that was
+    being read at the time is how this shape keeps coming back.
+    """
+    source = (SCRIPTS / script).read_text(encoding="utf-8")
+
+    assert "load_price_table()" not in source
+    assert "load_provider_price_table(PAID_VOICE_PRICE_PROVIDER)" in source
+
+
+def test_the_ceiling_still_reads_the_planning_block():
+    """The negative half of the swap, and it is deliberate.
+
+    ``estimate_cost_ceiling`` is a *pre-run* figure and the planning block is
+    what the pre-registration's approved amounts were computed from. Swapping it
+    here would move a number that has already been approved, which is a
+    different decision from fixing what a run reports about calls it made. The
+    block is wrong for that purpose too -- the file's own note says it
+    understates a ceiling by between two and twelve times -- and that is
+    recorded separately rather than folded in here.
+    """
+    from core import execution_envelope_cost
+
+    source = Path(execution_envelope_cost.__file__).read_text(encoding="utf-8")
+    ceiling = source[source.index("def estimate_cost_ceiling(") :]
+
+    assert "else load_price_table()" in ceiling[: ceiling.index("\n    unpriced")]


### PR DESCRIPTION
Smoke 5 (실행 `34660739834`)의 원본 artifact를 다시 읽고 고친 두 자리입니다.
둘 다 유료 실행 없이 고쳤고, 둘 다 **다음 유료 실행 전에** 들어가야 합니다.
지금 30문제를 돌리면 그 30개의 비용과 지표가 같은 방식으로 틀리게 적히고,
돈을 쓴 뒤에는 되돌릴 수 없기 때문입니다.

## 1. 한 파일에 가격표가 둘 있고, 유료 실행은 틀린 쪽을 읽었습니다

`experiments/execution_envelope/model_price_table.json` 안에 서로 다른
두 블록이 있습니다.

| 블록 | 입력 | 출력 | 출처 |
|---|---|---|---|
| `models.gpt-5.4` | $1.25/M | $5.00/M | 없음 |
| `providers.azure:gpt-5.4` | $2.50/M | $15.00/M | 소매 미터 이름 + `last_reviewed: 2026-08-29` |

비용 원장은 늘 아래쪽을 썼습니다. 유료 목소리 세 개(`run_agentic_v2_stage`,
`stage_a_probe`, `stage_d_probe`)는 모두 위쪽을 썼습니다. 같은 실행이 쓴 두
파일이 같은 호출을 입력 2배, 출력 3배 차이로 적고 있었고, 어느 쪽을 믿어야
하는지 아무 데도 적혀 있지 않았습니다.

`PAID_VOICE_PRICE_PROVIDER = "azure"`와 `load_provider_price_table`을 추가해
세 목소리가 모두 출처 있는 쪽을 읽게 했습니다. 출처나 `last_reviewed`가 없는
요율은 거부합니다 — 추적할 수 없는 요율은 가격이 아닙니다. 없는 모델은
`models` 블록으로 되돌아가지 않고 partial로 남습니다. 0이 아닙니다.

**사전 견적(`estimate_cost_ceiling`)은 일부러 그대로 둡니다.** 사전등록의
승인 금액이 그 블록으로 계산되었기 때문에, 옮기면 이미 승인된 숫자가
바뀝니다. `test_the_ceiling_still_reads_the_planning_block`이 이것을 지킵니다.

## 2. 도구 호출·모델 호출 수가 모든 실행, 모든 문제에서 0이었습니다

실행이 나빠서가 아니라 읽는 자리와 쓰는 자리의 모양이 달라서, 어떤 실행도
0을 벗어날 수 없었습니다. 네 자리입니다.

- **도구 호출**: 공개 이벤트의 payload는 `{result_commitment, replayed}`
  정확히 두 개로 검증되고 도구 이름은 그 안쪽에 있는데, 독자는 이벤트
  겉면에서 `tool_name`을 찾고 있었습니다. 검증기가 통과시킬 수 있는 어떤
  기록에도 거기엔 이름이 없습니다.
- **모델 호출**: `result["agentic_v2"]["model_api_calls"]`를 읽었는데, 그
  블록은 11개 키의 정확한 집합으로 검사되고 그 이름은 거기 없습니다. 없는
  것이 아니라 **금지된** 것이라, 채워 넣는 것은 고칠 방법이 아니었습니다.
  비용 영수증에서 읽습니다.
- **토큰**: 드라이버가 한 번도 넘기지 않아 지금까지 모든 V2 지표 블록에
  두 키가 없었습니다. 모르면 `None`으로 둡니다. 0은 모델이 아무것도 읽지
  않았다는 뜻이고 그런 호출은 없습니다.
- **보고서**: step6의 도구별 집계가 V1 이름 여섯 개만 양동이로 두어서 V2의
  여덟 중 일곱이 버려졌습니다. **`browser_run`이 그중 하나입니다.** 첫 유료
  단계에서 다섯 문제 중 셋이 그 도구에서 멈췄고 그것이 그 실행의 핵심
  관측인데, 요약에는 `finalize` 하나만 0이 아닌 채로 남았을 것입니다. 두
  어휘의 합집합으로 넓히고 V1 순서는 앞에 그대로 둡니다.

왜 검토를 통과했는지도 같이 고칩니다. 드라이버 테스트의 대역 결과가 읽는
쪽 모양대로 만들어져 있었습니다. 대역과 독자가 서로 맞고 둘 다 실제 러너와
달랐으므로 테스트는 초록이었습니다. 새 테스트는 실제 러너를 실제 fixture
백엔드로 돌려 나온 기록을 읽고, 그 기록에 대역을 맞춰 봅니다.

## Smoke 5 원본 artifact로 확인한 숫자

이 PR을 쓰면서 `34660739834`의 artifact를 직접 다시 계산했습니다.

```
이벤트(model_replied)   24    ← 늘 완전했음
기록된 turn             18    ← #552 이전, 6개 누락
원장 cost_calls         18    ← turn에서 만들어짐
문제별 합계             $0.1936700 = 원장 총계 ✓ (내부적으로는 일관)

목소리 기록  24회, $0.10903625  (계획용 요율로 계산됨)
원장         18회, $0.19367     (출처 있는 요율로 계산됨)
실제         24회, $0.2424875   (출처 있는 요율)

누락: 6/24회(25.0%), 입력 17,775 + 출력 292 토큰, $0.0488175 = 20.1%
```

누락 6개는 정확히 **도구 실패로 끝난 대화 6개의 마지막 턴 하나씩**입니다.
#552가 이 부분을 고쳤습니다. 이 PR은 남은 가격 오류를 고칩니다.

## 남은 구멍 (이 PR 아님, 다음 작업)

- `bind_run_to_ledger`가 `reserve` 직후 `settle`을 **대화가 끝난 뒤** 호출합니다.
  예약이 사후라서, 프로세스가 대화 도중 죽으면 그 문제의 행이 아예 없습니다.
- `ConversationOutcome.model_calls_not_counted`(#552에서 추가)를 아직 아무도
  읽지 않습니다. usage 없는 호출이 있어도 영수증은 `complete`로 남을 수 있습니다.
- `cost_runtime` 0행 — 게스트 실행 시간 비용이 전혀 기록되지 않습니다.

## 검사

유료 호출 없음. 관련 8개 파일 445개 통과, 전체 suite 실행 중.
mypy: 바뀐 네 파일의 수정된 줄에 새 오류 없음.
