### PR TITLE
거부된 샤드도 자기가 무엇을 맡았는지는 남깁니다

### DIFF
--- a/batch-runner/core/agentic_v2_run_driver.py
+++ b/batch-runner/core/agentic_v2_run_driver.py
@@ -183,6 +183,50 @@ class RunOutcome:
         }
 
 
+#: What a refused shard's halt is called in its record.
+#:
+#: Deliberately not one of the eight ``STOP_RULES``.
+#: :func:`~core.agentic_v2_shard_collection._rule_index_of` will not place it,
+#: and :func:`~core.agentic_v2_shard_collection.siblings_that_stopped_the_run`
+#: treats a rule it cannot place as a fact about the whole run rather than
+#: about one shard. That is the right reading here and not a side effect: a
+#: driver refuses on the *shape* of what a backend handed back, and the backend
+#: is the same checked-out code in every job -- so a shard about to start will
+#: be handed the same shape. At ``max-parallel: 4`` that bounds a refusal in
+#: the two hundred and twenty to about four shards' spend instead of
+#: seventeen.
+DRIVER_REFUSED_RULE = "the run driver refused to carry on"
+
+
+def the_run_was_refused(
+    refusal: BaseException | None, *, run_id: str
+) -> dict[str, Any]:
+    """The ``run`` block for a shard whose driver would not go on.
+
+    Shaped like :meth:`RunOutcome.as_dict`, because everything downstream reads
+    that shape and a second shape for the same slot would mean every reader had
+    to know which kind of record it was holding before it could ask anything of
+    it.
+
+    ``results`` and ``summary`` are ``None`` rather than ``[]`` and ``{}``. The
+    driver was part-way through the manifest when it refused, and the rows it
+    had built went with it -- so an empty list here would be a claim that no
+    task ran, published beside a ``journal.jsonl`` that says which ones did and
+    a ledger that says what they cost. ``None`` is the one value that sends a
+    reader to those two instead of answering for them.
+    """
+    return {
+        "run_id": run_id,
+        "results": None,
+        "summary": None,
+        "stopped_early": {
+            "rule": DRIVER_REFUSED_RULE,
+            "detail": str(refusal) if refusal is not None else "",
+        },
+        "skipped_on_resume": None,
+    }
+
+
 def _attempt_once(
     task: TaskToRun,
     *,

--- a/batch-runner/scripts/run_agentic_v2_stage.py
+++ b/batch-runner/scripts/run_agentic_v2_stage.py
@@ -89,8 +89,10 @@ from core.agentic_v2_route_check import (  # noqa: E402
 )
 from core.agentic_v2_run_driver import (  # noqa: E402
     DriverRefused,
+    RunOutcome,
     StoppedEarly,
     run_manifest,
+    the_run_was_refused,
 )
 from core.agentic_v2_sharding import ShardRefused  # noqa: E402
 from core.agentic_v2_sharding import parse as parse_shard  # noqa: E402
@@ -924,6 +926,12 @@ def main() -> int:
         )
         prices = load_provider_price_table(PAID_VOICE_PRICE_PROVIDER)
 
+    # Both named before the `try`, because the record below is written on the
+    # way out of either path and a name bound only inside a branch is the same
+    # defect as not writing the record at all.
+    outcome: RunOutcome | None = None
+    refused: DriverRefused | None = None
+
     try:
         if managed is not None:
             wrong_route = check_route_is_the_one_the_plan_fixed(
@@ -1243,8 +1251,16 @@ def main() -> int:
             ),
         )
     except DriverRefused as refusal:
-        print(f"\nThe run was refused.\n\n{refusal}")
-        return 1
+        # Not a `return`. Everything below this line is the record, and a run
+        # that was refused is exactly the run whose record somebody needs: the
+        # shard has already been charged for the tasks it got through, the
+        # ledger holds those amounts, and `journal.jsonl` holds the rows. What
+        # the refusal path alone did not leave behind was `run_record.json` --
+        # and that file is where the shard's own cohort list lives, so without
+        # it `roll_up_agentic_v2_cost.py` cannot tell a task this shard was
+        # never assigned from one it was assigned and never reached. A shard
+        # that stopped became a shard that might never have existed.
+        refused = refusal
     finally:
         if managed is not None:
             managed.close()
@@ -1304,7 +1320,11 @@ def main() -> int:
         ),
         "chosen_settings": chosen.as_dict(),
         "conversations": held.as_dict(),
-        "run": outcome.as_dict(),
+        "run": (
+            outcome.as_dict()
+            if outcome is not None
+            else the_run_was_refused(refused, run_id=run_id)
+        ),
     }
     if rehearsing is not None:
         record["rehearsal"] = rehearsing.as_dict()
@@ -1315,9 +1335,16 @@ def main() -> int:
     name = "rehearsal_record.json" if rehearsing is not None else "run_record.json"
     (into / name).write_text(written + "\n", encoding="utf-8")
 
-    summary = outcome.summary
+    summary = outcome.summary if outcome is not None else {}
     print()
     print(f"  record         {into / name}")
+    if outcome is None:
+        # The amount before the refusal, in that order and on purpose. A shard
+        # that refused still spent whatever it spent up to that point, and a
+        # reader shown only the refusal will assume it spent nothing.
+        print(f"  spent          {held.spent}")
+        print(f"\nThe run was refused.\n\n{refused}")
+        return 1
     print(f"  finished       {summary.get('succeeded', 0)} of {len(tasks_to_run)}")
     if rehearsing is not None:
         found = rehearsing.as_dict()

--- a/batch-runner/tests/test_a_refused_shard_still_says_what_it_was_told_to_run.py
+++ b/batch-runner/tests/test_a_refused_shard_still_says_what_it_was_told_to_run.py
@@ -1,0 +1,298 @@
+"""What a shard leaves behind when its driver will not carry on.
+
+Three files come out of a paid V2 shard and the artifact upload takes all of
+them: ``journal.jsonl`` as the tasks finish, the sqlite ledger as the calls
+settle, and ``run_record.json`` at the very end. Only the third says which
+tasks *this* shard was told to run.
+
+``DriverRefused`` is raised in three places and one of them is mid-run:
+:mod:`core.agentic_v2_run_driver` refuses a backend that hands back something
+that is not a result envelope, and it does that *after* ``runner.run`` has
+returned — that is, after the model was asked and the provider billed. The
+stage script caught it, printed it and returned, and the ``record = {...}``
+block sits below that return. So a shard that refused on task seven of ten
+uploaded a journal, a ledger and no record.
+
+What that costs, precisely, because it is not the money:
+
+* :func:`~core.agentic_v2_shard_collection.stage_problems` reads
+  ``shard.task_ids`` out of the record to decide coverage. With no record the
+  shard's tasks read as *nobody was assigned these*, which is a different
+  sentence from *these were assigned and not reached*.
+* :func:`scripts.roll_up_agentic_v2_cost.read_records` reads the same field for
+  the same reason, and says so in its own docstring: losing a record costs the
+  cohort list, not the amounts.
+* :func:`~core.agentic_v2_shard_collection.siblings_that_stopped_the_run` reads
+  ``run.stopped_early`` so that a shard which has not started yet can decline
+  to. A refusal that wrote nothing was invisible to it, and the waves after it
+  started and spent.
+
+So the refusal writes the record too, and this module pins both halves: that
+the handler does not return before it, and that what it writes is a record the
+existing readers understand.
+
+Nothing here spends anything.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from core.agentic_v2_run_driver import (
+    DRIVER_REFUSED_RULE,
+    DriverRefused,
+    RunOutcome,
+    the_run_was_refused,
+)
+from core.agentic_v2_shard_collection import (
+    RUN_RECORD_NAME,
+    read_shard_records,
+    siblings_that_stopped_the_run,
+    stage_problems,
+)
+
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+STAGE_SCRIPT = BATCH_RUNNER_ROOT / "scripts" / "run_agentic_v2_stage.py"
+for _path in (BATCH_RUNNER_ROOT, BATCH_RUNNER_ROOT / "scripts"):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
+
+RUN_ID = "run-refused-1"
+THE_SHARD_RAN = ("task-a", "task-b", "task-c")
+THE_OTHER_SHARD_RAN = ("task-d", "task-e")
+
+
+# ── the block the record is built from ───────────────────────────────────
+
+
+def test_the_refusal_block_is_the_shape_every_reader_already_knows():
+    """One shape for the ``run`` slot, or every reader needs a type check first."""
+    refused = the_run_was_refused(DriverRefused("the backend returned str"),
+                                  run_id=RUN_ID)
+    finished = RunOutcome(run_id=RUN_ID).as_dict()
+
+    assert set(refused) == set(finished)
+    assert refused["run_id"] == RUN_ID
+
+
+def test_what_was_not_measured_is_none_and_not_an_empty_list():
+    """``[]`` would be a claim. The journal beside it is the real answer.
+
+    The driver was part-way through the manifest, so some tasks ran and their
+    rows went with the exception. An empty ``results`` published beside a
+    journal full of rows is the reassuring reading of a disagreement, which is
+    the one that must not be written.
+    """
+    refused = the_run_was_refused(DriverRefused("mid-manifest"), run_id=RUN_ID)
+
+    assert refused["results"] is None
+    assert refused["summary"] is None
+    assert refused["skipped_on_resume"] is None
+    # And the finished path still says the opposite, so the difference means
+    # something rather than being two ways of writing the same silence.
+    assert RunOutcome(run_id=RUN_ID).as_dict()["results"] == []
+
+
+def test_the_refusal_carries_the_reason_rather_than_only_the_fact():
+    refused = the_run_was_refused(
+        DriverRefused("the runner returned str for 'task-b'"), run_id=RUN_ID
+    )
+    halt = refused["stopped_early"]
+
+    assert halt["rule"] == DRIVER_REFUSED_RULE
+    assert "task-b" in halt["detail"]
+
+
+def test_a_refusal_with_nothing_to_say_still_halts():
+    """``None`` in, a halt out. A missing reason must not read as no halt."""
+    halt = the_run_was_refused(None, run_id=RUN_ID)["stopped_early"]
+
+    assert halt["rule"] == DRIVER_REFUSED_RULE
+    assert halt["detail"] == ""
+
+
+# ── what the readers do with it ──────────────────────────────────────────
+
+
+def a_record(*, task_ids, index, of, run) -> dict:
+    """A shard record with the fields the collection code actually reads."""
+    return {
+        "stage": "trial_30",
+        "run_id": RUN_ID,
+        "binding": {"task_ids": list(THE_SHARD_RAN + THE_OTHER_SHARD_RAN)},
+        "shard": {
+            "index": index,
+            "of": of,
+            "task_count": len(task_ids),
+            "cohort_size": len(THE_SHARD_RAN + THE_OTHER_SHARD_RAN),
+            "task_ids": list(task_ids),
+        },
+        "run": run,
+    }
+
+
+def written(tmp_path: Path, name: str, record: dict) -> Path:
+    folder = tmp_path / name
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / RUN_RECORD_NAME).write_text(json.dumps(record), encoding="utf-8")
+    return folder
+
+
+@pytest.fixture()
+def one_refused_one_finished(tmp_path: Path) -> Path:
+    written(
+        tmp_path,
+        "agentic-v2-trial_30-shard-1-of-2",
+        a_record(
+            task_ids=THE_SHARD_RAN,
+            index=1,
+            of=2,
+            run=the_run_was_refused(
+                DriverRefused("the runner returned str for 'task-b'"),
+                run_id=RUN_ID,
+            ),
+        ),
+    )
+    written(
+        tmp_path,
+        "agentic-v2-trial_30-shard-2-of-2",
+        a_record(
+            task_ids=THE_OTHER_SHARD_RAN,
+            index=2,
+            of=2,
+            run=RunOutcome(run_id=RUN_ID).as_dict(),
+        ),
+    )
+    return tmp_path
+
+
+def test_the_refused_shards_tasks_are_still_known_to_have_been_assigned(
+    one_refused_one_finished,
+):
+    """The whole point of writing the file. Coverage can see the cohort again."""
+    records = read_shard_records(one_refused_one_finished)
+    assert len(records) == 2
+
+    assigned = [
+        task_id
+        for _, record in records
+        for task_id in record["shard"]["task_ids"]
+    ]
+    assert sorted(assigned) == sorted(THE_SHARD_RAN + THE_OTHER_SHARD_RAN)
+
+
+def test_the_stage_is_not_called_run_and_the_refusal_is_the_reason(
+    one_refused_one_finished,
+):
+    """Named, not merely missing. Both are failures; only one is diagnosable."""
+    records = read_shard_records(one_refused_one_finished)
+    problems = stage_problems(
+        records, task_ids=list(THE_SHARD_RAN + THE_OTHER_SHARD_RAN)
+    )
+
+    assert problems
+    joined = " ".join(problems)
+    assert DRIVER_REFUSED_RULE in joined
+    assert "task-b" in joined
+
+
+def test_a_shard_that_has_not_started_declines_to(one_refused_one_finished):
+    """The saving, and the reason the rule is deliberately unplaceable.
+
+    A driver refuses on the shape of what a backend returned, and the backend
+    is the same checked-out code in every job. ``_rule_index_of`` cannot place
+    this rule, and an unplaceable rule is treated as a fact about the whole
+    run — so the next wave does not start.
+    """
+    records = read_shard_records(one_refused_one_finished)
+    reasons = siblings_that_stopped_the_run(records)
+
+    assert len(reasons) == 1
+    assert "cannot place" in reasons[0]
+    assert "task-b" in reasons[0]
+
+
+def test_a_stage_where_nothing_refused_lets_the_next_wave_start(tmp_path):
+    """The control. Otherwise the test above passes on a function that always halts."""
+    written(
+        tmp_path,
+        "agentic-v2-trial_30-shard-1-of-1",
+        a_record(
+            task_ids=THE_SHARD_RAN + THE_OTHER_SHARD_RAN,
+            index=1,
+            of=1,
+            run=RunOutcome(run_id=RUN_ID).as_dict(),
+        ),
+    )
+    records = read_shard_records(tmp_path)
+
+    assert siblings_that_stopped_the_run(records) == []
+    assert (
+        stage_problems(records, task_ids=list(THE_SHARD_RAN + THE_OTHER_SHARD_RAN))
+        == []
+    )
+
+
+# ── the regression this module exists to stop ────────────────────────────
+
+
+def the_driver_refused_handler() -> ast.ExceptHandler:
+    """The ``except DriverRefused`` block in the stage script, as parsed.
+
+    Read off the syntax rather than by running ``main``: reaching this handler
+    for real needs a dataset snapshot, a bound cohort, a staged workspace and a
+    backend that misbehaves, and a test that heavy would be skipped long before
+    it was fixed. What can go wrong here is one line — a ``return`` put back
+    above the record — and that is a fact about the tree.
+    """
+    tree = ast.parse(STAGE_SCRIPT.read_text(encoding="utf-8"))
+    handlers = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ExceptHandler)
+        and isinstance(node.type, ast.Name)
+        and node.type.id == "DriverRefused"
+    ]
+    assert len(handlers) == 1, (
+        f"{len(handlers)} `except DriverRefused` handlers in {STAGE_SCRIPT.name}; "
+        "this check names one and would silently cover only the first"
+    )
+    return handlers[0]
+
+
+def test_the_refusal_handler_does_not_return_before_the_record_is_written():
+    """The defect itself, stated as the one line that brings it back.
+
+    ``print(...); return 1`` is what the handler used to be, and the
+    ``record = {...}`` block is below it. Everything else in this module tests
+    what the record says; this tests that there is one.
+    """
+    handler = the_driver_refused_handler()
+    returns = [node for node in ast.walk(handler) if isinstance(node, ast.Return)]
+
+    assert returns == [], (
+        "the `except DriverRefused` handler returns, so the record block below "
+        "it is skipped and a refused shard uploads a journal and a ledger with "
+        "nothing that says which tasks it was told to run"
+    )
+
+
+def test_the_handler_keeps_the_refusal_for_the_record_to_use():
+    """A handler that swallowed it would write a halt with an empty reason."""
+    handler = the_driver_refused_handler()
+    assigned = {
+        target.id
+        for node in ast.walk(handler)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name)
+    }
+
+    assert handler.name, "the exception is not bound to a name"
+    assert assigned, "the handler binds nothing, so the reason cannot reach the record"


### PR DESCRIPTION
## 무엇이 문제였나

유료 V2 샤드는 파일 세 개를 남깁니다. 과제가 끝날 때마다 `journal.jsonl`,
호출이 정산될 때마다 sqlite 원장, 맨 마지막에 `run_record.json`.
이 중 **"이 샤드가 어떤 과제를 맡았는가"를 적는 것은 세 번째뿐**입니다.

`DriverRefused`는 세 곳에서 오르고 그 중 하나는 실행 도중입니다.
`agentic_v2_run_driver`가 결과 봉투가 아닌 것을 돌려준 백엔드를 거부하는데,
그 시점은 `runner.run`이 이미 돌아온 뒤 — 모델에게 묻고 요금이 청구된 뒤입니다.
단계 스크립트는 이것을 잡아서 출력하고 `return` 했고, `record = {...}` 블록은
그 `return` 아래에 있었습니다. **열 개 중 일곱 번째에서 거부된 샤드는
저널과 원장만 올리고 기록은 올리지 않았습니다.**

## 잃는 것은 금액이 아니라 명단입니다

| 읽는 쪽 | 기록에서 읽는 것 | 기록이 없으면 |
|---|---|---|
| `stage_problems` | `shard.task_ids` | 그 과제들이 "아무에게도 배정되지 않았다"로 읽힘 — "배정되었으나 도달하지 못했다"와 다른 문장 |
| `roll_up_agentic_v2_cost.read_records` | 같은 필드 | 코호트 명단을 잃음(금액은 원장에 있음) |
| `siblings_that_stopped_the_run` | `run.stopped_early` | 거부가 보이지 않아 **뒤 물결이 그대로 출발해서 돈을 씀** |

## 고친 것

- `except DriverRefused` 핸들러가 더 이상 기록 블록 위에서 `return` 하지 않습니다.
- `the_run_was_refused()`가 `RunOutcome.as_dict()`와 **같은 모양**의 `run` 블록을
  만듭니다. 슬롯 하나에 모양이 둘이면 모든 독자가 무엇을 들고 있는지 먼저
  확인해야 합니다.
- `results`/`summary`는 `[]`/`{}` 가 아니라 `None`입니다. 드라이버는 매니페스트
  중간에 있었으므로 빈 목록은 "아무 과제도 돌지 않았다"는 **주장**이 되고,
  그 주장이 실제로 돈 행이 든 저널·원장 옆에 실립니다. `None`만이 읽는 쪽을
  그 둘로 보냅니다.
- 거부 출력에 **거부 사유보다 먼저 그때까지 쓴 금액**을 찍습니다. 거부만 본
  사람은 아무것도 안 썼다고 읽습니다.

`DRIVER_REFUSED_RULE`은 일부러 여덟 개 `STOP_RULES` 중 어느 것도 아닙니다.
`_rule_index_of`가 자리를 못 찾는 규칙은 한 샤드가 아니라 실행 전체에 관한
사실로 취급되는데, 여기서는 그 읽기가 맞습니다 — 드라이버는 백엔드가 돌려준
*모양*을 보고 거부하고 백엔드는 모든 잡에서 같은 체크아웃 코드이므로, 곧
시작할 샤드도 같은 모양을 받습니다. `max-parallel: 4`에서 220문제의 거부
손실이 열일곱 샤드가 아니라 네 샤드어치로 묶입니다.

## 검증

- 새 테스트 10개. 마지막 둘은 결함 자체를 AST로 고정합니다 — 핸들러에
  `return`이 다시 들어오면 실패합니다. 실행을 통째로 돌리려면 데이터셋
  스냅숏·바인딩된 코호트·스테이징된 워크스페이스·오작동 백엔드가 필요해서,
  그만큼 무거운 테스트는 고쳐지기 한참 전에 skip 됩니다.
- 백엔드 전체 스위트 **11,457 passed / 18 skipped / 0 failed**.
- 바뀐 두 파일에 대한 mypy 오류 **0건**.

## 이 PR이 쓰지 않은 돈

없습니다. 읽기와 테스트뿐입니다.
