### PR TITLE
청구된 다음에 적으면, 죽은 실행은 아무것도 남기지 않습니다

### DIFF
--- a/batch-runner/core/agentic_v2_conversation.py
+++ b/batch-runner/core/agentic_v2_conversation.py
@@ -585,9 +585,10 @@ class _BilledButUnanswered:
     ending after the tool was chosen still records which tool that was.
 
     Built only for a reply that reported what it used. A reply that did not is
-    left out of ``turns`` entirely and counted in
-    :attr:`ConversationOutcome.model_calls_not_counted`; the comment at the
-    construction site says why a zero would be the worse answer.
+    left out of ``turns`` entirely and listed in
+    :attr:`ConversationOutcome.turns_not_counted`, which reaches the ledger as
+    a row with no usage rather than as a turn with a zero one; the comment at
+    the construction site says why a zero would be the worse answer.
     """
 
     turn: int
@@ -681,25 +682,44 @@ class ConversationOutcome:
         )
 
     @property
-    def model_calls_not_counted(self) -> int:
-        """Replies that arrived without usable token counts, so are unpriced.
+    def turns_not_counted(self) -> tuple[int, ...]:
+        """Which turns were charged for and arrived without usable counts.
 
-        Not a cost and not a zero — a number *about* the account rather than in
-        it. A reply the provider sent with no usage, or with a usage the voice
-        could not read, was still charged for, and this is how many of those a
-        run had. Anything above zero means ``turns`` is short by that much and
-        the receipt built from it is a floor.
+        The turn numbers rather than a bare total, because each of these has to
+        reach the ledger as its own row and a row needs a name. The numbers are
+        the conversation's own and are unique within it;
+        :func:`~core.agentic_v2_conversation_runner.model_turns_of` namespaces
+        them by run, task and attempt on the way out, the same as every other
+        call id, so a resumed round files each one once.
+        """
+        return tuple(
+            event.turn
+            for event in self.events
+            if event.step is LoopStep.MODEL_REPLIED
+            and event.detail.get("counted") is False
+        )
+
+    @property
+    def model_calls_not_counted(self) -> int:
+        """How many replies arrived without usable token counts.
+
+        Not a cost and not a zero. A reply the provider sent with no usage, or
+        with a usage the voice could not read, was still charged for, and this
+        is how many of those a run had.
+
+        This used to be the end of the road: a number kept beside the account
+        rather than in it, which meant a run could make a call it could not
+        price and still publish a receipt reading ``complete``. Each of these
+        now goes to the ledger as a settled row carrying no usage, which prices
+        as ``usage_absent`` and holds the receipt at ``partial``. The count
+        stays because it is the readable form of the same fact, and because a
+        reader asking "how short is this bill" should not have to filter rows.
 
         Kept as a count rather than an estimate on purpose. Guessing what an
         uncounted call would have cost is the one arithmetic this codebase does
         not do.
         """
-        return sum(
-            1
-            for event in self.events
-            if event.step is LoopStep.MODEL_REPLIED
-            and event.detail.get("counted") is False
-        )
+        return len(self.turns_not_counted)
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -729,6 +749,7 @@ def run_model_conversation(
     limits: LoopLimits,
     tools_available: Sequence[str] = TOOL_NAMES,
     cancel_requested: Optional[Callable[[], bool]] = None,
+    before_model_call: Optional[Callable[[int], None]] = None,
     clock: Callable[[], float] = time.monotonic,
 ) -> ConversationOutcome:
     """Ask the model, run what it asked for, show it the answer, repeat.
@@ -738,6 +759,21 @@ def run_model_conversation(
     or a different run place on the model's behalf: a run that could not finish
     is reported as one, because a quiet substitution produces a result nobody
     can attribute to anything.
+
+    ``before_model_call`` is handed the turn number and called *immediately
+    before the request goes out*. It exists for one caller and one purpose: the
+    paid stage writes a reservation into the cost ledger there, so that a run
+    which dies between the request leaving and the reply being recorded leaves a
+    row saying *a call went out and we never found out what it cost* rather than
+    leaving nothing at all. Everything this loop records otherwise is written
+    after the fact, and a process killed by its own ``timeout-minutes`` does not
+    get to write anything after the fact.
+
+    If it raises, the call is not made. That is the whole point of it being a
+    hook rather than a notification: a run that cannot write down what it is
+    about to spend must not spend it. The run stops with
+    :attr:`StopReason.PAID_CALL_REFUSED`, which is the same sentence the two
+    checks above it make — a paid call the run was not in a position to make.
     """
     asked_to_stop = cancel_requested or (lambda: False)
     events: list[LoopEvent] = []
@@ -862,6 +898,22 @@ def run_model_conversation(
             history=tuple(history),
             turns_left=max_turns - turn,
         )
+        if before_model_call is not None:
+            # Last line before the request leaves. A reservation written here
+            # survives the run being killed; anything written after the reply
+            # does not, and "killed mid-task" is how a sharded stage ends when
+            # it runs out of wall clock.
+            try:
+                before_model_call(turn)
+            except Exception as error:  # noqa: BLE001 - any failure stops the run
+                return finish(
+                    StopReason.PAID_CALL_REFUSED,
+                    "this call would have been charged for and the run could "
+                    "not write down that it was about to make it "
+                    f"({type(error).__name__}: {error}), so it was not made. A "
+                    "call nobody can account for is the thing this run exists "
+                    "to not do",
+                )
         try:
             reply = voice.next_turn(request)
         except Exception as error:  # noqa: BLE001 - any failure ends the run
@@ -872,6 +924,25 @@ def run_model_conversation(
 
         usage = _usage_of(reply)
         if usage is None:
+            # The reply arrived. Something is in `reply` to read, so the
+            # provider served this request and will bill for it; what is
+            # missing is only the count. Recorded as a reply that happened and
+            # was not counted, for the same reason as the zero-input case
+            # below, and by the same route: `turns_not_counted` carries it to
+            # the ledger as a row with no usage, which prices as `usage_absent`
+            # and holds the receipt at `partial`.
+            events.append(LoopEvent(
+                step=LoopStep.MODEL_REPLIED,
+                turn=turn,
+                detail={
+                    "kind": type(reply).__name__,
+                    # Null rather than zero. Nothing was reported; writing a
+                    # number here would invent one.
+                    "input_tokens": None,
+                    "output_tokens": None,
+                    "counted": False,
+                },
+            ))
             return finish(
                 StopReason.MODEL_REPLY_UNUSABLE,
                 "the model's reply did not say how much it used, or said "
@@ -892,12 +963,17 @@ def run_model_conversation(
         # with a note saying so, and the walk-away's token fields default to
         # zero.
         #
-        # Such a call is not recorded, and that is deliberate. Filing it would
-        # put `0` in the ledger, and a zero settles to `$0.00` on a `complete`
-        # receipt: a measured-looking figure for a call nobody measured. That
-        # is worse than the gap it would paper over, because a gap can be seen.
-        # It is counted in `model_calls_not_counted` instead, which is a number
-        # about the account rather than in it.
+        # Such a call is not recorded *here*, and that is deliberate. Filing it
+        # as a turn would put `0` in the ledger, and a zero settles to `$0.00`
+        # on a `complete` receipt: a measured-looking figure for a call nobody
+        # measured. That is worse than the gap it would paper over, because a
+        # gap can be seen.
+        #
+        # It is listed in `turns_not_counted` instead, and `model_turns_of`
+        # turns each entry into a ledger row carrying no usage at all. An
+        # absent usage is not a zero one: it prices as `usage_absent`, adds
+        # nothing to the total, counts in `model_calls`, and holds the receipt
+        # at `partial`. So the call is in the account as the unknown it is.
         #
         # The same applies to the `usage is None` branch above, for the same
         # reason. Both are the honest edge of a record written after the fact;

--- a/batch-runner/core/agentic_v2_conversation_runner.py
+++ b/batch-runner/core/agentic_v2_conversation_runner.py
@@ -73,7 +73,7 @@ from core.agentic_v2_contract import TOOL_NAMES
 from core.agentic_v2_cost_binding import ModelTurn, retry_kind_for_error
 from core.agentic_v2_runner import AgenticV2ScriptedRunner
 from core.agentic_v2_stage_one_budget import StageOneBudget
-from core.cost_receipts import CallUsage, RETRY_NONE
+from core.cost_receipts import CallUsage, RETRY_NONE, STAGE_GENERATION
 
 
 class ConversationRunnerRefused(RuntimeError):
@@ -265,6 +265,7 @@ def conversation_seam(
     limits: LoopLimits,
     tools_available: Sequence[str] = TOOL_NAMES,
     cancel_requested: Optional[Callable[[], bool]] = None,
+    before_model_call: Optional[Callable[[int], None]] = None,
     on_outcome: Optional[Callable[[Any], None]] = None,
 ) -> Callable[[str, Callable[..., Any]], Any]:
     """A callable the runner can hand its dispatch function to.
@@ -274,6 +275,10 @@ def conversation_seam(
     the cancel check, the deadline, the state commitment and the two chain
     appends that a scripted call gets. A desk that reached past it would produce
     a record that looks the same and proves less.
+
+    ``before_model_call`` is passed straight through to the loop, which calls it
+    with the turn number immediately before each request leaves. See
+    :func:`reserve_before_each_call` for the one thing it is for.
     """
 
     def converse(task_prompt: str, dispatch: Callable[..., Any]) -> Any:
@@ -284,6 +289,7 @@ def conversation_seam(
             limits=limits,
             tools_available=tools_available,
             cancel_requested=cancel_requested,
+            before_model_call=before_model_call,
         )
         if on_outcome is not None:
             on_outcome(outcome)
@@ -303,6 +309,9 @@ def build_runner_factory(
     budget_caps: Optional[Mapping[str, Any]] = None,
     required_backend_type: type | None = None,
     cancel_requested: Optional[Callable[[], bool]] = None,
+    before_model_call_for: Optional[
+        Callable[[str, int], Optional[Callable[[int], None]]]
+    ] = None,
     tools_available: Sequence[str] = TOOL_NAMES,
 ) -> Callable[[Any], AgenticV2ScriptedRunner]:
     """A ``runner_factory`` for :func:`core.agentic_v2_run_driver.run_manifest`.
@@ -331,6 +340,15 @@ def build_runner_factory(
     A scripted voice spends nothing and has no budget to get wrong, which is why
     ``voice`` still exists. Exactly one of the two is required — defaulting
     either way would mean guessing, and the wrong guess is the expensive one.
+
+    ``before_model_call_for`` is asked, per task and attempt, for the hook that
+    writes each call's reservation before it goes out. It is per task and
+    attempt rather than per run because the reservation's id contains both, and
+    this is the one place that knows which attempt a runner is being built for.
+    A caller with no ledger passes nothing and the loop reserves nothing, which
+    is right for a rehearsal: a rehearsal makes no call, so there is nothing to
+    reserve and a reserved row would be the one line in the ledger claiming a
+    model was asked.
     """
     if (voice is None) == (voice_for is None):
         raise ConversationRunnerRefused(
@@ -365,6 +383,11 @@ def build_runner_factory(
                 limits=limits,
                 tools_available=tools_available,
                 cancel_requested=cancel_requested,
+                before_model_call=(
+                    None
+                    if before_model_call_for is None
+                    else before_model_call_for(task_id, attempt)
+                ),
                 on_outcome=lambda outcome: conversations.record(
                     task_id, attempt, outcome
                 ),
@@ -376,6 +399,86 @@ def build_runner_factory(
         )
 
     return build
+
+
+def ledger_call_id(*, run_id: str, task_id: str, attempt: int, turn: int) -> str:
+    """What one model call is called in the cost ledger.
+
+    One function because two callers must never disagree: the reservation
+    written before the request leaves, and the settlement written after the
+    reply arrives. Two spellings of the same id would mean the reservation
+    never settles and the settlement never finds its reservation, so every paid
+    call would appear in the ledger twice — once standing open and once priced —
+    and the total would be double the truth while every individual row looked
+    right.
+
+    Every part is the run's own and every part is known before the request goes
+    out. Nothing in it comes from the model.
+    """
+    return f"{run_id}:{task_id}:{attempt}:turn-{int(turn)}"
+
+
+def reserve_before_each_call(
+    ledger: Any,
+    *,
+    run_id: str,
+    task_id: str,
+    attempt: int,
+    provider: str,
+    requested_model: str,
+    deployment: str | None = None,
+    api_version: str | None = None,
+    stage: str = STAGE_GENERATION,
+    retry_kind: str = RETRY_NONE,
+) -> Callable[[int], None]:
+    """A ``before_model_call`` hook that writes the reservation.
+
+    Handed to :func:`~core.agentic_v2_conversation.run_model_conversation`,
+    which calls it with the turn number as the last thing it does before the
+    request leaves.
+
+    This is the half of the accounting that cannot be reconstructed afterwards.
+    Everything else — what the call used, what it cost, which tool it asked for
+    — is read off a record written once the reply is in hand, and a process that
+    is killed does not get to write one. The three ways that happens are all
+    real here: a shard that exceeds its ``timeout-minutes`` is killed outright,
+    an exception between the request and the reply unwinds past every recorder,
+    and a resumed run starts a fresh journal that knows nothing of the attempt
+    that died. In each case the provider was still asked and will still bill.
+
+    A reservation left standing is exactly the right sentence for that: the
+    receipt reads ``partial`` with
+    :data:`~core.cost_receipts.REASON_CALL_REACHABILITY_UNKNOWN`, which says *a
+    call went out and this run never found out what happened to it*. It does
+    not guess an amount, and it does not let the total read ``complete``.
+
+    ``retry_kind`` must be the same one :func:`model_turns_of` will settle the
+    call under. They are passed separately because the reservation happens
+    before the attempt has an outcome, so nothing can derive one from the other;
+    a caller that lets them drift files a retry as a first attempt.
+
+    No note is written. ``state`` and ``reserved_at`` already say a call was
+    reserved before it left, and leaving the field empty is what lets the
+    settlement fill in *why* a call could not be priced — which is knowable only
+    afterwards, and only :meth:`~core.cost_receipts.CostReceiptLedger.reserve`
+    is in a position to add it without overwriting anything.
+    """
+
+    def reserve(turn: int) -> None:
+        ledger.reserve(
+            call_id=ledger_call_id(
+                run_id=run_id, task_id=task_id, attempt=attempt, turn=turn
+            ),
+            task_id=task_id,
+            stage=stage,
+            retry_kind=retry_kind,
+            provider=provider,
+            requested_model=requested_model,
+            deployment=deployment,
+            api_version=api_version,
+        )
+
+    return reserve
 
 
 def model_turns_of(
@@ -393,11 +496,26 @@ def model_turns_of(
 ) -> tuple[ModelTurn, ...]:
     """One task's conversation, as ledger entries.
 
-    ``call_id`` is namespaced by run, task and attempt. The ids inside a
-    conversation are the model's own and are only unique within it; writing them
-    into a shared ledger unqualified would have task 200's third call settle
-    against task 3's, and the corruption would show up as a total that is wrong
-    by an unknowable amount months later.
+    ``call_id`` is ``run:task:attempt:turn-N``, and every part of that is the
+    run's own. It used to end in the id the *model* chose for its tool call,
+    which was wrong in two ways. A model's id is not unique — nothing stops a
+    reply reusing one, and a ledger whose primary key the model picks is a
+    ledger the model can corrupt. And it does not exist until the reply arrives,
+    which makes it unusable for the thing that matters more: a reservation
+    written *before* the request goes out, so that a run killed mid-call leaves
+    a row rather than silence. The turn number is known before the request and
+    is unique by construction, so reserve and settle can name the same row.
+
+    The model's own id is not lost. It stays on the
+    :class:`~core.agentic_v2_conversation.TurnRecord`, which is kept beside the
+    run, and that is where a reader reconstructing the transcript should look.
+    The ledger holds money, not the transcript.
+
+    The run, task and attempt prefix stays for the reason it was added: ids
+    inside a conversation are only unique within it, and writing them into a
+    shared ledger unqualified would have task 200's third call settle against
+    task 3's, with the corruption showing up as a total that is wrong by an
+    unknowable amount months later.
 
     ``preceding_error`` is the error that caused this attempt to be made, or
     ``None`` for a first attempt. It decides the retry kind, via the same
@@ -416,6 +534,19 @@ def model_turns_of(
     ``resolved_model`` is what the provider said answered, which is not always
     what was asked for. Left ``None`` when the caller does not know — a receipt
     with no resolved model is incomplete, and incomplete is the honest state.
+
+    Entries come out in two groups. The first is the conversation's turns. The
+    second is one entry per reply the provider billed for and did not report a
+    usage for, carrying an empty :class:`CallUsage`, so that the ledger holds a
+    row saying *this was charged and cannot be priced* instead of holding
+    nothing. Without them a run could make twenty-four calls, price eighteen,
+    and publish a ``complete`` receipt for the eighteen — which is what the
+    first paid stage did, to the tune of 20% of the bill.
+
+    The two groups cannot name the same row. A reply is either counted, in
+    which case the loop files a turn for it, or it is not, in which case the
+    loop lists its number — never both, because the one ``model_replied`` event
+    per turn carries the ``counted`` flag that decides which.
     """
     retry_kind = RETRY_NONE
     if preceding_error is not None:
@@ -434,7 +565,12 @@ def model_turns_of(
     for record in turns:
         entries.append(
             ModelTurn(
-                call_id=f"{run_id}:{task_id}:{attempt}:{record.call_id}",
+                call_id=ledger_call_id(
+                    run_id=run_id,
+                    task_id=task_id,
+                    attempt=attempt,
+                    turn=record.turn,
+                ),
                 usage=CallUsage(
                     input_tokens=record.input_tokens,
                     output_tokens=record.output_tokens,
@@ -448,6 +584,35 @@ def model_turns_of(
                 retry_kind=retry_kind,
             )
         )
+    for turn_number in getattr(outcome, "turns_not_counted", ()) or ():
+        entries.append(
+            ModelTurn(
+                call_id=ledger_call_id(
+                    run_id=run_id,
+                    task_id=task_id,
+                    attempt=attempt,
+                    turn=turn_number,
+                ),
+                # Empty, not zero, and the distinction is the whole point. A
+                # `CallUsage()` prices as `usage_absent`: no amount, one more
+                # call in `model_calls`, and a receipt held at `partial`. A
+                # `CallUsage(0, 0)` would price as `$0.00` and let the receipt
+                # read `complete` — a measured-looking figure for a call
+                # nobody measured.
+                usage=CallUsage(),
+                provider=provider,
+                requested_model=requested_model,
+                deployment=deployment,
+                api_version=api_version,
+                resolved_model=resolved_model,
+                request_sha256=None,
+                retry_kind=retry_kind,
+                note=(
+                    "the provider answered and will bill for this call, and "
+                    "reported no usage the run could read"
+                ),
+            )
+        )
     return tuple(entries)
 
 
@@ -458,5 +623,7 @@ __all__ = [
     "TaskConversations",
     "build_runner_factory",
     "conversation_seam",
+    "ledger_call_id",
     "model_turns_of",
+    "reserve_before_each_call",
 ]

--- a/batch-runner/core/agentic_v2_provenance.py
+++ b/batch-runner/core/agentic_v2_provenance.py
@@ -37,8 +37,17 @@ _FOUNDATION_MODULES = (
     "agentic_v2_runner.py",
     "agentic_v2_tools.py",
 )
+#: The event kind that carries a redacted tool result in the public trace.
+#:
+#: Named because a reader outside this module has to filter on it, and the one
+#: that did filtered on a literal it had got wrong -- it looked for a
+#: ``tool_name`` on the event, which :func:`verify_trace_pair` forbids at that
+#: level, and so read every V2 run as having made no tool calls. A shared
+#: constant means the filter and the validator move together.
+EVENT_TOOL_PUBLIC = "tool_result_public"
+
 _EVENT_KINDS = frozenset({
-    "started", "tool_result", "tool_result_public", "failure"
+    "started", "tool_result", EVENT_TOOL_PUBLIC, "failure"
 })
 _PUBLIC_COMMITMENT_FIELDS = (
     "call_id",
@@ -412,7 +421,7 @@ def verify_event_chain(events: Any, expected_head_sha256: str) -> None:
             tool_event_kind = kind
         elif kind != tool_event_kind:
             raise ValueError("agentic v2 event trace classification is mixed")
-        if kind in {"tool_result", "tool_result_public"} and isinstance(
+        if kind in {"tool_result", EVENT_TOOL_PUBLIC} and isinstance(
             last_tool_result, Mapping
         ) and (
             last_tool_result.get("ok") is False
@@ -472,7 +481,7 @@ def verify_event_chain(events: Any, expected_head_sha256: str) -> None:
                 })
                 if request_sha256 != result.get("request_sha256"):
                     raise ValueError("agentic v2 tool request hash mismatch")
-        if kind == "tool_result_public":
+        if kind == EVENT_TOOL_PUBLIC:
             if not isinstance(payload, dict) or set(payload) != {
                 "result_commitment", "replayed"
             } or not isinstance(payload.get("replayed"), bool):
@@ -557,7 +566,7 @@ def verify_trace_pair(
             continue
         if (
             private_event.get("kind") != "tool_result"
-            or public_event.get("kind") != "tool_result_public"
+            or public_event.get("kind") != EVENT_TOOL_PUBLIC
         ):
             raise ValueError("agentic v2 trace pair kind mismatch")
         private_payload = private_event["payload"]

--- a/batch-runner/core/agentic_v2_run_driver.py
+++ b/batch-runner/core/agentic_v2_run_driver.py
@@ -59,6 +59,7 @@ from core.agentic_v2_deliverable_collection import (
     collect_deliverables,
 )
 from core.agentic_v2_preregistration import STOP_RULES
+from core.agentic_v2_provenance import EVENT_TOOL_PUBLIC
 from core.agentic_v2_run_report import (
     build_agentic_v2_metrics,
     build_result_row,
@@ -341,11 +342,14 @@ def run_manifest(
             )
 
             standing = journal.standing(task_id)
+            input_tokens, output_tokens = _tokens_of(receipt)
             metrics = build_agentic_v2_metrics(
                 result,
                 standing=standing,
                 tool_calls=_tool_calls_of(result),
-                model_api_calls=_model_calls_of(result),
+                model_api_calls=_model_calls_of(receipt),
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
                 task_wall_time_ms=elapsed_ms,
                 receipt=receipt,
             )
@@ -435,6 +439,21 @@ def _tool_calls_of(result: Mapping[str, Any]) -> Sequence[Mapping[str, Any]]:
 
     The private audit is not read here on purpose: a report is a public
     artefact and should be built from the trace that was redacted for one.
+
+    This used to look for ``tool_name`` on the event itself and always found
+    nothing, so every V2 run reported an empty tool breakdown. The name is two
+    levels in. A public event is ``{"result_commitment": ..., "replayed": ...}``
+    and the commitment is where the redacted fields live --
+    ``core.agentic_v2_provenance`` rejects a public payload with any other key
+    set, so the shape the old filter was looking for is one the verifier could
+    never have admitted. What is returned here is the commitment rather than
+    the event, because the commitment is the part
+    :func:`~core.agentic_v2_run_report._tool_counts` reads a name off.
+
+    A replayed call is counted. The desk answers a repeated identical request
+    from what it stored, but the model still asked, and a model that sends the
+    same oversized request three times is the case this count exists to make
+    visible rather than hide.
     """
     block = result.get("agentic_v2")
     if not isinstance(block, Mapping):
@@ -445,18 +464,60 @@ def _tool_calls_of(result: Mapping[str, Any]) -> Sequence[Mapping[str, Any]]:
     events = trace.get("events")
     if not isinstance(events, Sequence):
         return ()
-    return [
-        event
-        for event in events
-        if isinstance(event, Mapping) and event.get("tool_name")
-    ]
+    calls: list[Mapping[str, Any]] = []
+    for event in events:
+        if not isinstance(event, Mapping) or event.get("kind") != EVENT_TOOL_PUBLIC:
+            continue
+        payload = event.get("payload")
+        if not isinstance(payload, Mapping):
+            continue
+        commitment = payload.get("result_commitment")
+        if isinstance(commitment, Mapping) and commitment.get("tool_name"):
+            calls.append(commitment)
+    return calls
 
 
-def _model_calls_of(result: Mapping[str, Any]) -> int:
-    block = result.get("agentic_v2")
-    if not isinstance(block, Mapping):
+def _model_calls_of(receipt: Mapping[str, Any] | None) -> int:
+    """How many calls to the model this task was billed for.
+
+    Read off the receipt, because the receipt is the only thing that knows. It
+    used to be read off ``result["agentic_v2"]["model_api_calls"]``, which is a
+    key nothing writes and nothing may write: ``verify_agentic_v2_metadata``
+    compares that block against an exact key set, so a run that carried the
+    field would be refused as invalid. The reader was looking for a number the
+    schema forbids, and returned 0 for every task of every run.
+
+    Zero is still returned when there is no receipt, and that is a floor rather
+    than a measurement. The row says so beside it --
+    ``agentic_v2_cost_receipt_status`` reads ``not_run`` and ``usage_complete``
+    reads false -- which is the same pairing the cost fields already use.
+    """
+    if not isinstance(receipt, Mapping):
         return 0
-    count = block.get("model_api_calls")
+    count = receipt.get("model_calls")
     if type(count) is int and count >= 0:
         return count
     return 0
+
+
+def _tokens_of(receipt: Mapping[str, Any] | None) -> tuple[int | None, int | None]:
+    """The task's token counts, or ``None`` where none were recorded.
+
+    ``None`` and ``0`` are different answers and the report treats them
+    differently: ``build_agentic_v2_metrics`` omits the key entirely for
+    ``None``, and an absent key claims nothing, where a zero claims the model
+    read and wrote nothing. No V2 task has ever had a zero-token call -- the
+    task prompt alone is thousands of tokens -- so a zero here would always be
+    the wrong one of the two.
+    """
+    if not isinstance(receipt, Mapping):
+        return (None, None)
+    usage = receipt.get("usage")
+    if not isinstance(usage, Mapping):
+        return (None, None)
+
+    def _count(name: str) -> int | None:
+        value = usage.get(name)
+        return value if type(value) is int and value >= 0 else None
+
+    return (_count("input_tokens"), _count("output_tokens"))

--- a/batch-runner/core/agentic_v2_run_report.py
+++ b/batch-runner/core/agentic_v2_run_report.py
@@ -63,9 +63,10 @@ STATUS_ERROR = "error"
 
 #: The tool names ``step6_report._compute_agentic_metrics`` buckets calls under.
 #:
-#: Copied here so the mismatch with V2 can be asserted rather than described.
-#: If the report ever learns V2's vocabulary this constant stops matching it and
-#: the test that guards it fails, which is the point.
+#: V1's vocabulary, and for a long time the whole of what the report could
+#: name. Kept as its own constant because the V1 names have to stay in the
+#: breakdown and in that order -- a V1 run's report must not change shape
+#: because V2 arrived.
 TOOL_NAMES_THE_REPORT_KNOWS = (
     "inspect_workspace",
     "inspect_environment",
@@ -80,11 +81,9 @@ TOOL_NAMES_V2_USES = TOOL_NAMES
 
 #: The one name both vocabularies share.
 #:
-#: ``finalize`` means the same thing in both, so its count *will* appear in the
-#: report's existing breakdown. Every other V2 tool will not, and a reader who
-#: sees a lone non-zero ``finalize`` beside five zeros would reasonably conclude
-#: the model used one tool. Naming the overlap is what makes that conclusion
-#: checkable instead of surprising.
+#: ``finalize`` means the same thing in both, so a count under it is a sum
+#: across two different runners and cannot be attributed to either. Naming the
+#: overlap is what makes that checkable instead of surprising.
 SHARED_TOOL_NAMES = tuple(
     name for name in TOOL_NAMES_V2_USES if name in TOOL_NAMES_THE_REPORT_KNOWS
 )
@@ -94,6 +93,25 @@ if set(SHARED_TOOL_NAMES) != {"finalize"}:  # pragma: no cover - import guard
         "the report's tool vocabulary and V2's now overlap differently than "
         f"recorded: {sorted(SHARED_TOOL_NAMES)}"
     )
+
+#: Every bucket the report's tool breakdown offers, both vocabularies.
+#:
+#: The report used to offer only the six above. A V2 row carries counts under
+#: all eight of V2's names, seven of which were not in that list, so seven of
+#: them were dropped on the way into the summary and the breakdown showed a
+#: lone non-zero ``finalize`` beside five zeros -- which reads as a model that
+#: used one tool, for a run in which it used several.
+#:
+#: ``browser_run`` is why this is worth the widening rather than a footnote.
+#: Three of the five tasks in the first paid stage ended on it, and it was the
+#: single most informative thing that run produced. It was also one of the
+#: seven names with nowhere to land.
+#:
+#: V1's names come first and keep their order, so an existing report's
+#: breakdown gains keys and does not reorder or lose any.
+TOOL_NAMES_THE_REPORT_BUCKETS = TOOL_NAMES_THE_REPORT_KNOWS + tuple(
+    name for name in TOOL_NAMES_V2_USES if name not in TOOL_NAMES_THE_REPORT_KNOWS
+)
 
 
 class ReportRowRefused(RuntimeError):

--- a/batch-runner/core/agentic_v2_run_report.py
+++ b/batch-runner/core/agentic_v2_run_report.py
@@ -278,10 +278,23 @@ def summarise_v2_run(
     none must not be readable as a run that graded 220, so ``graded`` is
     ``None`` with a stated reason rather than ``0`` — zero graded and grading
     not attempted look identical as a number and are not the same fact.
+
+    ``receipt_ceiling`` is the journal's ceiling: what the run may claim given
+    what was abandoned. It is a ceiling and not a verdict, and it was being
+    read as the verdict. The journal knows about attempts that vanished; it
+    knows nothing about a call the provider billed and did not count, because
+    that is a fact about a ledger row. So a run could hand every task a
+    ``partial`` receipt and still publish ``cost_is_fully_accounted: true`` —
+    which is what the first paid stage did, for a bill that was 20% short.
+
+    The rows are therefore asked as well, and the lower of the two answers
+    wins. A run is fully accounted only where the journal lost nothing *and*
+    every receipt written under it reads ``complete``.
     """
     dispositions: dict[str, int] = {}
     abandoned = 0
     succeeded = 0
+    unsettled: dict[str, int] = {}
     for row in rows:
         metrics = (row.get("observability") or {}).get("agentic_metrics") or {}
         disposition = metrics.get("agentic_v2_disposition")
@@ -290,6 +303,20 @@ def summarise_v2_run(
         abandoned += int(metrics.get("agentic_v2_abandoned_attempts") or 0)
         if row.get("status") == STATUS_SUCCESS:
             succeeded += 1
+        # Read off the receipt the row carries rather than off the metrics
+        # copy, because the receipt is the object the money is on and the
+        # metrics field is derived from it. A row with no receipt says nothing
+        # here: absent is not a complaint, and `receipt_ceiling` above already
+        # covers a task the journal could not close.
+        receipt = row.get("problem_solving_cost")
+        if isinstance(receipt, Mapping):
+            status = str(receipt.get("status") or "")
+            if status and status != STATUS_COMPLETE:
+                unsettled[status] = unsettled.get(status, 0) + 1
+
+    ceiling = str(receipt_ceiling)
+    every_receipt_settled = not unsettled
+    accounted = ceiling == STATUS_COMPLETE and every_receipt_settled
 
     return {
         "schema_version": AGENTIC_V2_METRICS_SCHEMA_VERSION,
@@ -301,8 +328,12 @@ def summarise_v2_run(
         "not_reached": max(0, int(manifest_size) - len(rows)),
         "abandoned_attempts": abandoned,
         "dispositions": dict(sorted(dispositions.items())),
-        "receipt_ceiling": str(receipt_ceiling),
-        "cost_is_fully_accounted": receipt_ceiling == STATUS_COMPLETE,
+        "receipt_ceiling": ceiling,
+        # How many tasks the run could not settle, and under which status.
+        # Empty where every receipt read `complete`; a reader chasing a short
+        # bill starts here rather than by opening 220 receipts.
+        "unsettled_receipts": dict(sorted(unsettled.items())),
+        "cost_is_fully_accounted": accounted,
         "graded": None,
         "graded_reason": "grading is a separate run and has not been made",
     }

--- a/batch-runner/core/cost_receipts.py
+++ b/batch-runner/core/cost_receipts.py
@@ -1350,8 +1350,27 @@ class CostReceiptLedger:
             )
         existing = self._row(call_id)
         if existing is not None:
-            # A resumed round re-reserving a call it already recorded. Keep the
-            # original row; re-reserving must never reset a settled one.
+            # Two callers arrive here. A resumed round re-reserving a call it
+            # already recorded, and — since the agentic v2 stage began writing
+            # a reservation before each request leaves — the settlement pass
+            # offering the same id again on its way to :meth:`settle`. Keep the
+            # original row either way; re-reserving must never reset a settled
+            # one.
+            #
+            # The one thing a second reservation may add is a note where the
+            # row has none. A call reserved before it left cannot say why it
+            # turned out to be unpriceable, because that is knowable only from
+            # the reply; without this the paid path's rows would carry less
+            # explanation than the same rows written offline, and the
+            # explanation is the whole value of the row. Never an overwrite:
+            # the first note stands, and a row that has one keeps it.
+            if note is not None and existing["note"] is None:
+                self._connection.execute(
+                    "UPDATE cost_calls SET note = ? "
+                    "WHERE call_id = ? AND note IS NULL",
+                    (note, call_id),
+                )
+                self._connection.commit()
             return call_id
         self._connection.execute(
             "INSERT INTO cost_calls (call_id, run_id, task_id, stage, "

--- a/batch-runner/core/execution_envelope_cost.py
+++ b/batch-runner/core/execution_envelope_cost.py
@@ -43,6 +43,19 @@ PRICE_TABLE_SCHEMA_VERSION = "execution-envelope-price-table-v1"
 
 TOKENS_PER_MILLION = Decimal(1_000_000)
 
+#: Whose published rates a voice prices its own calls with.
+#:
+#: Every paid run in this repository speaks to Azure, so this is a statement
+#: about the client that gets built rather than a setting anyone chooses. It is
+#: named because the price list holds two blocks and they disagree: the
+#: ``models`` block understates 5.4 by half on input and two thirds on output
+#: and carries no source, and the ``providers`` block keyed ``azure:`` carries
+#: the retail meter names and the date they were read. The cost ledger has
+#: always used the second. Until this constant existed every voice used the
+#: first, so the same calls were reported at two prices in two files written by
+#: the same run, and nothing said which to believe.
+PAID_VOICE_PRICE_PROVIDER = "azure"
+
 # How much of one reference file may reach the model's prompt. The module that
 # decides this is core/file_preview.py, which every run place goes through —
 # not core/file_reader.py, whose 50,000-character cut is only reachable through
@@ -97,6 +110,96 @@ def load_price_table(path: str | Path | None = None) -> dict[str, ModelPrice]:
         )
     if not prices:
         raise ValueError("the price list names no model")
+    return prices
+
+
+def load_provider_price_table(
+    provider: str, path: str | Path | None = None
+) -> dict[str, ModelPrice]:
+    """One provider's prices, keyed by bare model name.
+
+    The same file holds two price lists and they do not agree. The ``models``
+    block above prices a plan before it runs; the ``providers`` block prices a
+    call after it. For ``gpt-5.4`` the first says $1.25 in and $5.00 out and
+    carries no source, and the second says $2.50 and $15.00 and carries the
+    Azure retail meter names, the API it was read from, and the date it was
+    read. The file's own note records that on 2026-08-29 not one figure in the
+    ``models`` block matched a published meter.
+
+    Anything pricing a call that really happened wants the second, and until
+    this existed the only reader of the ``providers`` block was the cost
+    ledger. The voice priced each call it made from the first, so a run record
+    and the ledger beside it reported roughly half and a whole bill for the
+    same calls, and nothing said which to believe.
+
+    Keyed by bare model name because that is what a caller holds: the model
+    name comes back in the reply, and the provider is a property of the client
+    that was built, not of the answer. ``ModelPrice`` has no cached-input rate
+    and no caller measures cached tokens, so every input token is priced at the
+    full rate. That is the upper bound of the two, and it is the same
+    arithmetic the ledger does on the same token counts, so the two agree
+    exactly rather than approximately.
+
+    A model with no entry for this provider is left out rather than filled in
+    from the ``models`` block. A caller that cannot find a price reports the
+    call unpriced, and the run total goes to ``None`` -- missing is partial,
+    never zero. Silently substituting an unsourced figure would turn that
+    refusal into a number, which is the defect this function exists to close.
+    """
+    wanted = str(provider).strip()
+    if not wanted or ":" in wanted:
+        raise ValueError(
+            f"{provider!r} is not a provider name; it names the client that "
+            "was built, such as 'azure'"
+        )
+    target = Path(path) if path is not None else PRICE_TABLE_PATH
+    if not target.is_file():
+        raise ValueError(f"the price list is missing at {target}")
+    raw = json.loads(target.read_text(encoding="utf-8"))
+    # The ledger's own constant rather than a second copy of the string. The
+    # two blocks in this file are versioned separately and the loader that
+    # reads one must move with it, not with the other.
+    from core.cost_receipts import (
+        PRICE_TABLE_SCHEMA_VERSION as PROVIDER_BLOCK_SCHEMA_VERSION,
+    )
+
+    if raw.get("cost_receipt_schema_version") != PROVIDER_BLOCK_SCHEMA_VERSION:
+        raise ValueError(
+            "the provider price list was written for "
+            f"{raw.get('cost_receipt_schema_version')!r}, but this code reads "
+            f"{PROVIDER_BLOCK_SCHEMA_VERSION!r}"
+        )
+    prices: dict[str, ModelPrice] = {}
+    for key, entry in dict(raw.get("providers") or {}).items():
+        if not isinstance(entry, Mapping):
+            raise ValueError(f"the price entry for {key} is not a block")
+        named, _, model = str(key).partition(":")
+        if not named or not model:
+            raise ValueError(
+                f"the price key {key!r} must name both a provider and a model, "
+                "written as provider:model"
+            )
+        if named != wanted:
+            continue
+        # The same two fields the receipt loader insists on. A rate with no
+        # source and no review date is the thing that went wrong in the block
+        # this function exists to stop reading.
+        for required in ("source", "last_reviewed"):
+            if not str(entry.get(required) or "").strip():
+                raise ValueError(
+                    f"the price entry for {key} has no {required}; a rate "
+                    "nobody can trace is not a price"
+                )
+        for required in ("input_usd_per_million", "output_usd_per_million"):
+            if entry.get(required) in (None, ""):
+                raise ValueError(f"the price entry for {key} has no {required}")
+        prices[model] = ModelPrice(
+            model=model,
+            input_usd_per_million=Decimal(str(entry["input_usd_per_million"])),
+            output_usd_per_million=Decimal(str(entry["output_usd_per_million"])),
+        )
+    if not prices:
+        raise ValueError(f"the price list names no model for {wanted!r}")
     return prices
 
 

--- a/batch-runner/scripts/run_agentic_stage_a_probe.py
+++ b/batch-runner/scripts/run_agentic_stage_a_probe.py
@@ -58,8 +58,9 @@ from core.agentic_v2_stage_one_budget import (  # noqa: E402
     run_stage_one_preflight,
 )
 from core.execution_envelope_cost import (  # noqa: E402
+    PAID_VOICE_PRICE_PROVIDER,
     CostAssumptions,
-    load_price_table,
+    load_provider_price_table,
 )
 from core.execution_envelope_preflight import load_plan  # noqa: E402
 from core.execution_envelope_tasks import (  # noqa: E402
@@ -331,7 +332,7 @@ def main() -> int:
             max_output_tokens_per_turn=verdict.max_output_tokens_per_turn,
             max_tool_calls=verdict.tool_calls_per_attempt,
             max_seconds=float(plan["fixed_settings"]["per_task_timeout_seconds"]),
-            prices=load_price_table(),
+            prices=load_provider_price_table(PAID_VOICE_PRICE_PROVIDER),
             tools=PROBE_TOOLS,
         )
         fingerprint = managed.runtime_fingerprint

--- a/batch-runner/scripts/run_agentic_stage_d_probe.py
+++ b/batch-runner/scripts/run_agentic_stage_d_probe.py
@@ -77,7 +77,10 @@ from core.agentic_v2_stage_d_probe import (  # noqa: E402
 )
 from core.agentic_v2_stage_one_budget import STAGE_ONE_PLAN_PATH  # noqa: E402
 from core.agentic_v2_substrate import AgenticV2SubstrateManifest  # noqa: E402
-from core.execution_envelope_cost import load_price_table  # noqa: E402
+from core.execution_envelope_cost import (  # noqa: E402
+    PAID_VOICE_PRICE_PROVIDER,
+    load_provider_price_table,
+)
 from core.execution_envelope_tasks import DATASET_REVISION  # noqa: E402
 
 #: Where C2 leaves the artefact this refuses to run without.
@@ -319,7 +322,10 @@ def the_paid_setup_a_dry_run_can_reach() -> list[str]:
     problems: list[str] = []
     for reading, load in (
         ("the substrate manifest", lambda: AgenticV2SubstrateManifest.load(SUBSTRATE_MANIFEST)),
-        ("the price table", load_price_table),
+        (
+            "the price table",
+            lambda: load_provider_price_table(PAID_VOICE_PRICE_PROVIDER),
+        ),
     ):
         try:
             load()
@@ -489,7 +495,7 @@ def main(argv: list[str] | None = None) -> int:
             max_seconds=seconds,
             max_tool_calls=args.max_tool_calls,
             collect_outputs_into=workspace / "collected",
-            prices=load_price_table(),
+            prices=load_provider_price_table(PAID_VOICE_PRICE_PROVIDER),
             tools=PROBE_TOOLS,
         )
         fingerprint = managed.runtime_fingerprint

--- a/batch-runner/scripts/run_agentic_v2_stage.py
+++ b/batch-runner/scripts/run_agentic_v2_stage.py
@@ -105,8 +105,9 @@ from core.cost_receipts import (  # noqa: E402
     STATUS_UNAVAILABLE,
 )
 from core.execution_envelope_cost import (  # noqa: E402
+    PAID_VOICE_PRICE_PROVIDER,
     CostAssumptions,
-    load_price_table,
+    load_provider_price_table,
 )
 from core.execution_envelope_preflight import load_plan  # noqa: E402
 from core.execution_envelope_tasks import (  # noqa: E402
@@ -254,8 +255,17 @@ def model_calls_record(
     The sqlite ledger beside this is the bill. This is the evidence the bill
     was made from, and it is kept because the two are computed from different
     things and disagreement between them is worth being able to see: the
-    ledger prices from the committed price list, and the voice prices from the
-    same list keyed by the name the reply gave.
+    ledger prices from the committed list keyed ``provider:model``, and the
+    voice prices from the same provider's entries keyed by the name the reply
+    gave. Same rates, same token counts, two arrivals at the figure.
+
+    That was not true until ``PAID_VOICE_PRICE_PROVIDER`` existed. The voice
+    read the ``models`` block, which prices a plan rather than a call, carries
+    no source, and states $1.25 and $5.00 per million where the meters say
+    $2.50 and $15.00. So the disagreement this record exists to expose was
+    guaranteed instead of diagnostic -- always a factor of two on input and
+    three on output, whatever the run did, which is the one thing a difference
+    meant to be read cannot be.
 
     ``resolved_model`` is the point of it. A deployment is an alias, and what
     answers behind it can change without the alias changing -- so "which model
@@ -441,12 +451,18 @@ def open_the_ledger(into: Path, *, run_id: str):
     2026-08-29, so a run without this argument would have reported the whole
     cohort as unaccounted for while the figures sat in the repository.
 
-    Two loaders read that same file and their names are close enough to swap by
-    accident. ``execution_envelope_cost.load_price_table`` returns prices keyed
-    by bare model name for the pre-run ceiling and for the voice;
-    ``cost_receipts.load_receipt_price_table`` returns the table the ledger
-    takes, keyed ``provider:model``, and fingerprints the file so a receipt can
-    name the exact bytes that priced it. The ledger wants the second.
+    Three loaders read that same file and their names are close enough to swap
+    by accident. ``execution_envelope_cost.load_price_table`` returns the
+    ``models`` block keyed by bare model name, which is the pre-run ceiling and
+    nothing else; ``load_provider_price_table`` returns one provider's entries
+    out of the ``providers`` block, also keyed by bare model name, which is
+    what the voice prices its calls with; ``cost_receipts.load_receipt_price_table``
+    returns the whole ``providers`` block keyed ``provider:model`` and
+    fingerprints the file, so a receipt can name the exact bytes that priced
+    it. The ledger wants the third. The first two read *different blocks* and
+    the blocks disagree -- the voice used to read the ceiling's block, and the
+    run record it wrote reported half of what the ledger beside it reported for
+    the same calls.
     """
     from core.cost_receipts import CostReceiptLedger, load_receipt_price_table
 
@@ -561,7 +577,7 @@ def the_paid_setup_a_dry_run_can_reach(stage: str) -> list[str]:
         # the same file the paid run will, and a price list that has stopped
         # parsing is found here rather than after a deployment has been leased.
         try:
-            load_price_table()
+            load_provider_price_table(PAID_VOICE_PRICE_PROVIDER)
         except Exception as broke:  # noqa: BLE001 - reported, not handled
             return [f"the committed price list cannot be loaded: {broke!r}"]
         try:
@@ -905,7 +921,7 @@ def main() -> int:
             settings=settings,
             timeout=float(plan["fixed_settings"]["per_task_timeout_seconds"]),
         )
-        prices = load_price_table()
+        prices = load_provider_price_table(PAID_VOICE_PRICE_PROVIDER)
 
     try:
         if managed is not None:

--- a/batch-runner/scripts/run_agentic_v2_stage.py
+++ b/batch-runner/scripts/run_agentic_v2_stage.py
@@ -67,6 +67,7 @@ from core.agentic_v2_conversation_runner import (  # noqa: E402
     # would let the promise and the enforcement drift apart silently.
     ceilings_from,
     model_turns_of,
+    reserve_before_each_call,
 )
 from core.agentic_v2_cost_binding import bind_run_to_ledger  # noqa: E402
 from core.agentic_v2_fixture_backend import AgenticV2FixtureBackend  # noqa: E402
@@ -1127,12 +1128,49 @@ def main() -> int:
                     "failure here is not the model's either"
                 )
             return AgenticV2FixtureBackend(root=task_root, **kwargs)
+
+        # Opened before the factory that writes into it, and before the first
+        # model call rather than after the first finished task. The reservation
+        # below needs it in hand at the moment a request leaves; a ledger opened
+        # at settle time is a ledger that only ever sees calls that came back.
+        if rehearsing is None:
+            # Through the same helper the dry run calls, so this line cannot
+            # drift from the one that is supposed to be checking it.
+            ledger = open_the_ledger(into, run_id=run_id)
+
+        def reserve_for(task_id: str, attempt: int):
+            """The hook that books each call before it is made, per attempt.
+
+            ``None`` for a rehearsal. A rehearsal asks no model, so a reserved
+            row would be the one line in the ledger claiming otherwise.
+
+            ``retry_kind`` is not passed, which means :data:`RETRY_NONE`, and it
+            has to match what ``model_turns_of`` settles under. That call passes
+            no ``preceding_error`` either, so both are ``retry_none`` and they
+            agree. The day one of them learns about retries the other has to
+            learn in the same change: a reservation filed as a first attempt and
+            settled as a retry keeps the reservation's kind, and the ledger's
+            retry counts quietly stop describing the run.
+            """
+            if ledger is None:
+                return None
+            return reserve_before_each_call(
+                ledger,
+                run_id=run_id,
+                task_id=task_id,
+                attempt=attempt,
+                provider="azure",
+                requested_model=deployment,
+                deployment=deployment,
+            )
+
         factory = build_runner_factory(
             backend_factory=backend_factory,
             profile=profile,
             conversations=held,
             attempt_of=attempt_of,
             cancel_requested=cancel_requested,
+            before_model_call_for=reserve_for,
             **(
                 {"voice": rehearsing}
                 if rehearsing is not None
@@ -1146,9 +1184,6 @@ def main() -> int:
             # that reads as a measurement of a model that was never asked.
             receipt_for = lambda task, attempt: None  # noqa: E731
         else:
-            # Through the same helper the dry run calls, so this line cannot
-            # drift from the one that is supposed to be checking it.
-            ledger = open_the_ledger(into, run_id=run_id)
 
             def receipt_for(task, attempt: int):
                 outcome = held.outcome_of(task.task_id, attempt)

--- a/batch-runner/step6_report.py
+++ b/batch-runner/step6_report.py
@@ -45,6 +45,9 @@ from core.cost_projection import (  # noqa: E402
     verify_cost_ledger,
 )
 from core.execution_metrics import bounded_count, bounded_duration_ms  # noqa: E402
+from core.agentic_v2_run_report import (  # noqa: E402
+    TOOL_NAMES_THE_REPORT_BUCKETS,
+)
 from core.measurement_display import render_measured  # noqa: E402
 from core.prepared_fingerprint import FINGERPRINT_RE  # noqa: E402
 from core.result_fingerprint import RESULT_FINGERPRINT_RE  # noqa: E402
@@ -360,10 +363,7 @@ def _compute_agentic_metrics(data: dict) -> dict | None:
         if result.get("status") == "success"
         and raw.get("recovered_after_tool_error") is True
     )
-    tool_names = (
-        "inspect_workspace", "inspect_environment", "run_python",
-        "run_ffmpeg", "inspect_artifacts", "finalize",
-    )
+    tool_names = TOOL_NAMES_THE_REPORT_BUCKETS
     calls_by_name = {name: 0 for name in tool_names}
     terminal_categories: dict[str, int] = {}
     conservative_cost = 0.0

--- a/batch-runner/tests/test_a_call_booked_before_it_goes_out.py
+++ b/batch-runner/tests/test_a_call_booked_before_it_goes_out.py
@@ -1,0 +1,516 @@
+"""What the ledger holds when the run does not survive the call it made.
+
+Every other thing this run records about a model call is written after the
+reply is in hand: what it used, what it cost, which tool it asked for, whether
+the tool answered. That is fine for a run that finishes. It is worth nothing to
+a run that stops between the request leaving and the reply arriving, and three
+ordinary things do exactly that:
+
+* a shard that exceeds its ``timeout-minutes`` is killed where it stands,
+* an exception between the two unwinds past every recorder,
+* a resumed run starts a fresh journal that knows nothing of the attempt that
+  died.
+
+In all three the provider was asked and will bill. Before this, all three left
+the ledger empty for that call, and an empty ledger reads as *no call was
+made* — the same sentence a run that genuinely made none would write.
+
+So the call is booked before it goes out. The reservation carries no amount and
+claims none; it says *a call left and this run never found out what happened to
+it*, which is :data:`~core.cost_receipts.REASON_CALL_REACHABILITY_UNKNOWN`, and
+it holds the receipt at ``partial``. A run that comes back settles the same row
+by the same id — :func:`~core.agentic_v2_conversation_runner.ledger_call_id`
+builds it for both, because two spellings would mean every paid call appeared
+twice, once open and once priced, with each row looking right on its own.
+
+The path exercised here is the paid one, function for function::
+
+    reserve_before_each_call  →  run_model_conversation(before_model_call=…)
+                              →  model_turns_of  →  settle_into_a_receipt
+
+``open_the_ledger`` and ``settle_into_a_receipt`` are imported from the paid
+script rather than reimplemented. Nothing spends anything: the model is a
+stand-in, the tool desk is a list written in advance, and the ledger is a
+sqlite file in a temporary directory.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from core.agentic_v2_conversation import (
+    AskForTool,
+    GaveUp,
+    LoopLimits,
+    ScriptedToolDesk,
+    ScriptedVoice,
+    StopReason,
+    ToolOutcome,
+    run_model_conversation,
+)
+from core.agentic_v2_conversation_runner import (
+    ledger_call_id,
+    model_turns_of,
+    reserve_before_each_call,
+)
+from core.agentic_v2_stage_one_budget import StageOneBudget
+from core.cost_receipts import (
+    BUCKET_PROBLEM_SOLVING,
+    REASON_CALL_REACHABILITY_UNKNOWN,
+    STATE_RESERVED,
+    STATE_SETTLED,
+    STATUS_PARTIAL,
+    STATUS_UNAVAILABLE,
+)
+
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+for _path in (BATCH_RUNNER_ROOT, BATCH_RUNNER_ROOT / "scripts"):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
+
+import run_agentic_v2_stage as stage  # noqa: E402
+
+
+RUN_ID = "run-booked-1"
+DEPLOYMENT = "gpt-5.4"
+INPUT_TOKENS = 1_000
+OUTPUT_TOKENS = 100
+
+
+# ── the paid path's own pieces ───────────────────────────────────────────
+
+
+@pytest.fixture()
+def ledger(tmp_path):
+    opened = stage.open_the_ledger(tmp_path, run_id=RUN_ID)
+    try:
+        yield opened
+    finally:
+        opened.close()
+
+
+def limits(**changes) -> LoopLimits:
+    settings = {
+        "max_model_turns": 6,
+        "max_written_tokens_per_turn": 2048,
+        "max_seconds": 60.0,
+        "max_repeats_of_one_request": 2,
+        "budget": StageOneBudget(
+            max_model_calls=16,
+            max_input_tokens=1_000_000,
+            max_output_tokens=200_000,
+        ),
+    }
+    settings.update(changes)
+    return LoopLimits(**settings)
+
+
+def ask(call_id: str, tool_name: str, /, **arguments) -> AskForTool:
+    return AskForTool(
+        call_id=call_id,
+        tool_name=tool_name,
+        arguments=arguments,
+        why=f"stand-in model asked for {tool_name}",
+        input_tokens=INPUT_TOKENS,
+        output_tokens=OUTPUT_TOKENS,
+    )
+
+
+def booking(ledger, *, task_id: str, attempt: int = 1):
+    """The hook the paid stage hands the loop, built the way the stage builds it."""
+    return reserve_before_each_call(
+        ledger,
+        run_id=RUN_ID,
+        task_id=task_id,
+        attempt=attempt,
+        provider="azure",
+        requested_model=DEPLOYMENT,
+        deployment=DEPLOYMENT,
+    )
+
+
+def converse(ledger, *, task_id: str, voice, desk=None, attempt: int = 1, **changes):
+    # ``cancel_requested`` and ``clock`` belong to the loop, everything else to
+    # its limits. Splitting here rather than at each call site keeps the tests
+    # below reading as what the run did, not as how the run was wired.
+    loop_only = {
+        name: changes.pop(name)
+        for name in ("cancel_requested", "clock")
+        if name in changes
+    }
+    return run_model_conversation(
+        task_prompt="write a short report",
+        voice=voice,
+        desk=desk if desk is not None else ScriptedToolDesk(),
+        limits=limits(**changes),
+        before_model_call=booking(ledger, task_id=task_id, attempt=attempt),
+        **loop_only,
+    )
+
+
+def settle(ledger, outcome, *, task_id: str, attempt: int = 1):
+    """The second half, exactly as the stage's ``receipt_for`` runs it."""
+    return stage.settle_into_a_receipt(
+        ledger,
+        task_id=task_id,
+        model_turns=model_turns_of(
+            outcome,
+            run_id=RUN_ID,
+            task_id=task_id,
+            attempt=attempt,
+            provider="azure",
+            requested_model=DEPLOYMENT,
+            deployment=DEPLOYMENT,
+            resolved_model=DEPLOYMENT,
+        ),
+    )
+
+
+def rows_in(ledger, task_id: str) -> dict[str, dict]:
+    return {
+        row["call_id"]: row
+        for row in ledger.calls_for(task_id, bucket=BUCKET_PROBLEM_SOLVING)
+    }
+
+
+def a_receipt_over(ledger, task_id: str) -> dict:
+    """What the task's receipt says, with nothing settled into it first.
+
+    ``when_empty`` matches the stage's, so a task with no rows at all is
+    ``unavailable`` rather than a ``$0`` the run never measured.
+    """
+    return ledger.receipt_for(
+        task_id, bucket=BUCKET_PROBLEM_SOLVING, when_empty=STATUS_UNAVAILABLE
+    ).as_dict()
+
+
+def two_calls_then_finish() -> ScriptedVoice:
+    return ScriptedVoice(
+        replies=[
+            ask("call-1", "capabilities_query", kind="commands"),
+            ask("call-2", "finalize", deliverables=["r.txt"], summary="ok"),
+        ]
+    )
+
+
+def a_desk_that_answers_then_commits() -> ScriptedToolDesk:
+    return ScriptedToolDesk(
+        answers=[
+            ToolOutcome.worked(commands=[]),
+            ToolOutcome.committed({"deliverables": ["r.txt"]}),
+        ]
+    )
+
+
+# ── the ordering claim, which is the whole point ─────────────────────────
+
+
+def test_the_row_exists_before_the_request_leaves(ledger):
+    """Checked from inside the request, which is the only honest place.
+
+    A test that looks afterwards cannot tell a row written before the call from
+    one written after it, and "after" is the defect. So the stand-in model looks
+    the ledger up from inside ``next_turn`` — it has been asked, the hook has
+    run, and nothing else has.
+    """
+    seen: list[tuple[str, str]] = []
+
+    class AVoiceThatChecksItsOwnBooking:
+        makes_paid_calls = False
+
+        def next_turn(self, request):
+            call_id = ledger_call_id(
+                run_id=RUN_ID, task_id="task-checked", attempt=1, turn=request.turn
+            )
+            row = rows_in(ledger, "task-checked").get(call_id)
+            assert row is not None, "the call went out before it was booked"
+            seen.append((call_id, row["state"]))
+            return GaveUp(note="that is all I needed to know")
+
+    outcome = converse(
+        ledger, task_id="task-checked", voice=AVoiceThatChecksItsOwnBooking()
+    )
+
+    assert outcome.stop_reason is StopReason.MODEL_STOPPED_WITHOUT_FINISHING
+    assert seen == [(f"{RUN_ID}:task-checked:1:turn-1", STATE_RESERVED)]
+
+
+# ── the three ways a run does not come back ──────────────────────────────
+
+
+class TheShardRanOutOfWallClock(BaseException):
+    """Not an ``Exception``, so the loop cannot catch it.
+
+    That is the point. A shard killed by ``timeout-minutes`` does not get a
+    handler, does not return an outcome, and does not reach a single line of
+    the accounting that runs after the loop. Anything the ledger holds
+    afterwards was written before the call.
+    """
+
+
+def test_a_run_killed_mid_call_still_has_both_calls_in_the_ledger(ledger):
+    class AVoiceTheProcessDiesIn:
+        makes_paid_calls = False
+
+        def next_turn(self, request):
+            if request.turn == 1:
+                return ask("call-1", "capabilities_query", kind="commands")
+            raise TheShardRanOutOfWallClock()
+
+    with pytest.raises(TheShardRanOutOfWallClock):
+        converse(
+            ledger,
+            task_id="task-killed",
+            voice=AVoiceTheProcessDiesIn(),
+            desk=ScriptedToolDesk(answers=[ToolOutcome.worked(commands=[])]),
+        )
+
+    rows = rows_in(ledger, "task-killed")
+    assert set(rows) == {
+        f"{RUN_ID}:task-killed:1:turn-1",
+        f"{RUN_ID}:task-killed:1:turn-2",
+    }
+    # Both still open. Turn one's reply arrived and was priceable, but pricing
+    # happens after the loop returns and the loop never returned — so even the
+    # call that went well is an unknown, which is the true reading.
+    assert [row["state"] for row in rows.values()] == [STATE_RESERVED] * 2
+    assert all(row["model_cost_usd"] is None for row in rows.values())
+
+
+def test_the_receipt_over_a_killed_run_says_it_never_found_out(ledger):
+    """``partial`` and a reason, not ``complete`` and not ``$0``."""
+
+    class AVoiceTheProcessDiesIn:
+        makes_paid_calls = False
+
+        def next_turn(self, request):
+            raise TheShardRanOutOfWallClock()
+
+    with pytest.raises(TheShardRanOutOfWallClock):
+        converse(ledger, task_id="task-killed", voice=AVoiceTheProcessDiesIn())
+
+    receipt = a_receipt_over(ledger, "task-killed")
+    assert receipt["status"] == STATUS_PARTIAL
+    assert REASON_CALL_REACHABILITY_UNKNOWN in receipt["missing_reasons"]
+    assert receipt["model_calls"] == 1
+    assert receipt["estimated_cost_usd"] is None
+
+
+def test_an_exception_in_the_voice_leaves_the_call_open_not_absent(ledger):
+    """The loop catches this one, and the row is still the honest shape.
+
+    ``next_turn`` raising might mean the request never left — a client that
+    could not be built — or that it left and the reply could not be read. This
+    process cannot tell, and the ledger has a word for each: ``abandoned``
+    claims the call never went out, and its own docstring restricts it to
+    failures *known* to precede the request. This is not one of those, so the
+    row stays reserved and says so.
+    """
+
+    class AVoiceThatFallsOver:
+        makes_paid_calls = False
+
+        def next_turn(self, request):
+            if request.turn == 1:
+                return ask("call-1", "capabilities_query", kind="commands")
+            raise RuntimeError("the client fell over")
+
+    outcome = converse(
+        ledger,
+        task_id="task-raised",
+        voice=AVoiceThatFallsOver(),
+        desk=ScriptedToolDesk(answers=[ToolOutcome.worked(commands=[])]),
+    )
+    assert outcome.stop_reason is StopReason.MODEL_REPLY_UNUSABLE
+
+    receipt = settle(ledger, outcome, task_id="task-raised")
+    rows = rows_in(ledger, "task-raised")
+
+    # Turn one came back and is priced. Turn two went out and never answered.
+    assert rows[f"{RUN_ID}:task-raised:1:turn-1"]["state"] == STATE_SETTLED
+    assert rows[f"{RUN_ID}:task-raised:1:turn-2"]["state"] == STATE_RESERVED
+    assert receipt["status"] == STATUS_PARTIAL
+    assert REASON_CALL_REACHABILITY_UNKNOWN in receipt["missing_reasons"]
+    # The half that is known is still published, as a floor rather than a total.
+    assert receipt["known_cost_usd"] > 0
+    assert receipt["model_calls"] == 2
+
+
+def test_a_cancelled_run_settles_the_calls_it_already_made(ledger):
+    """Cancellation returns, so the run settles — and must settle the same rows.
+
+    Two ids for one call would put every cancelled call in the ledger twice,
+    once open and once priced, and the doubled total would be made of rows that
+    each look correct.
+    """
+    stops = iter([False, True])
+    outcome = converse(
+        ledger,
+        task_id="task-cancelled",
+        voice=two_calls_then_finish(),
+        desk=a_desk_that_answers_then_commits(),
+        cancel_requested=lambda: next(stops, True),
+    )
+    assert outcome.stop_reason is StopReason.CANCELLED
+
+    receipt = settle(ledger, outcome, task_id="task-cancelled")
+    rows = rows_in(ledger, "task-cancelled")
+
+    assert set(rows) == {f"{RUN_ID}:task-cancelled:1:turn-1"}
+    assert rows[f"{RUN_ID}:task-cancelled:1:turn-1"]["state"] == STATE_SETTLED
+    assert receipt["model_calls"] == 1
+    assert receipt["known_cost_usd"] > 0
+
+
+def test_a_resumed_attempt_neither_doubles_the_bill_nor_drops_a_call(ledger):
+    """The third way a run does not come back: it comes back as a new process.
+
+    The resumed round re-runs the same attempt and re-books the same turns. The
+    ids are the run's own and derived from the turn number, so a second pass
+    finds the rows it left rather than writing new ones. Anything derived from
+    a timestamp or a list position would bill the dead attempt twice, and
+    neither pass would look wrong on its own.
+    """
+    first = converse(
+        ledger,
+        task_id="task-resumed",
+        voice=two_calls_then_finish(),
+        desk=a_desk_that_answers_then_commits(),
+    )
+    settle(ledger, first, task_id="task-resumed")
+    before = a_receipt_over(ledger, "task-resumed")
+
+    second = converse(
+        ledger,
+        task_id="task-resumed",
+        voice=two_calls_then_finish(),
+        desk=a_desk_that_answers_then_commits(),
+    )
+    settle(ledger, second, task_id="task-resumed")
+    after = a_receipt_over(ledger, "task-resumed")
+
+    assert len(rows_in(ledger, "task-resumed")) == 2
+    assert before["model_calls"] == after["model_calls"] == 2
+    assert before["known_cost_usd"] == after["known_cost_usd"]
+
+
+def test_a_retry_of_a_killed_attempt_keeps_the_dead_attempt_open(ledger):
+    """A second attempt is more spend, and does not settle the first's unknown.
+
+    This is the shape a resumed run actually has: attempt one died mid-call,
+    attempt two ran to the end. The task's receipt has to carry both, because
+    both were charged — and it has to stay ``partial``, because what attempt
+    one cost is still not known.
+    """
+
+    class AVoiceTheProcessDiesIn:
+        makes_paid_calls = False
+
+        def next_turn(self, request):
+            raise TheShardRanOutOfWallClock()
+
+    with pytest.raises(TheShardRanOutOfWallClock):
+        converse(
+            ledger,
+            task_id="task-retried",
+            voice=AVoiceTheProcessDiesIn(),
+            attempt=1,
+        )
+
+    second = converse(
+        ledger,
+        task_id="task-retried",
+        voice=two_calls_then_finish(),
+        desk=a_desk_that_answers_then_commits(),
+        attempt=2,
+    )
+    receipt = settle(ledger, second, task_id="task-retried", attempt=2)
+
+    rows = rows_in(ledger, "task-retried")
+    assert set(rows) == {
+        f"{RUN_ID}:task-retried:1:turn-1",
+        f"{RUN_ID}:task-retried:2:turn-1",
+        f"{RUN_ID}:task-retried:2:turn-2",
+    }
+    assert rows[f"{RUN_ID}:task-retried:1:turn-1"]["state"] == STATE_RESERVED
+    assert receipt["model_calls"] == 3
+    assert receipt["status"] == STATUS_PARTIAL
+    assert REASON_CALL_REACHABILITY_UNKNOWN in receipt["missing_reasons"]
+
+
+# ── the booking and the settlement have to be one row ────────────────────
+
+
+def test_the_booking_and_the_settlement_name_the_same_row(ledger):
+    """One call, one row, both halves. The id function is why."""
+    outcome = converse(
+        ledger,
+        task_id="task-whole",
+        voice=two_calls_then_finish(),
+        desk=a_desk_that_answers_then_commits(),
+    )
+    assert outcome.stop_reason is StopReason.FINISHED_NORMALLY
+
+    booked = set(rows_in(ledger, "task-whole"))
+    receipt = settle(ledger, outcome, task_id="task-whole")
+    after = rows_in(ledger, "task-whole")
+
+    assert booked == set(after)
+    assert len(after) == 2
+    assert [row["state"] for row in after.values()] == [STATE_SETTLED] * 2
+    assert receipt["status"] == "complete"
+    assert receipt["missing_reasons"] == []
+
+
+def test_a_booking_that_cannot_be_written_stops_the_run_before_the_call(ledger):
+    """If the run cannot write down what it is about to spend, it does not spend it.
+
+    The inverse of everything above. A hook that fails means the reservation is
+    not there, and making the call anyway would recreate exactly the gap this
+    change closes — a charge with no row.
+    """
+    asked: list[int] = []
+
+    class AVoiceThatMustNotBeAsked:
+        makes_paid_calls = False
+
+        def next_turn(self, request):  # pragma: no cover - the point is it is not
+            asked.append(request.turn)
+            return GaveUp(note="should never get here")
+
+    def a_ledger_that_will_not_take_it(turn: int) -> None:
+        raise RuntimeError("the ledger is not writable")
+
+    outcome = run_model_conversation(
+        task_prompt="write a short report",
+        voice=AVoiceThatMustNotBeAsked(),
+        desk=ScriptedToolDesk(),
+        limits=limits(),
+        before_model_call=a_ledger_that_will_not_take_it,
+    )
+
+    assert outcome.stop_reason is StopReason.PAID_CALL_REFUSED
+    assert asked == []
+    assert outcome.turns == ()
+    assert "not writable" in outcome.detail
+
+
+def test_a_run_with_no_booking_still_works(ledger):
+    """The hook is optional, and a caller without a ledger is not broken by it.
+
+    The rehearsal path passes nothing — it asks no model, so there is nothing
+    to book and a reserved row would be the one line claiming otherwise.
+    """
+    outcome = run_model_conversation(
+        task_prompt="write a short report",
+        voice=two_calls_then_finish(),
+        desk=a_desk_that_answers_then_commits(),
+        limits=limits(),
+    )
+
+    assert outcome.stop_reason is StopReason.FINISHED_NORMALLY
+    assert rows_in(ledger, "task-whole") == {}

--- a/batch-runner/tests/test_agentic_v2_conversation_runner.py
+++ b/batch-runner/tests/test_agentic_v2_conversation_runner.py
@@ -22,8 +22,10 @@ from core.agentic_v2_conversation import (
     AskForTool,
     GaveUp,
     LoopLimits,
+    ScriptedToolDesk,
     ScriptedVoice,
     StopReason,
+    run_model_conversation,
 )
 from core.agentic_v2_conversation_runner import (
     ConversationRunnerRefused,
@@ -665,6 +667,46 @@ class TestTheConversationReachesTheLedger:
         )
         assert written["bucket"] == BUCKET_PROBLEM_SOLVING
 
-    def test_an_empty_conversation_produces_no_entries(self, tmp_path):
+    def test_a_reply_with_no_counts_is_an_entry_that_cannot_be_priced(
+        self, tmp_path
+    ):
+        """A conversation that did nothing still asked the model once.
+
+        This used to assert no entries at all, on the reading that a model
+        which walked away immediately produced an empty conversation. It did
+        not: the request went out, a reply came back, and the provider bills
+        for that whatever the reply says. ``GaveUp`` with no counts is the real
+        voice's walk-away, whose token fields default to zero — so the entry
+        carries no usage rather than a zero one, and prices as ``usage_absent``.
+        """
         _, outcome, _ = _run(tmp_path, [GaveUp(note="nothing to do")])
+
+        (entry,) = self._turns(outcome)
+        assert entry.usage.is_empty
+        assert entry.call_id == "run-a:task-1:1:turn-1"
+
+    def test_a_conversation_that_never_asked_the_model_produces_no_entries(
+        self, tmp_path
+    ):
+        """The genuinely empty case, which is a refusal and not a walk-away.
+
+        A voice that does not declare whether it costs anything is stopped
+        before the first request. Nothing was asked, so nothing was billed, and
+        the ledger is offered nothing — which is different from being offered a
+        call it cannot price.
+        """
+
+        class AVoiceThatNeverDeclaredItself:
+            def next_turn(self, request):  # pragma: no cover - never reached
+                raise AssertionError("the loop must refuse before asking")
+
+        held = TaskConversations(CEILINGS)
+        outcome = run_model_conversation(
+            task_prompt="Write the report",
+            voice=AVoiceThatNeverDeclaredItself(),
+            desk=ScriptedToolDesk(),
+            limits=held.limits_for("task-1", 1),
+        )
+
+        assert outcome.stop_reason is StopReason.PAID_CALL_REFUSED
         assert self._turns(outcome) == ()

--- a/batch-runner/tests/test_agentic_v2_run_driver.py
+++ b/batch-runner/tests/test_agentic_v2_run_driver.py
@@ -41,14 +41,40 @@ def _tasks(count=3):
 
 
 def _success(task_id, *, calls=("exec_run", "finalize")):
+    """A result shaped the way the runner shapes one, minus the hashes.
+
+    The nesting is not decoration. A public event's payload is checked against
+    an exact key set, and the tool name lives on the commitment inside it, two
+    levels down -- so a stand-in with the name on the event is a shape no run
+    can produce and no verifier would admit. It was, for a while, and the
+    driver read the trace the same wrong way, which is how V2 came to report
+    zero tool calls for every task of every run without a test going red.
+
+    ``model_api_calls`` is not here for the same reason: the metadata is
+    compared against an exact key set that does not include it. The count comes
+    from the cost receipt, which is the only object that knows it.
+
+    Kept honest by
+    ``test_the_metrics_block_that_always_read_zero.py::test_the_drivers_stand_in_result_is_shaped_like_a_real_one``,
+    which boots the real fixture backend and compares this shape against the
+    record it writes.
+    """
     return {
         "success": True,
         "deliverable_text": f"answer for {task_id}",
         "files": [{"filename": "report.xlsx", "content": b"payload"}],
         "agentic_v2": {
-            "model_api_calls": 2,
             "public_trace": {
-                "events": [{"tool_name": name} for name in calls]
+                "events": [
+                    {
+                        "kind": "tool_result_public",
+                        "payload": {
+                            "result_commitment": {"tool_name": name},
+                            "replayed": False,
+                        },
+                    }
+                    for name in calls
+                ]
             },
         },
     }
@@ -190,10 +216,15 @@ def test_the_files_reach_the_submission_layout(tmp_path):
 
 
 def test_v2_tool_calls_are_counted_from_the_public_trace(tmp_path):
-    outcome, _ = _run(tmp_path, _tasks(1), _success)
+    def receipt_for(task, attempt):
+        return {"status": STATUS_COMPLETE, "model_calls": 2}
+
+    outcome, _ = _run(tmp_path, _tasks(1), _success, receipt_for=receipt_for)
     metrics = outcome.rows[0]["observability"]["agentic_metrics"]
     assert metrics["tool_calls"] == 2
     assert metrics["tool_calls_by_name"]["exec_run"] == 1
+    # From the receipt, not the result: the metadata verifier rejects a record
+    # that carries a call count, so the result cannot be asked for one.
     assert metrics["model_api_calls"] == 2
 
 

--- a/batch-runner/tests/test_agentic_v2_run_report.py
+++ b/batch-runner/tests/test_agentic_v2_run_report.py
@@ -4,7 +4,8 @@ Most of these tests are about the things that would be easy to state wrongly: a
 zero where a number is unknown, a graded count where nothing was graded, a
 deliverable list that came from the model rather than from the disk. The
 mismatch between V1's tool names and V2's is asserted here rather than merely
-noted, so that fixing the report later breaks this file on purpose.
+noted: the summary now offers a bucket for both vocabularies, and these tests
+are what stops the two lists drifting apart again.
 """
 
 from __future__ import annotations
@@ -17,6 +18,7 @@ from core.agentic_v2_run_report import (
     SHARED_TOOL_NAMES,
     STATUS_ERROR,
     STATUS_SUCCESS,
+    TOOL_NAMES_THE_REPORT_BUCKETS,
     TOOL_NAMES_THE_REPORT_KNOWS,
     ReportRowRefused,
     build_agentic_v2_metrics,
@@ -94,6 +96,48 @@ def test_the_report_s_tool_names_and_v2_s_share_only_finalize():
     overlap = set(TOOL_NAMES) & set(TOOL_NAMES_THE_REPORT_KNOWS)
     assert overlap == {"finalize"}
     assert SHARED_TOOL_NAMES == ("finalize",)
+
+
+def test_the_breakdown_has_a_bucket_for_every_name_either_runner_uses():
+    """Seven of V2's eight had nowhere to land, so they were dropped.
+
+    Including ``browser_run``, which three of the five tasks in the first paid
+    stage ended on. The summary showed a lone non-zero ``finalize``.
+    """
+    assert set(TOOL_NAMES_THE_REPORT_BUCKETS) == set(TOOL_NAMES) | set(
+        TOOL_NAMES_THE_REPORT_KNOWS
+    )
+    assert len(TOOL_NAMES_THE_REPORT_BUCKETS) == len(
+        set(TOOL_NAMES_THE_REPORT_BUCKETS)
+    )
+    # V1's order, unchanged, at the front: an existing report's breakdown gains
+    # keys rather than reordering.
+    assert (
+        TOOL_NAMES_THE_REPORT_BUCKETS[: len(TOOL_NAMES_THE_REPORT_KNOWS)]
+        == TOOL_NAMES_THE_REPORT_KNOWS
+    )
+
+
+def test_the_report_buckets_under_exactly_these_names():
+    """The constant and the summary that reads it, checked against each other.
+
+    ``step6_report`` used to hold its own copy of the list. A copy is how the
+    two came to disagree in the first place.
+    """
+    import step6_report
+
+    row = {
+        "task_wall_time_ms": 1.0,
+        "tool_calls": 2,
+        "tool_calls_by_name": {"browser_run": 1, "finalize": 1},
+    }
+    summary = step6_report._compute_agentic_metrics(
+        {"results": [{"observability": {"agentic_metrics": row}}]}
+    )
+
+    assert set(summary["tool_calls_by_name"]) == set(TOOL_NAMES_THE_REPORT_BUCKETS)
+    assert summary["tool_calls_by_name"]["browser_run"] == 1
+    assert summary["total_tool_calls"] == 2
 
 
 def test_every_v2_tool_gets_a_bucket_even_when_unused():

--- a/batch-runner/tests/test_step6_v2_fields.py
+++ b/batch-runner/tests/test_step6_v2_fields.py
@@ -979,6 +979,9 @@ def test_generate_report_adds_agentic_metrics_only_when_measured(monkeypatch, tm
     assert metrics["usage_complete_tasks"] == 1
     assert metrics["usage_coverage_pct"] == 50.0
     assert metrics["conservative_cost_usd"] == 0.75
+    # V1's six keep their counts. The seven V2-only names are present and zero:
+    # this fixture is a V1 run, and a bucket with nothing in it is the right
+    # answer for a tool that run could not have called.
     assert metrics["tool_calls_by_name"] == {
         "inspect_workspace": 1,
         "inspect_environment": 1,
@@ -986,6 +989,13 @@ def test_generate_report_adds_agentic_metrics_only_when_measured(monkeypatch, tm
         "run_ffmpeg": 1,
         "inspect_artifacts": 1,
         "finalize": 1,
+        "capabilities_query": 0,
+        "workspace_apply": 0,
+        "exec_run": 0,
+        "environment_resolve": 0,
+        "environment_activate": 0,
+        "browser_run": 0,
+        "verify_public": 0,
     }
     assert metrics["terminal_error_categories"] == {"capability_missing": 1}
     assert rd["task_results"][0]["observability"]["agentic_metrics"][

--- a/batch-runner/tests/test_the_calls_the_run_was_billed_for_and_never_filed.py
+++ b/batch-runner/tests/test_the_calls_the_run_was_billed_for_and_never_filed.py
@@ -24,9 +24,10 @@ What is pinned here
 * the turn says which tool the money was spent asking for, where the run got
   far enough to know,
 * a turn is filed exactly once, never twice,
-* the calls that genuinely cannot be filed — a reply that never said what it
-  used, and a reply whose counts came back zero — are left out and counted as
-  uncounted, rather than filed as zeros that would settle to ``$0.00``,
+* the calls that genuinely cannot be priced — a reply that never said what it
+  used, and a reply whose counts came back zero — reach the ledger as rows
+  with no usage rather than as turns carrying zeros that would settle to
+  ``$0.00``,
 * what reaches the ledger, through ``model_turns_of``, matches what was asked.
 
 Nothing here spends anything: the model is a stand-in and the tool desk is a
@@ -379,20 +380,28 @@ class AVoiceThatDoesNotSayWhatItUsed:
 
 
 def test_a_reply_that_never_said_what_it_used_is_left_out_not_zeroed():
-    """The honest gap, kept open on purpose.
+    """The honest gap, now open in the ledger instead of outside it.
 
     A reply with no usable counts was charged for like any other, and the run
-    has no figure for it. Filing it with zeros would put the one number in the
-    account that reads as a measurement, so it is left out and the stop reason
-    says why. Closing this properly needs a reservation written before the call
-    rather than a record written after it, which is a different change.
+    has no figure for it. Filing it as a turn with zeros would put the one
+    number in the account that reads as a measurement, so it is not a turn. It
+    is a ledger row with no usage at all, which is a different sentence: *this
+    was charged and cannot be priced*. The receipt built over it says
+    ``partial`` rather than quietly reading ``complete`` for the calls it did
+    manage to price.
     """
     outcome = a_run(AVoiceThatDoesNotSayWhatItUsed(), ScriptedToolDesk())
 
     assert outcome.stop_reason is StopReason.MODEL_REPLY_UNUSABLE
     assert outcome.turns == ()
-    assert calls_the_model_answered(outcome) == 0
+    assert calls_the_model_answered(outcome) == 1
+    assert outcome.model_calls_not_counted == 1
     assert "how much it used" in outcome.detail
+
+    (entry,) = a_ledger_entry_per_turn(outcome)
+    assert entry.usage.is_empty
+    assert entry.usage.input_tokens is None
+    assert entry.usage.output_tokens is None
 
 
 def test_a_reply_reporting_no_input_tokens_is_counted_but_not_priced():
@@ -402,8 +411,10 @@ def test_a_reply_reporting_no_input_tokens_is_counted_but_not_priced():
     walk-away's token fields default to zero. Nothing calls a model for nothing
     on the way in — the task prompt alone is thousands of tokens — so a zero
     input count is a reply that was never counted, not a reply that was free.
-    Filing it would settle to ``$0.00`` on a ``complete`` receipt, which reads
-    as a measurement of a call nobody measured.
+    Filing it as a turn would settle to ``$0.00`` on a ``complete`` receipt,
+    which reads as a measurement of a call nobody measured; so it reaches the
+    ledger with its usage absent instead, and absent does not add up to
+    anything.
     """
     outcome = a_run(
         ScriptedVoice(replies=[GaveUp(note="the model answered without saying "
@@ -413,11 +424,15 @@ def test_a_reply_reporting_no_input_tokens_is_counted_but_not_priced():
 
     assert outcome.stop_reason is StopReason.MODEL_STOPPED_WITHOUT_FINISHING
     assert outcome.turns == ()
-    assert a_ledger_entry_per_turn(outcome) == ()
-    # The reply is not lost, only unpriced: it is visible here and nowhere else.
     assert outcome.model_calls_not_counted == 1
     assert calls_the_model_answered(outcome) == 1
     assert outcome.as_dict()["model_calls_not_counted"] == 1
+
+    # In the account, and in it as an unknown rather than as a zero.
+    (entry,) = a_ledger_entry_per_turn(outcome)
+    assert entry.usage.is_empty
+    assert entry.call_id == "run-1:task-1:1:turn-1"
+    assert "reported no usage" in (entry.note or "")
 
 
 def test_a_counted_reply_does_not_show_up_as_uncounted():
@@ -454,7 +469,11 @@ def test_the_ledger_gets_one_entry_for_every_call_the_model_answered():
     assert len(entries) == calls_the_model_answered(outcome) == 1
     assert entries[0].usage.input_tokens == INPUT_TOKENS
     assert entries[0].usage.output_tokens == OUTPUT_TOKENS
-    assert entries[0].call_id == "run-1:task-1:1:call-1"
+    # Named by the run's own turn counter, not by the id the model chose. The
+    # model's id is still on the turn record beside the run; what the ledger
+    # needs is a key it can write before the reply exists, because that is what
+    # a reservation is.
+    assert entries[0].call_id == "run-1:task-1:1:turn-1"
 
 
 def test_no_two_ledger_entries_from_one_run_share_a_call_id():

--- a/batch-runner/tests/test_the_metrics_block_that_always_read_zero.py
+++ b/batch-runner/tests/test_the_metrics_block_that_always_read_zero.py
@@ -1,0 +1,355 @@
+"""Every V2 task reported no tool calls and no model calls, in every run.
+
+Not a bad run. A shape mismatch, in both directions, that no run could avoid.
+
+**The tool breakdown.** ``_tool_calls_of`` filtered the public trace for events
+with a ``tool_name`` on them. A public event has ``kind``, ``payload`` and the
+chain fields, and its payload is exactly ``{"result_commitment", "replayed"}``
+-- ``verify_trace_pair`` raises for any other key set. The tool name is two
+levels in, on the commitment. So the filter matched nothing a verifier would
+admit, and ``tool_calls`` and ``tool_calls_by_name`` were empty for every task
+of every run.
+
+**The model-call count.** ``_model_calls_of`` read
+``result["agentic_v2"]["model_api_calls"]``. That block is checked against an
+*exact* key set by ``verify_agentic_v2_metadata``, and ``model_api_calls`` is
+not in it -- so a run that carried the field would be refused as invalid. The
+reader was looking for a number the schema forbids, and got 0 every time.
+
+**The tokens.** ``build_agentic_v2_metrics`` accepts ``input_tokens`` and
+``output_tokens`` and omits the keys when they are ``None``. The driver never
+passed either, so they were absent from every V2 metrics block ever written.
+
+Why this survived review: the driver's own test builds a stand-in result in the
+shape the reader was looking for, complete with a top-level ``tool_name`` and a
+``model_api_calls`` field. Stand-in and reader agreed with each other and
+neither agreed with the runner. So the tests below run the *real* runner against
+the *real* fixture backend and read the record it actually produces. One of them
+then checks the stand-in against that record, so the two cannot drift apart
+again without something going red.
+
+What the fix reads instead: the commitment, for tool names; and the cost
+receipt, for the call count and the tokens -- the receipt being the only object
+in the system that knows how many calls a task was billed for.
+
+Nothing here calls a model, reaches a network or spends anything.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.agentic_v2_fixture_backend import AgenticV2FixtureBackend  # noqa: E402
+from core.agentic_v2_provenance import (  # noqa: E402
+    EVENT_TOOL_PUBLIC,
+    verify_agentic_v2_metadata,
+    verify_agentic_v2_result,
+)
+from core.agentic_v2_run_driver import (  # noqa: E402
+    _model_calls_of,
+    _tokens_of,
+    _tool_calls_of,
+)
+from core.agentic_v2_run_report import build_agentic_v2_metrics  # noqa: E402
+from core.agentic_v2_runner import AgenticV2ScriptedRunner  # noqa: E402
+from core.agentic_v2_task_journal import TaskStanding  # noqa: E402
+from core.cost_receipts import STATUS_COMPLETE  # noqa: E402
+
+PROFILE = {
+    "tool_contract_version": "2.0",
+    "policy_profile_id": "offline-full-v1",
+    "foundation_only": True,
+}
+
+WRITE_THEN_FINALIZE = [
+    {
+        "call_id": "write-1",
+        "name": "workspace_apply",
+        "arguments": {
+            "operation": "write",
+            "path": "report.txt",
+            "content": "done",
+        },
+    },
+    {
+        "call_id": "final-1",
+        "name": "finalize",
+        "arguments": {"deliverables": ["report.txt"], "summary": "done"},
+    },
+]
+
+
+@pytest.fixture
+def real_result(tmp_path):
+    """A run record the verifier accepts, from the runner that writes them."""
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=list(WRITE_THEN_FINALIZE),
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+    verify_agentic_v2_result(result)
+    return result
+
+
+def a_receipt(**changes):
+    receipt = {
+        "status": STATUS_COMPLETE,
+        "model_calls": 4,
+        "usage": {
+            "input_tokens": 17_775,
+            "cached_input_tokens": 0,
+            "output_tokens": 292,
+            "reasoning_tokens": 0,
+        },
+        "estimated_cost_usd": 0.24249,
+        "missing_reasons": [],
+    }
+    receipt.update(changes)
+    return receipt
+
+
+def a_standing(*, fully_accounted=True):
+    """A journal standing, made unaccounted the way a real one becomes so.
+
+    ``cost_is_fully_accounted`` is derived, not stored -- it is false when an
+    attempt was opened and never closed. So the unaccounted case here is an
+    abandoned attempt rather than a flag, which is the state a run actually
+    reaches when a task dies mid-call.
+    """
+    return TaskStanding(
+        task_id="task-1",
+        attempts=1 if fully_accounted else 2,
+        abandoned_attempts=0 if fully_accounted else 1,
+        last_closed=None,
+        decision="run",
+        reason="",
+    )
+
+
+# ---------------------------------------------------------------------------
+# The measurement: what the old filters found in a real record
+# ---------------------------------------------------------------------------
+
+
+def test_the_real_record_has_no_tool_name_where_the_old_filter_looked(real_result):
+    """The defect, as a property of a record the verifier accepted."""
+    events = real_result["agentic_v2"]["public_trace"]["events"]
+
+    assert events, "the fixture produced no public events at all"
+    assert [event for event in events if event.get("tool_name")] == []
+
+
+def test_the_real_record_has_no_model_api_calls_field(real_result):
+    assert "model_api_calls" not in real_result["agentic_v2"]
+
+
+def test_a_record_carrying_that_field_would_be_refused(real_result):
+    """So the old reader could not have been satisfied by any valid run.
+
+    This is the part that makes it a schema mismatch rather than an omission.
+    Writing the field the reader wanted is not a fix available to anyone: the
+    metadata is compared against an exact key set, and the record stops
+    verifying the moment the field is there.
+    """
+    metadata = dict(real_result["agentic_v2"])
+    verify_agentic_v2_metadata(metadata)
+
+    metadata["model_api_calls"] = 2
+    with pytest.raises(ValueError, match="metadata is invalid"):
+        verify_agentic_v2_metadata(metadata)
+
+
+# ---------------------------------------------------------------------------
+# What the fixed readers find in the same record
+# ---------------------------------------------------------------------------
+
+
+def test_the_tool_calls_are_found_where_the_runner_writes_them(real_result):
+    calls = _tool_calls_of(real_result)
+
+    assert [call["tool_name"] for call in calls] == ["workspace_apply", "finalize"]
+
+
+def test_the_calls_come_from_public_events_and_carry_no_arguments(real_result):
+    """The public trace is the one a report may be built from.
+
+    Each returned item is the redacted commitment -- hashes and a verdict, no
+    request body. A reader that reached into the private audit for a nicer
+    field would be putting unredacted material into a public artefact.
+    """
+    events = real_result["agentic_v2"]["public_trace"]["events"]
+    public = [event for event in events if event.get("kind") == EVENT_TOOL_PUBLIC]
+
+    assert len(public) == len(_tool_calls_of(real_result))
+    for call in _tool_calls_of(real_result):
+        assert "arguments" not in call
+        assert "data" not in call
+        assert set(call) == {
+            "call_id",
+            "tool_name",
+            "request_sha256",
+            "result_sha256",
+            "ok",
+            "error_type",
+            "usage_delta",
+            "state_before_sha256",
+            "state_after_sha256",
+        }
+
+
+def test_the_started_event_is_not_counted_as_a_tool_call(real_result):
+    """Filtering by kind rather than by "has a name" is the point.
+
+    The chain opens with a ``started`` event and may close with a ``failure``
+    one. Neither is a call, and a looser filter that happened to work today
+    would count them the first time either grew a name-shaped field.
+    """
+    events = real_result["agentic_v2"]["public_trace"]["events"]
+
+    assert events[0]["kind"] == "started"
+    assert len(_tool_calls_of(real_result)) == len(events) - 1
+
+
+def test_the_metrics_block_now_names_the_tools_that_ran(real_result):
+    metrics = build_agentic_v2_metrics(
+        real_result,
+        standing=a_standing(),
+        tool_calls=_tool_calls_of(real_result),
+        model_api_calls=_model_calls_of(a_receipt()),
+        task_wall_time_ms=1234.0,
+        receipt=a_receipt(),
+    )
+
+    assert metrics["tool_calls"] == 2
+    assert metrics["tool_calls_by_name"]["workspace_apply"] == 1
+    assert metrics["tool_calls_by_name"]["finalize"] == 1
+    assert metrics["tool_calls_by_name"]["browser_run"] == 0
+
+
+# ---------------------------------------------------------------------------
+# The count and the tokens, read off the only thing that knows them
+# ---------------------------------------------------------------------------
+
+
+def test_the_model_call_count_comes_from_the_receipt():
+    assert _model_calls_of(a_receipt(model_calls=6)) == 6
+
+
+def test_no_receipt_is_a_floor_and_the_row_says_so(real_result):
+    """Zero with no receipt, and two other fields that stop it reading as a fact.
+
+    There is no better answer available -- nothing else in the system counts
+    model calls -- so the honest handling is the one the cost fields already
+    use: report what is known and mark it as not the whole story.
+    """
+    assert _model_calls_of(None) == 0
+
+    metrics = build_agentic_v2_metrics(
+        real_result,
+        standing=a_standing(fully_accounted=False),
+        tool_calls=_tool_calls_of(real_result),
+        model_api_calls=_model_calls_of(None),
+        task_wall_time_ms=1234.0,
+        receipt=None,
+    )
+
+    assert metrics["model_api_calls"] == 0
+    assert metrics["usage_complete"] is False
+    assert metrics["agentic_v2_cost_receipt_status"] == "not_run"
+
+
+def test_a_receipt_with_no_usable_count_is_not_read_as_none_made():
+    for broken in (a_receipt(model_calls=None), a_receipt(model_calls=-1)):
+        assert _model_calls_of(broken) == 0
+
+
+def test_the_tokens_come_from_the_receipts_usage():
+    assert _tokens_of(a_receipt()) == (17_775, 292)
+
+
+def test_missing_tokens_stay_missing_rather_than_becoming_zero():
+    """``None`` and ``0`` are different claims and only one of them is true.
+
+    No V2 call has ever carried zero input tokens -- the task prompt alone is
+    thousands -- so a zero written here would say the model read nothing, which
+    is never what happened. The builder omits the key for ``None``.
+    """
+    assert _tokens_of(None) == (None, None)
+    assert _tokens_of({"status": STATUS_COMPLETE}) == (None, None)
+    assert _tokens_of(a_receipt(usage={"output_tokens": 292})) == (None, 292)
+
+
+@pytest.mark.parametrize(
+    "receipt, present",
+    [
+        (a_receipt(), True),
+        (None, False),
+    ],
+)
+def test_the_token_keys_are_written_only_when_they_are_known(
+    real_result, receipt, present
+):
+    input_tokens, output_tokens = _tokens_of(receipt)
+    metrics = build_agentic_v2_metrics(
+        real_result,
+        standing=a_standing(fully_accounted=present),
+        tool_calls=_tool_calls_of(real_result),
+        model_api_calls=_model_calls_of(receipt),
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        task_wall_time_ms=1234.0,
+        receipt=receipt,
+    )
+
+    assert ("input_tokens" in metrics) is present
+    assert ("output_tokens" in metrics) is present
+
+
+# ---------------------------------------------------------------------------
+# The stand-in that agreed with the reader instead of with the runner
+# ---------------------------------------------------------------------------
+
+
+def test_the_drivers_stand_in_result_is_shaped_like_a_real_one(real_result):
+    """The guard that would have caught this, and now does.
+
+    ``tests/test_agentic_v2_run_driver.py`` fabricates a result rather than
+    booting a backend, which is the right trade for what it tests. What made
+    the defect invisible is that the fabrication was written from the reader
+    rather than from the writer, so reader and stand-in matched and the runner
+    matched neither.
+
+    Checked structurally, not by equality: the stand-in has one tool call and
+    no chain hashes, and demanding a byte-identical record would mean booting a
+    backend in every driver test.
+    """
+    from tests import test_agentic_v2_run_driver as driver_test
+
+    stand_in = driver_test._success("task-0001")["agentic_v2"]
+    real = real_result["agentic_v2"]
+
+    assert "model_api_calls" not in stand_in, (
+        "the stand-in carries a field the metadata verifier forbids; a run "
+        "record cannot look like this"
+    )
+    for event in stand_in["public_trace"]["events"]:
+        assert event["kind"] == EVENT_TOOL_PUBLIC
+        assert set(event["payload"]) == {"result_commitment", "replayed"}
+        assert "tool_name" not in event
+
+    real_event = next(
+        event
+        for event in real["public_trace"]["events"]
+        if event["kind"] == EVENT_TOOL_PUBLIC
+    )
+    stand_in_event = stand_in["public_trace"]["events"][0]
+    assert set(stand_in_event["payload"]) == set(real_event["payload"])

--- a/batch-runner/tests/test_the_receipt_that_knows_what_it_is_missing.py
+++ b/batch-runner/tests/test_the_receipt_that_knows_what_it_is_missing.py
@@ -1,0 +1,497 @@
+"""Whether an unpriceable call reaches the receipt, or stops one step short.
+
+The first Agentic Sandbox V2 stage that reached a real model made 24 calls,
+filed 18, and published five receipts every one of which read ``complete`` with
+an empty ``missing_reasons``. Six calls — a fifth of the bill — were simply not
+in the account, and nothing in the output said so.
+
+`#552 <https://github.com/hyeonsangjeon/gdpval-realworks/pull/552>`_ closed the
+larger half: a reply that reported its usage is now filed as a turn whatever
+the run does next. It left a smaller half open on purpose. A reply that arrives
+with *no* usable count was still charged for and still cannot be priced, and
+that was kept as a number beside the account — ``model_calls_not_counted`` —
+with no consumer anywhere. A count nobody reads does not change a receipt, so
+such a run could still make a call it could not price and publish ``complete``
+for the calls it could.
+
+This module pins the other end of that wire. The chain it walks is the paid
+one, function for function:
+
+    run_model_conversation  →  model_turns_of  →  bind_run_to_ledger
+                            →  CostReceiptLedger.receipt_for
+
+``settle_into_a_receipt`` and ``open_the_ledger`` are imported from the paid
+script rather than reimplemented, because a copy of the paid path is exactly
+what stops being the paid path. Nothing here spends anything: the model is a
+stand-in, the tool desk is a list written in advance, and the ledger is a
+sqlite file in a temporary directory.
+
+Four numbers have to agree, and the run that prompted this had them disagreeing
+in silence:
+
+1. replies the provider sent      (``model_replied`` events)
+2. rows in the ledger             (``cost_calls``)
+3. calls on the task's receipt    (``receipt["model_calls"]``)
+4. the sum of the per-task totals (the grand total)
+"""
+
+from __future__ import annotations
+
+import sys
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from core.agentic_v2_conversation import (
+    AskForTool,
+    ConversationOutcome,
+    GaveUp,
+    LoopLimits,
+    LoopStep,
+    ScriptedToolDesk,
+    ScriptedVoice,
+    StopReason,
+    ToolOutcome,
+    run_model_conversation,
+)
+from core.agentic_v2_conversation_runner import model_turns_of
+from core.agentic_v2_run_report import STATUS_SUCCESS, summarise_v2_run
+from core.agentic_v2_stage_one_budget import StageOneBudget
+from core.cost_receipts import (
+    BUCKET_PROBLEM_SOLVING,
+    REASON_USAGE_ABSENT,
+    STATE_SETTLED,
+    STATUS_COMPLETE,
+    STATUS_PARTIAL,
+    build_receipt,
+)
+
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+for _path in (BATCH_RUNNER_ROOT, BATCH_RUNNER_ROOT / "scripts"):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
+
+import run_agentic_v2_stage as stage  # noqa: E402
+
+
+RUN_ID = "run-receipts-1"
+INPUT_TOKENS = 1_000
+OUTPUT_TOKENS = 100
+
+#: The model the plan pins, and the one the committed price list prices. A
+#: made-up name would settle ``price_missing`` on every row and turn every
+#: receipt ``partial`` for a reason that has nothing to do with what is being
+#: tested here.
+DEPLOYMENT = "gpt-5.4"
+
+
+# ── the stand-in conversation ────────────────────────────────────────────
+
+
+def limits(**changes) -> LoopLimits:
+    settings = {
+        "max_model_turns": 6,
+        "max_written_tokens_per_turn": 2048,
+        "max_seconds": 60.0,
+        "max_repeats_of_one_request": 2,
+        "budget": StageOneBudget(
+            max_model_calls=16,
+            max_input_tokens=1_000_000,
+            max_output_tokens=200_000,
+        ),
+    }
+    settings.update(changes)
+    return LoopLimits(**settings)
+
+
+def ask(call_id: str, tool_name: str, /, **arguments) -> AskForTool:
+    return AskForTool(
+        call_id=call_id,
+        tool_name=tool_name,
+        arguments=arguments,
+        why=f"stand-in model asked for {tool_name}",
+        input_tokens=INPUT_TOKENS,
+        output_tokens=OUTPUT_TOKENS,
+    )
+
+
+def a_run(voice, desk, **limit_changes) -> ConversationOutcome:
+    return run_model_conversation(
+        task_prompt="write a short report",
+        voice=voice,
+        desk=desk,
+        limits=limits(**limit_changes),
+    )
+
+
+def a_conversation_that_reports_everything() -> ConversationOutcome:
+    """Two calls, both counted, both answered. The clean case."""
+    return a_run(
+        ScriptedVoice(
+            replies=[
+                ask("call-1", "capabilities_query", kind="commands"),
+                ask("call-2", "finalize", deliverables=["r.txt"], summary="ok"),
+            ]
+        ),
+        ScriptedToolDesk(
+            answers=[
+                ToolOutcome.worked(commands=[]),
+                # `committed` rather than `worked`: this is what ends the run.
+                # A `worked` finalize leaves the loop asking, the stand-in
+                # voice runs out of written replies, and the extra turn is a
+                # third call that was never meant to be part of the fixture.
+                ToolOutcome.committed({"deliverables": ["r.txt"]}),
+            ]
+        ),
+    )
+
+
+def a_conversation_with_one_uncounted_reply() -> ConversationOutcome:
+    """Two calls, the second of which came back without a usage.
+
+    This is what the real voice does: when a response arrives carrying no
+    ``usage`` block it walks away with a note, and the walk-away's token fields
+    default to zero. Both calls were served and both will be billed.
+    """
+    return a_run(
+        ScriptedVoice(
+            replies=[
+                ask("call-1", "capabilities_query", kind="commands"),
+                GaveUp(note="the model answered without saying what it used"),
+            ]
+        ),
+        ScriptedToolDesk(answers=[ToolOutcome.worked(commands=[])]),
+    )
+
+
+def replies_the_provider_sent(outcome: ConversationOutcome) -> int:
+    """Straight off the event log, which is the half that was always right."""
+    return sum(
+        1 for event in outcome.events if event.step is LoopStep.MODEL_REPLIED
+    )
+
+
+# ── the paid accounting path, run for real ───────────────────────────────
+
+
+@pytest.fixture()
+def ledger(tmp_path):
+    opened = stage.open_the_ledger(tmp_path, run_id=RUN_ID)
+    try:
+        yield opened
+    finally:
+        opened.close()
+
+
+def file_it(ledger, outcome: ConversationOutcome, *, task_id: str, attempt=1):
+    """One task's conversation through the exact calls the paid stage makes."""
+    turns = model_turns_of(
+        outcome,
+        run_id=RUN_ID,
+        task_id=task_id,
+        attempt=attempt,
+        provider="azure",
+        requested_model=DEPLOYMENT,
+        deployment=DEPLOYMENT,
+        resolved_model=DEPLOYMENT,
+    )
+    return stage.settle_into_a_receipt(ledger, task_id=task_id, model_turns=turns)
+
+
+def rows_in(ledger, task_id: str):
+    return ledger.calls_for(task_id, bucket=BUCKET_PROBLEM_SOLVING)
+
+
+# ── the clean case, so the failing one means something ───────────────────
+
+
+def test_a_run_that_counted_everything_gets_a_complete_receipt(ledger):
+    outcome = a_conversation_that_reports_everything()
+    receipt = file_it(ledger, outcome, task_id="task-clean")
+
+    assert outcome.model_calls_not_counted == 0
+    assert receipt["status"] == STATUS_COMPLETE
+    assert receipt["missing_reasons"] == []
+    assert receipt["model_calls"] == replies_the_provider_sent(outcome) == 2
+    assert receipt["estimated_cost_usd"] > 0
+
+
+# ── the case this module exists for ──────────────────────────────────────
+
+
+def test_an_uncounted_call_makes_the_receipt_say_partial(ledger):
+    """The wire, end to end: a count that used to stop at the outcome.
+
+    Before this, the second call was missing from the ledger entirely and the
+    receipt reported one call, one price and ``complete``. The bill was 50%
+    short and said nothing.
+    """
+    outcome = a_conversation_with_one_uncounted_reply()
+    receipt = file_it(ledger, outcome, task_id="task-short")
+
+    assert outcome.model_calls_not_counted == 1
+    assert receipt["status"] == STATUS_PARTIAL
+    assert REASON_USAGE_ABSENT in receipt["missing_reasons"]
+
+
+def test_the_uncounted_call_is_counted_even_though_it_is_not_priced(ledger):
+    """A call with no amount is still a call. Both halves matter.
+
+    Counting it is what makes the receipt's ``model_calls`` match the event
+    log, which is the check that catches this class of gap. Not pricing it is
+    what keeps the total honest — an amount nobody measured must not appear.
+    """
+    outcome = a_conversation_with_one_uncounted_reply()
+    receipt = file_it(ledger, outcome, task_id="task-short")
+
+    assert receipt["model_calls"] == replies_the_provider_sent(outcome) == 2
+    assert receipt["known_cost_usd"] == pytest.approx(
+        float(one_call_at_list_price()), rel=1e-9
+    )
+
+
+def one_call_at_list_price() -> Decimal:
+    """What the single counted call costs, from the committed price list.
+
+    Read rather than written down, so that a price change moves this test with
+    the repository instead of against it.
+    """
+    from core.cost_receipts import load_receipt_price_table
+
+    price = load_receipt_price_table().lookup("azure", DEPLOYMENT)
+    assert price is not None, "the committed list prices azure:gpt-5.4"
+    return (
+        Decimal(INPUT_TOKENS) * price.input_usd_per_million
+        + Decimal(OUTPUT_TOKENS) * price.output_usd_per_million
+    ) / Decimal(1_000_000)
+
+
+def test_the_unpriceable_row_holds_no_amount_and_says_why(ledger):
+    """What is actually written to sqlite, not just what the receipt says."""
+    outcome = a_conversation_with_one_uncounted_reply()
+    file_it(ledger, outcome, task_id="task-short")
+
+    rows = rows_in(ledger, "task-short")
+    assert len(rows) == 2
+    (unpriced,) = [row for row in rows if row["model_cost_usd"] is None]
+
+    assert unpriced["state"] == STATE_SETTLED
+    assert REASON_USAGE_ABSENT in unpriced["missing_reasons"]
+    # Absent, never zero. A zero here is the defect this whole module is about.
+    assert unpriced["input_tokens"] is None
+    assert unpriced["output_tokens"] is None
+    assert "reported no usage" in (unpriced["note"] or "")
+
+
+def test_the_receipt_names_the_call_rather_than_hiding_it_in_a_total(ledger):
+    """A reader has to be able to find which call is missing, not just how many."""
+    outcome = a_conversation_with_one_uncounted_reply()
+    receipt = file_it(ledger, outcome, task_id="task-short")
+
+    (short,) = [
+        component
+        for component in receipt["components"]
+        if component["status"] == STATUS_PARTIAL
+    ]
+    assert REASON_USAGE_ABSENT in short["missing_reasons"]
+
+    # Which turn, by name. Every call in the conversation has a row and the
+    # rows are named by the run's own turn counter, so "the second call is the
+    # one that cannot be priced" is a readable fact rather than a subtraction.
+    rows = {row["call_id"]: row for row in rows_in(ledger, "task-short")}
+    assert set(rows) == {
+        f"{RUN_ID}:task-short:1:turn-1",
+        f"{RUN_ID}:task-short:1:turn-2",
+    }
+    assert rows[f"{RUN_ID}:task-short:1:turn-2"]["model_cost_usd"] is None
+    assert rows[f"{RUN_ID}:task-short:1:turn-1"]["model_cost_usd"] is not None
+
+
+# ── the four numbers that have to agree ──────────────────────────────────
+
+
+def test_events_rows_receipt_and_grand_total_all_agree(ledger):
+    """The reconciliation the paid run could not do, over a mixed cohort.
+
+    Three tasks: one clean, one short a count, one short a count on a retry.
+    Every number is derived from a different object, which is the point — the
+    24-vs-18 run had each of these computed from the same short list, so they
+    agreed with each other and with nothing that happened.
+    """
+    work = {
+        "task-a": a_conversation_that_reports_everything(),
+        "task-b": a_conversation_with_one_uncounted_reply(),
+        "task-c": a_conversation_with_one_uncounted_reply(),
+    }
+    receipts = {
+        task_id: file_it(ledger, outcome, task_id=task_id)
+        for task_id, outcome in work.items()
+    }
+
+    replies = sum(replies_the_provider_sent(o) for o in work.values())
+    rows = sum(len(rows_in(ledger, task_id)) for task_id in work)
+    on_receipts = sum(receipt["model_calls"] for receipt in receipts.values())
+    assert replies == rows == on_receipts == 6
+
+    per_task = sum(
+        Decimal(str(receipt["known_cost_usd"])) for receipt in receipts.values()
+    )
+    whole_run = build_receipt(
+        [
+            row
+            for task_id in ledger.task_ids()
+            for row in rows_in(ledger, task_id)
+        ]
+    )
+    assert per_task == whole_run.known_cost_usd
+    assert whole_run.model_calls == replies
+
+    # And the run as a whole refuses to call itself settled.
+    assert {receipts["task-b"]["status"], receipts["task-c"]["status"]} == {
+        STATUS_PARTIAL
+    }
+    assert receipts["task-a"]["status"] == STATUS_COMPLETE
+    assert whole_run.status == STATUS_PARTIAL
+
+
+def test_the_run_summary_will_not_call_a_short_bill_fully_accounted():
+    """The top of the chain, which was reading only half its evidence.
+
+    ``receipt_ceiling`` comes from the journal, and the journal knows about
+    attempts that vanished. It cannot know about a call the provider billed
+    and did not count — that is a fact about a ledger row. So a run whose every
+    receipt said ``partial`` could still publish
+    ``cost_is_fully_accounted: true``, which is exactly what the first paid
+    stage published over a bill that was a fifth short.
+    """
+    settled = {
+        "status": STATUS_SUCCESS,
+        "problem_solving_cost": {"status": STATUS_COMPLETE},
+        "observability": {"agentic_metrics": {}},
+    }
+    short = {
+        "status": STATUS_SUCCESS,
+        "problem_solving_cost": {
+            "status": STATUS_PARTIAL,
+            "missing_reasons": [REASON_USAGE_ABSENT],
+        },
+        "observability": {"agentic_metrics": {}},
+    }
+
+    clean = summarise_v2_run(
+        [settled, settled], manifest_size=2, receipt_ceiling=STATUS_COMPLETE
+    )
+    assert clean["cost_is_fully_accounted"] is True
+    assert clean["unsettled_receipts"] == {}
+
+    # One short receipt is enough, and the journal is happy in both runs.
+    mixed = summarise_v2_run(
+        [settled, short], manifest_size=2, receipt_ceiling=STATUS_COMPLETE
+    )
+    assert mixed["cost_is_fully_accounted"] is False
+    assert mixed["unsettled_receipts"] == {STATUS_PARTIAL: 1}
+    # The journal's own answer is reported unchanged beside it, so a reader can
+    # tell which of the two lowered the verdict.
+    assert mixed["receipt_ceiling"] == STATUS_COMPLETE
+
+
+def test_a_row_with_no_receipt_is_not_read_as_a_complaint():
+    """Absent is not partial. The journal's ceiling already covers that case."""
+    bare = {"status": STATUS_SUCCESS, "observability": {"agentic_metrics": {}}}
+    summary = summarise_v2_run(
+        [bare], manifest_size=1, receipt_ceiling=STATUS_COMPLETE
+    )
+    assert summary["unsettled_receipts"] == {}
+    assert summary["cost_is_fully_accounted"] is True
+
+
+def test_filing_the_same_conversation_twice_does_not_double_the_bill(ledger):
+    """A resumed round re-offers rows it already wrote. Ids are what stop it.
+
+    The invented id for an uncounted call is derived from the turn number, so
+    it is the same id on the second pass. An id derived from anything mutable —
+    a position in a list, a timestamp — would make a resumed run bill the same
+    uncounted call twice, and neither pass would look wrong on its own.
+    """
+    outcome = a_conversation_with_one_uncounted_reply()
+
+    first = file_it(ledger, outcome, task_id="task-resumed")
+    second = file_it(ledger, outcome, task_id="task-resumed")
+
+    assert len(rows_in(ledger, "task-resumed")) == 2
+    assert first["model_calls"] == second["model_calls"] == 2
+    assert first["known_cost_usd"] == second["known_cost_usd"]
+
+
+def test_two_attempts_at_one_task_are_two_sets_of_rows(ledger):
+    """A retry is more spend, not a correction of the first attempt's spend."""
+    outcome = a_conversation_with_one_uncounted_reply()
+
+    file_it(ledger, outcome, task_id="task-retried", attempt=1)
+    receipt = file_it(ledger, outcome, task_id="task-retried", attempt=2)
+
+    assert len(rows_in(ledger, "task-retried")) == 4
+    assert receipt["model_calls"] == 4
+    assert receipt["status"] == STATUS_PARTIAL
+
+
+# ── the shape of the claim, checked against the loop itself ──────────────
+
+
+def test_every_reply_the_loop_saw_becomes_exactly_one_ledger_row(ledger):
+    """No reply is filed twice and none is dropped, across both kinds.
+
+    Stated against the event log rather than against ``turns``, because
+    ``turns`` is the list that was wrong.
+    """
+    for name, outcome in (
+        ("counted", a_conversation_that_reports_everything()),
+        ("uncounted", a_conversation_with_one_uncounted_reply()),
+    ):
+        turns = model_turns_of(
+            outcome,
+            run_id=RUN_ID,
+            task_id=name,
+            attempt=1,
+            provider="azure",
+            requested_model=DEPLOYMENT,
+            deployment=DEPLOYMENT,
+            resolved_model=DEPLOYMENT,
+        )
+        assert len(turns) == replies_the_provider_sent(outcome)
+        assert len({turn.call_id for turn in turns}) == len(turns)
+
+
+def test_a_reply_that_never_named_its_usage_at_all_is_also_filed(ledger):
+    """The other way a count goes missing: a reply with no usage to read.
+
+    ``GaveUp`` above defaults its counts to zero. This one has no readable
+    usage whatsoever, which the loop stops on — and the reply still arrived,
+    so the provider still billed for it.
+    """
+
+    class AVoiceThatSaysNothingAboutUsage:
+        # Every voice has to declare whether asking it costs anything; a voice
+        # that does not is refused before the first call. Declared here so the
+        # run reaches the usage check this test is about.
+        makes_paid_calls = False
+
+        def next_turn(self, request):
+            return AskForTool(
+                call_id="call-1",
+                tool_name="capabilities_query",
+                arguments={"kind": "commands"},
+                why="no counts",
+                input_tokens=-1,
+                output_tokens=OUTPUT_TOKENS,
+            )
+
+    outcome = a_run(AVoiceThatSaysNothingAboutUsage(), ScriptedToolDesk())
+    assert outcome.stop_reason is StopReason.MODEL_REPLY_UNUSABLE
+
+    receipt = file_it(ledger, outcome, task_id="task-unreadable")
+    assert receipt["model_calls"] == replies_the_provider_sent(outcome) == 1
+    assert receipt["status"] == STATUS_PARTIAL
+    assert REASON_USAGE_ABSENT in receipt["missing_reasons"]

--- a/batch-runner/tests/test_the_record_was_written_after_the_client_was_shut.py
+++ b/batch-runner/tests/test_the_record_was_written_after_the_client_was_shut.py
@@ -235,7 +235,7 @@ def test_a_price_list_that_will_not_load_is_reported_and_not_raised(monkeypatch)
     def refuse(*_args, **_kwargs):
         raise ValueError("the price list is not yaml any more")
 
-    monkeypatch.setattr(runner, "load_price_table", refuse)
+    monkeypatch.setattr(runner, "load_provider_price_table", refuse)
     problems = runner.the_paid_setup_a_dry_run_can_reach("advance_check_5")
 
     assert len(problems) == 1

--- a/batch-runner/tests/test_two_price_lists_in_one_file.py
+++ b/batch-runner/tests/test_two_price_lists_in_one_file.py
@@ -1,0 +1,375 @@
+"""One file, two price lists, and the voice was reading the wrong one.
+
+Measured, not supposed. ``experiments/execution_envelope/model_price_table.json``
+holds two blocks of rates for the same models:
+
+* ``models.gpt-5.4`` — $1.25 in, $5.00 out per million. No source, no review
+  date. The file's own note records that on 2026-08-29 every figure in this
+  block was checked against the Azure Retail Prices API and **none of them
+  matched a published meter**.
+* ``providers.azure:gpt-5.4`` — $2.50 in, $15.00 out per million, with the
+  three meter names it was read from, the API it was read from, and the date.
+
+The cost ledger has always read the second. The voice read the first, so the
+run record and the sqlite ledger written by the same run priced the same calls
+at two different rates — a factor of two on input and three on output.
+
+Neither figure was marked as doubtful, and the run record's docstring said the
+two were computed from "the same list", differing only in the key. Same file,
+different block.
+
+The fix is a loader, not an edit to the price list. The list is shared and its
+bytes are fingerprinted into receipts, so changing it would invalidate the
+provenance of records that are already written. ``load_provider_price_table``
+reads the sourced block and keys it the way the voice looks things up.
+
+Three scripts build a paid Azure client and price what they spend — the V2
+stage and the two probes — and all three read the unsourced block. The swap is
+applied to all three, and the constant naming the provider lives beside the
+loader rather than being copied into each.
+
+What is *not* swapped, deliberately: ``estimate_cost_ceiling``. That is a
+pre-run figure and the planning block is what the pre-registration's approved
+amounts were computed from. Moving it would move a number that has already been
+approved, which is a different decision from fixing what a run reports about
+calls it has already made.
+
+What is pinned here
+-------------------
+
+* the sourced rates are what the voice's loader returns,
+* the two blocks really do disagree, so this is a measurement and not a story,
+* the voice and the ledger now reach the *same* figure on the same tokens,
+* a rate with no source or no review date is refused,
+* a model this provider does not price is left out rather than borrowed from
+  the unsourced block — missing stays partial and never becomes a number,
+* all three paid voices moved, and the ceiling did not.
+
+Nothing here calls a model or opens a network connection.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+SCRIPTS = BATCH_RUNNER_ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import run_agentic_v2_stage as stage  # noqa: E402
+from core.cost_receipts import (  # noqa: E402
+    CallUsage,
+    load_receipt_price_table,
+    price_call,
+)
+from core.execution_envelope_cost import (  # noqa: E402
+    PRICE_TABLE_PATH,
+    load_price_table,
+    load_provider_price_table,
+)
+
+# What the six calls the first paid stage never filed actually carried.
+UNFILED_INPUT_TOKENS = 17_775
+UNFILED_OUTPUT_TOKENS = 292
+
+PINNED_MODEL = "gpt-5.4"
+
+#: Every script that builds a paid client and prices what it spends.
+#:
+#: All three had the same line. The defect was found reading the first.
+PAID_VOICES = (
+    "run_agentic_v2_stage.py",
+    "run_agentic_stage_a_probe.py",
+    "run_agentic_stage_d_probe.py",
+)
+
+
+def a_price_list(tmp_path: Path, providers: dict) -> Path:
+    """A committed-shaped file holding only what a case needs."""
+    document = {
+        "schema_version": "execution-envelope-price-table-v1",
+        "currency": "USD",
+        "unit": "per 1,000,000 tokens",
+        "models": {
+            "a-model": {
+                "input_usd_per_million": "1.00",
+                "output_usd_per_million": "2.00",
+            }
+        },
+        "cost_receipt_schema_version": "cost-receipt-price-table-v1",
+        "providers": providers,
+    }
+    target = tmp_path / "model_price_table.json"
+    target.write_text(json.dumps(document), encoding="utf-8")
+    return target
+
+
+def a_sourced_entry(**changes) -> dict:
+    entry = {
+        "input_usd_per_million": "2.50",
+        "cached_input_usd_per_million": "0.25",
+        "output_usd_per_million": "15.00",
+        "reasoning_billed_as": "output",
+        "source": "https://prices.azure.com/api/retail/prices",
+        "last_reviewed": "2026-08-29",
+        "currency": "USD",
+        "unit": "per 1,000,000 tokens",
+    }
+    entry.update(changes)
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# The two blocks, as committed
+# ---------------------------------------------------------------------------
+
+
+def test_the_voices_price_list_is_the_one_with_a_source():
+    prices = load_provider_price_table("azure")
+
+    assert PINNED_MODEL in prices
+    assert prices[PINNED_MODEL].input_usd_per_million == Decimal("2.50")
+    assert prices[PINNED_MODEL].output_usd_per_million == Decimal("15.00")
+
+
+def test_the_sourced_rates_are_the_ones_in_the_committed_file():
+    """Read straight out of the file, so this cannot pass on a stale constant."""
+    document = json.loads(PRICE_TABLE_PATH.read_text(encoding="utf-8"))
+    entry = document["providers"][f"azure:{PINNED_MODEL}"]
+
+    assert entry["source"].startswith("https://prices.azure.com/")
+    assert entry["last_reviewed"]
+    assert set(entry["meters"]) == {"input", "cached_input", "output"}
+
+    prices = load_provider_price_table("azure")
+    assert prices[PINNED_MODEL].input_usd_per_million == Decimal(
+        entry["input_usd_per_million"]
+    )
+
+
+def test_the_two_blocks_in_the_one_file_disagree():
+    """The measurement the rest of this file rests on.
+
+    If these ever come to agree the disagreement is over and several of the
+    comments in this repository need rewriting -- so this test failing would be
+    good news that still has to be read.
+    """
+    planning = load_price_table()[PINNED_MODEL]
+    sourced = load_provider_price_table("azure")[PINNED_MODEL]
+
+    assert planning.input_usd_per_million == Decimal("1.25")
+    assert planning.output_usd_per_million == Decimal("5.00")
+    assert sourced.input_usd_per_million == planning.input_usd_per_million * 2
+    assert sourced.output_usd_per_million == planning.output_usd_per_million * 3
+
+
+# ---------------------------------------------------------------------------
+# What the two records now say about the same calls
+# ---------------------------------------------------------------------------
+
+
+def test_the_voice_and_the_ledger_reach_the_same_figure():
+    """Two separate paths, same tokens, same amount.
+
+    The voice multiplies through ``ModelPrice.cost_of``; the ledger goes
+    through ``price_call``, which slices cached and audio tokens out first.
+    The V2 voice reports neither, so the slices are empty and the two
+    arithmetics have to land on the same Decimal -- not on a rounding of it.
+    """
+    usage = CallUsage(
+        input_tokens=UNFILED_INPUT_TOKENS, output_tokens=UNFILED_OUTPUT_TOKENS
+    )
+
+    by_the_voice = load_provider_price_table("azure")[PINNED_MODEL].cost_of(
+        input_tokens=usage.input_tokens, output_tokens=usage.output_tokens
+    )
+    by_the_ledger = price_call(
+        load_receipt_price_table().lookup("azure", PINNED_MODEL), usage
+    )
+
+    assert by_the_ledger.missing_reasons == ()
+    assert by_the_ledger.cost_usd == by_the_voice
+
+
+def test_the_old_list_would_have_reached_a_different_one():
+    """What the disagreement was worth, on the tokens that were measured."""
+    usage = CallUsage(
+        input_tokens=UNFILED_INPUT_TOKENS, output_tokens=UNFILED_OUTPUT_TOKENS
+    )
+    by_the_ledger = price_call(
+        load_receipt_price_table().lookup("azure", PINNED_MODEL), usage
+    ).cost_usd
+    by_the_planning_block = load_price_table()[PINNED_MODEL].cost_of(
+        input_tokens=usage.input_tokens, output_tokens=usage.output_tokens
+    )
+
+    assert by_the_planning_block < by_the_ledger
+    # Stated rather than asserted to a rounded literal: the ratio moves if the
+    # token mix moves, and the point is the direction and the order.
+    assert by_the_ledger > by_the_planning_block * Decimal("1.9")
+
+
+# ---------------------------------------------------------------------------
+# What the loader refuses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("missing", ["source", "last_reviewed"])
+def test_a_rate_nobody_can_trace_is_refused(tmp_path, missing):
+    path = a_price_list(
+        tmp_path, {f"azure:{PINNED_MODEL}": a_sourced_entry(**{missing: ""})}
+    )
+
+    with pytest.raises(ValueError) as refusal:
+        load_provider_price_table("azure", path)
+
+    assert missing in str(refusal.value)
+
+
+@pytest.mark.parametrize("field", ["input_usd_per_million", "output_usd_per_million"])
+def test_a_rate_with_a_side_missing_is_refused(tmp_path, field):
+    entry = a_sourced_entry()
+    del entry[field]
+    path = a_price_list(tmp_path, {f"azure:{PINNED_MODEL}": entry})
+
+    with pytest.raises(ValueError) as refusal:
+        load_provider_price_table("azure", path)
+
+    assert field in str(refusal.value)
+
+
+def test_a_provider_nobody_priced_is_refused_rather_than_guessed(tmp_path):
+    path = a_price_list(tmp_path, {f"azure:{PINNED_MODEL}": a_sourced_entry()})
+
+    with pytest.raises(ValueError) as refusal:
+        load_provider_price_table("some-other-cloud", path)
+
+    assert "some-other-cloud" in str(refusal.value)
+
+
+def test_a_model_this_provider_does_not_price_is_left_out_not_borrowed(tmp_path):
+    """The important negative: no fallback to the unsourced block.
+
+    ``a-model`` is in the planning block of the stand-in file and in no
+    provider's. Filling it in from there would turn a call this repository
+    cannot price into a number, which is the whole defect wearing a different
+    hat.
+    """
+    path = a_price_list(tmp_path, {f"azure:{PINNED_MODEL}": a_sourced_entry()})
+
+    prices = load_provider_price_table("azure", path)
+
+    assert "a-model" in load_price_table(path)
+    assert "a-model" not in prices
+
+
+def test_a_key_that_names_no_provider_is_refused(tmp_path):
+    path = a_price_list(tmp_path, {PINNED_MODEL: a_sourced_entry()})
+
+    with pytest.raises(ValueError) as refusal:
+        load_provider_price_table("azure", path)
+
+    assert "provider:model" in str(refusal.value)
+
+
+@pytest.mark.parametrize("bad", ["", "  ", "azure:gpt-5.4"])
+def test_the_argument_names_a_provider_not_a_price_key(bad):
+    with pytest.raises(ValueError) as refusal:
+        load_provider_price_table(bad)
+
+    assert "provider" in str(refusal.value)
+
+
+def test_a_file_written_for_another_schema_is_refused(tmp_path):
+    document = json.loads(
+        a_price_list(
+            tmp_path, {f"azure:{PINNED_MODEL}": a_sourced_entry()}
+        ).read_text(encoding="utf-8")
+    )
+    document["cost_receipt_schema_version"] = "something-else-v9"
+    target = tmp_path / "wrong_schema.json"
+    target.write_text(json.dumps(document), encoding="utf-8")
+
+    with pytest.raises(ValueError) as refusal:
+        load_provider_price_table("azure", target)
+
+    assert "something-else-v9" in str(refusal.value)
+
+
+# ---------------------------------------------------------------------------
+# That the paid stage is the thing that changed
+# ---------------------------------------------------------------------------
+
+
+def test_the_paid_stage_names_the_provider_it_is_billed_by():
+    assert stage.PAID_VOICE_PRICE_PROVIDER == "azure"
+    assert (
+        stage.PAID_VOICE_PRICE_PROVIDER
+        in load_receipt_price_table().models[f"azure:{PINNED_MODEL}"].key
+    )
+
+
+def test_the_constant_lives_beside_the_loader_and_is_not_copied():
+    """One definition, imported by three scripts.
+
+    It was a local in the V2 stage first. Two more scripts build the same Azure
+    client and price their own calls, so a second and third copy of the string
+    was the obvious next step and the wrong one: a copy is something that can
+    disagree, which is the defect this whole file is about.
+    """
+    from core import execution_envelope_cost
+
+    for script in PAID_VOICES:
+        source = (SCRIPTS / script).read_text(encoding="utf-8")
+        assert (
+            'PAID_VOICE_PRICE_PROVIDER = "' not in source
+        ), f"{script} defines its own copy of the constant"
+
+    assert execution_envelope_cost.PAID_VOICE_PRICE_PROVIDER == "azure"
+
+
+@pytest.mark.parametrize("script", PAID_VOICES)
+def test_a_paid_voice_reads_the_sourced_block_and_not_the_planning_one(script):
+    """A regression guard on the swap, not on the loader.
+
+    The two loaders' names are close enough to swap back by accident -- the
+    module docstring at the call site says so -- and the free job and the paid
+    run have to move together, or the dry run certifies a loader the paid run
+    does not use.
+
+    Parametrised over all three because the defect was found in one of them and
+    the other two had the same line. A fix applied to only the script that was
+    being read at the time is how this shape keeps coming back.
+    """
+    source = (SCRIPTS / script).read_text(encoding="utf-8")
+
+    assert "load_price_table()" not in source
+    assert "load_provider_price_table(PAID_VOICE_PRICE_PROVIDER)" in source
+
+
+def test_the_ceiling_still_reads_the_planning_block():
+    """The negative half of the swap, and it is deliberate.
+
+    ``estimate_cost_ceiling`` is a *pre-run* figure and the planning block is
+    what the pre-registration's approved amounts were computed from. Swapping it
+    here would move a number that has already been approved, which is a
+    different decision from fixing what a run reports about calls it made. The
+    block is wrong for that purpose too -- the file's own note says it
+    understates a ceiling by between two and twelve times -- and that is
+    recorded separately rather than folded in here.
+    """
+    from core import execution_envelope_cost
+
+    source = Path(execution_envelope_cost.__file__).read_text(encoding="utf-8")
+    ceiling = source[source.index("def estimate_cost_ceiling(") :]
+
+    assert "else load_price_table()" in ceiling[: ceiling.index("\n    unpriced")]


### PR DESCRIPTION
## 무엇이 문제였는가

유료 V2 단계는 모델 호출에 대한 모든 것을 **답이 돌아온 뒤에** 적습니다.
토큰도, 금액도, 어떤 도구를 불렀는지도 전부 그렇습니다. 끝까지 돌아온
실행에는 문제가 없지만, 요청이 나간 뒤 답이 오기 전에 멈춘 실행에는 아무
값어치가 없습니다. 그렇게 멈추는 길은 평범한 것으로 셋입니다.

- `timeout-minutes`를 넘긴 샤드는 그 자리에서 죽습니다
- 요청과 응답 사이의 예외는 모든 기록 지점을 지나쳐 풀립니다
- 재개한 실행은 죽은 시도를 모르는 새 저널에서 시작합니다

셋 다 공급자는 이미 요청을 받았고 청구도 합니다. 그런데 원장은 비어 있고,
**빈 원장은 "호출이 없었다"와 글자 그대로 같은 문장**입니다.

## 관측 — 실행 34660739834 아티팩트에서 직접 센 값

`advance_check_5`, 2026-09-12 00:10, 워크플로 결론 `success`.

| | |
|---|---|
| 대화 | 7개 (과제 5개, 한 과제는 3회 시도) |
| 모델 응답 | **24회** |
| 원장 행 | **18개** |
| 기록되지 않은 응답 | **6회** |
| 빠진 토큰 | 입력 17,775 / 출력 292 — 입력의 **26.3%** |

빠진 6회는 무작위가 아닙니다.

```
0112fc9b#1  stop=finished_normally  replies=7  filed=7  missing=[]
02aa1805#1  stop=tool_desk_broke    replies=3  filed=2  missing=[3]
0818571f#1  stop=tool_desk_broke    replies=3  filed=2  missing=[3]
2ea2e5b5#1  stop=tool_desk_broke    replies=3  filed=2  missing=[3]
2ea2e5b5#2  stop=tool_desk_broke    replies=2  filed=1  missing=[2]
2ea2e5b5#3  stop=tool_desk_broke    replies=3  filed=2  missing=[3]
3baa0009#1  stop=tool_desk_broke    replies=3  filed=2  missing=[3]
```

정상 종료한 대화 하나는 7회를 모두 남겼고, `tool_desk_broke`로 끝난 여섯 개가
각각 **마지막 응답 정확히 하나씩**을 잃었습니다. 턴 기록이 도구 응답 이후에
붙는데 `tool_desk_broke`는 도구가 답하지 않은 자리이기 때문입니다.

그 실행은 그 상태로 receipt 다섯 장을 전부 `complete`, `missing_reasons`를 전부
빈 배열, `cost_is_fully_accounted`를 `true`로 발행했습니다. **모자란 것보다
모자란 채로 확신한 것이 문제입니다.**

## 무엇을 바꿨는가

1. **호출 전 예약.** `run_model_conversation`에 `before_model_call` 훅이 생기고,
   요청이 나가기 **직전에** 금액 없는 예약 행을 씁니다. 정산되지 않은 예약은
   `call_reachability_unknown`이 되고 receipt를 `partial`로 묶습니다. 훅이
   실패하면 호출 자체를 하지 않습니다 — 적어둘 수 없는 지출은 하지 않습니다.

2. **호출 id를 모델의 응답 id에서 실행 자신의 턴 번호로** 바꿨습니다
   (`{run_id}:{task_id}:{attempt}:turn-{n}`). 예약 시점에는 모델의 id가 아직
   없고, 모델이 정하는 기본키는 모델이 망가뜨릴 수 있는 기본키입니다.
   `ledger_call_id()` 하나를 예약과 정산이 같이 쓰므로 철자가 갈릴 수 없습니다.
   갈리면 호출 하나가 열린 행과 값 매겨진 행으로 두 번 나타나고, 합계는 두 배가
   되는데 개별 행은 저마다 멀쩡해 보입니다.

3. **`summarise_v2_run`이 receipt의 `status`도 읽습니다.** 이전에는 저널의
   ceiling만 보고 `cost_is_fully_accounted`를 정했는데, 저널은 사라진 시도는
   알아도 청구되고 계산되지 않은 호출은 모릅니다. `unsettled_receipts`가 새로
   나갑니다.

4. **`usage`를 말하지 않은 응답**은 `counted=False`인 `MODEL_REPLIED` 이벤트로
   남고, `0`이 아니라 **부재**로 원장에 들어갑니다. `0`은 측정한 값처럼 읽히고
   `complete` receipt 위에서 `$0.00`으로 정산됩니다.

5. **`reserve()`가 기존 행의 NULL note만 채웁니다.** 덮어쓰지 않습니다. 예약이
   note 없이 먼저 쓰이고 정산이 사유를 채우는 순서라서 필요합니다. 덕분에 유료
   경로의 행과 무료 경로의 행이 글자까지 같습니다.

## 검증

`tests/test_a_call_booked_before_it_goes_out.py` (신규, 10개)가 유료 경로를
함수 단위로 그대로 지나갑니다.

```
reserve_before_each_call → run_model_conversation(before_model_call=…)
                         → model_turns_of → settle_into_a_receipt
```

`open_the_ledger`와 `settle_into_a_receipt`는 유료 스크립트에서 그대로
가져옵니다. 유료 경로의 사본은 더 이상 유료 경로가 아니기 때문입니다.

- 예약이 요청보다 먼저 있는지를 **요청 안에서** 확인합니다 (나중에 보면
  전후를 구분할 수 없고, "나중"이 바로 이 결함입니다)
- `Exception`이 아닌 `BaseException`으로 죽인 실행이 두 호출을 모두 남깁니다
  — 루프가 잡을 수 없으므로 남은 것은 전부 호출 전에 쓰인 것입니다
- 예외로 끊긴 턴은 `reserved`, 답이 온 턴은 `settled`로 남습니다
- 취소된 실행이 이미 한 호출을 **같은 행에** 정산합니다
- 재개는 행도 금액도 늘리지 않습니다
- 죽은 시도의 예약은 다음 시도가 성공해도 열린 채로 남고 receipt는 `partial`

### 재개한 실행이 `partial`로 남는 것은 결함이 아닙니다

죽은 시도가 얼마였는지 그 실행은 **모릅니다**. 아는 만큼은 `known_cost_usd`로
바닥값으로 발행되고, 모르는 부분은 사유와 함께 남습니다.

### 이 PR이 하지 않는 것

- `exec_run`은 그대로 닫혀 있습니다. 격리 백엔드는 여전히
  `AgenticV2FixtureBackend`이고, `browser_run`은 `capability_unavailable`입니다
  (실제 Firecracker는 모델 구독의 부팅 호스트에 `write` 권한 3개가 없어 막혀
  있습니다 — 실행 34549220652)
- 채점은 건드리지 않습니다. 원장은 전부 problem-solving 버킷입니다
- 가격표 JSON은 바꾸지 않았습니다 (A의 실행과 공유)
- `cost_runtime`은 여전히 0행입니다. `bind_run_to_ledger`의 `guest_runtime`
  인자에 생산자가 없습니다. 게스트가 뜨지 않는 지금은 정직한 0이고, 실제
  격리가 생기는 순간 구멍이 됩니다. 별도 건입니다

## 검사

- 백엔드 전체 **11,402 passed, 18 skipped, 0 failed** (24:06)
- 바꾼 다섯 파일에 **mypy 오류 0** (저장소 전체 기준선 88개는 전부 손대지 않은
  파일들, `scripts/`는 CI가 타입 검사하지 않으므로 직접 돌렸습니다)
