### PR TITLE
권한 조사가 템플릿이 실제로 하는 일을 재게 합니다

### DIFF
--- a/batch-runner/scripts/azure_boot_host_survey.py
+++ b/batch-runner/scripts/azure_boot_host_survey.py
@@ -38,8 +38,8 @@ So the output is one of four answers, and only the first two are good news:
     registered, and the region has quota. A host could be deployed under
     permissions that already exist, with no access change at all.
 ``blocked_and_the_change_is_named``
-    One or more of those three is missing. The report names which, in the exact
-    terms somebody would need to approve it. It does not ask for it.
+    One or more of those preconditions is missing. The report names which, in
+    the exact terms somebody would need to approve it. It does not ask for it.
 ``not_measured``
     ``az`` did not answer. Nothing was learned, and in particular this is *not*
     evidence that anything is absent. A local login reaches a different
@@ -117,18 +117,119 @@ class SurveyRefused(RuntimeError):
 # What a host would need
 # -------------------------------------------------------------------------
 
-#: The three control-plane writes that deploying ``infra/dev-host/main.bicep``
-#: into a subscription would perform. Listed as actions rather than as a role
+SCOPE_RESOURCE_GROUP = "resource_group"
+SCOPE_SUBSCRIPTION = "subscription"
+
+
+@dataclass(frozen=True)
+class NeededAction:
+    """One control-plane action deploying the host definition would perform.
+
+    ``scope`` is the smallest scope an assignment granting it could sit at, and
+    it is the difference between an access change the resource-group owner can
+    make and one that has to be made across the whole subscription.
+
+    ``only_if`` names the condition under which the template performs it at all.
+    An action carrying one is measured like the others but does not block the
+    verdict, because a deployment that never takes that branch never needs it.
+    """
+
+    action: str
+    why: str
+    scope: str = SCOPE_RESOURCE_GROUP
+    only_if: str = ""
+
+    @property
+    def always(self) -> bool:
+        return not self.only_if
+
+
+#: Every control-plane write that deploying ``infra/dev-host/main.bicep``
+#: performs, one entry per resource the template declares, read off the
+#: template rather than chosen here. Listed as actions rather than as a role
 #: name because the question is what the identity *can do*, and two identities
 #: holding different roles can both be able to do this.
-REQUIRED_ACTIONS: tuple[tuple[str, str], ...] = (
-    ("Microsoft.Compute/virtualMachines/write", "create the machine itself"),
-    ("Microsoft.Network/networkInterfaces/write", "give it a network interface"),
-    (
+#:
+#: An earlier version of this list named three actions. That was not the
+#: template's list: it was missing the network security group, the virtual
+#: network, the data disk, the auto-shutdown schedule and the deployment object
+#: itself, so an identity could have passed the survey and still failed the
+#: deployment. The three it did name are still here.
+REQUIRED_ACTIONS: tuple[NeededAction, ...] = (
+    NeededAction(
+        "Microsoft.Resources/deployments/write",
+        "submit the template at all -- a deployment is itself a resource",
+    ),
+    NeededAction(
+        "Microsoft.Network/networkSecurityGroups/write",
+        "create the security group that closes the host to the internet",
+    ),
+    NeededAction(
+        "Microsoft.Network/virtualNetworks/write",
+        "create the network and the subnet the host sits on",
+    ),
+    NeededAction(
+        "Microsoft.Network/networkInterfaces/write",
+        "give it a network interface",
+    ),
+    NeededAction(
+        "Microsoft.Compute/disks/write",
+        "create the data disk the guest images would live on",
+    ),
+    NeededAction(
+        "Microsoft.Compute/virtualMachines/write",
+        "create the machine itself",
+    ),
+    NeededAction(
+        "Microsoft.DevTestLab/schedules/write",
+        "attach the auto-shutdown that stops it billing overnight",
+    ),
+    NeededAction(
+        "Microsoft.Network/publicIPAddresses/write",
+        "give it an address reachable from outside",
+        only_if="attachPublicIp is set, and the template defaults it to false",
+    ),
+    NeededAction(
         "Microsoft.Resources/subscriptions/resourceGroups/write",
-        "put it in a resource group",
+        "create the resource group to put it all in",
+        scope=SCOPE_SUBSCRIPTION,
+        only_if=(
+            "the resource group does not already exist -- deploy.sh creates it "
+            "in a separate step, so an owner who creates it first removes this "
+            "action, and with it the only subscription-scope item on the list"
+        ),
     ),
 )
+
+#: The joins. Creating a resource that attaches to another one needs permission
+#: on *both*, and these are the ones the template's own attachments require.
+#: Kept apart from the writes because they are the reason
+#: ``Virtual Machine Contributor`` alone nearly works: it holds every join here
+#: and only two of the writes above are outside it.
+REQUIRED_JOINS: tuple[NeededAction, ...] = (
+    NeededAction(
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "put the interface on the subnet",
+    ),
+    NeededAction(
+        "Microsoft.Network/networkSecurityGroups/join/action",
+        "apply the security group to that subnet",
+    ),
+    NeededAction(
+        "Microsoft.Network/networkInterfaces/join/action",
+        "attach the interface to the machine",
+    ),
+)
+
+
+def actions_measured() -> tuple[NeededAction, ...]:
+    """Everything the survey asks about, writes first."""
+    return REQUIRED_ACTIONS + REQUIRED_JOINS
+
+
+def actions_that_block() -> tuple[NeededAction, ...]:
+    """The subset a deployment cannot go ahead without, under the defaults."""
+    return tuple(needed for needed in actions_measured() if needed.always)
 
 #: Without this registered, no virtual machine can be created in the
 #: subscription however the roles read. Registering it is itself a write, so it
@@ -363,10 +464,28 @@ def read_quota(
     )
 
 
+def _list_assignments(
+    runner: Callable[[Sequence[str]], Any], rbac: Any, *, principal: str
+) -> tuple[list[Mapping[str, Any]], bool]:
+    """Every assignment this principal holds, group-inherited ones included.
+
+    ``--include-groups`` is asked for first and dropped if the installed CLI
+    will not take it. It matters in one direction only: without it, a grant the
+    identity holds through a group is invisible, and this survey's "no" is about
+    to be quoted as the reason for a role request. A "no" that has not looked at
+    group membership is a weaker "no", so which of the two ran is reported.
+    """
+    base = ["role", "assignment", "list", "--all", "--assignee", principal]
+    try:
+        return rbac._as_mappings(runner([*base, "--include-groups"])), True
+    except rbac.AzureReadFailure:
+        return rbac._as_mappings(runner(base)), False
+
+
 def read_permissions(
     runner: Callable[[Sequence[str]], Any], rbac: Any, *, principal: str
 ) -> Finding:
-    """Which of the three writes this identity's roles already permit."""
+    """Which of the actions a deployment performs this identity's roles permit."""
     question = "can this identity already perform the writes a host needs"
     if not principal:
         return Finding(
@@ -376,8 +495,8 @@ def read_permissions(
             note="no principal id was available to ask about",
         )
     try:
-        assignments = rbac._as_mappings(
-            runner(["role", "assignment", "list", "--all", "--assignee", principal])
+        assignments, groups_included = _list_assignments(
+            runner, rbac, principal=principal
         )
     except rbac.AzureReadFailure as failure:
         return Finding(
@@ -408,16 +527,40 @@ def read_permissions(
             )
 
     permitted = {
-        action: _permits(definitions, action, rbac) for action, _ in REQUIRED_ACTIONS
+        needed.action: _permits(definitions, needed.action, rbac)
+        for needed in actions_measured()
     }
+    blocked = sorted(
+        needed.action
+        for needed in actions_that_block()
+        if not permitted[needed.action]
+    )
     return Finding(
         question,
         measured=True,
         answer={
             "assignments_held": len(assignments),
             "permits": permitted,
-            "permits_all_three": all(permitted.values()),
+            "permits_every_action_a_deployment_would_take": not blocked,
+            "actions_measured": len(permitted),
+            "blocking_actions_not_permitted": blocked,
+            "scopes": {
+                needed.action: needed.scope for needed in actions_measured()
+            },
+            "measured_but_not_blocking": {
+                needed.action: needed.only_if
+                for needed in actions_measured()
+                if not needed.always
+            },
         },
+        note=(
+            ""
+            if groups_included
+            else (
+                "the installed az would not take --include-groups, so a grant "
+                "held through a group membership would not appear here"
+            )
+        ),
     )
 
 
@@ -473,14 +616,21 @@ def decide(findings: Mapping[str, Finding]) -> dict[str, Any]:
             "increase would have to be requested"
         )
     permissions = findings["permissions"].answer or {}
-    denied = sorted(
-        action for action, allowed in (permissions.get("permits") or {}).items()
-        if not allowed
-    )
+    denied = list(permissions.get("blocking_actions_not_permitted") or [])
     if denied:
         missing.append(
             "this identity's roles do not permit: " + ", ".join(denied)
         )
+    # Held apart from ``missing`` on purpose. A deployment under the template's
+    # defaults never reaches these, so they must neither block a verdict on
+    # their own nor pad the list somebody takes to the subscription owner.
+    would_also_be_needed = [
+        f"{action}, but only if {why}"
+        for action, why in sorted(
+            (permissions.get("measured_but_not_blocking") or {}).items()
+        )
+        if not (permissions.get("permits") or {}).get(action, True)
+    ]
 
     if missing:
         return {
@@ -490,6 +640,7 @@ def decide(findings: Mapping[str, Finding]) -> dict[str, Any]:
                 "capacity that exist today"
             ),
             "what_would_have_to_change": missing,
+            "would_also_be_needed_under_other_options": would_also_be_needed,
             "and_note": (
                 "this is a report, not a request. Each item above is an access "
                 "or capacity change and belongs to whoever owns the "
@@ -497,14 +648,17 @@ def decide(findings: Mapping[str, Finding]) -> dict[str, Any]:
             ),
         }
 
+    measured_count = int(permissions.get("actions_measured") or 0)
     return {
         "verdict": VERDICT_WITHIN_PERMISSIONS,
         "because": (
             "the provider is registered, the region has room for one "
-            f"{HOST_VM_SIZE}, and this identity's existing roles permit all "
-            "three writes. No access change is needed to put a host here"
+            f"{HOST_VM_SIZE}, and this identity's existing roles permit every "
+            f"one of the {measured_count} actions a deployment would take. No "
+            "access change is needed to put a host here"
         ),
         "what_would_have_to_change": [],
+        "would_also_be_needed_under_other_options": would_also_be_needed,
     }
 
 
@@ -530,7 +684,9 @@ def survey(
     }
     report: dict[str, Any] = {
         "artifact": "agentic-v2-boot-host-survey",
-        "artifact_version": "1.0",
+        # 1.1 widened the measured action list from three writes to every
+        # action the host definition performs, and split the answer by scope.
+        "artifact_version": "1.1",
         "question": (
             "could the subscription the model deployment lives in host a "
             "Firecracker guest, under permissions that already exist"
@@ -547,6 +703,15 @@ def survey(
             "vm_size": HOST_VM_SIZE,
             "vcpus": HOST_VCPUS,
             "quota_family": HOST_QUOTA_FAMILY,
+            "actions_it_performs": [
+                {
+                    "action": needed.action,
+                    "why": needed.why,
+                    "scope": needed.scope,
+                    "only_if": needed.only_if,
+                }
+                for needed in actions_measured()
+            ],
         },
         "findings": {name: f.as_dict() for name, f in findings.items()},
     }
@@ -583,6 +748,11 @@ def render(report: Mapping[str, Any]) -> str:
         for item in report["what_would_have_to_change"]:
             lines.append(f"  - {item}")
         lines.append(f"  {report.get('and_note', '')}")
+    if report.get("would_also_be_needed_under_other_options"):
+        lines.append("")
+        lines.append("Not needed for this deployment, and not part of the ask:")
+        for item in report["would_also_be_needed_under_other_options"]:
+            lines.append(f"  - {item}")
     return "\n".join(lines)
 
 

--- a/batch-runner/tests/test_azure_boot_host_survey.py
+++ b/batch-runner/tests/test_azure_boot_host_survey.py
@@ -99,7 +99,12 @@ def az(
                 for i, _ in enumerate(definitions)
             ]
         if head == "role definition":
-            return [definitions[0]] if definitions else []
+            # Keyed on the name asked for, so that an identity holding two
+            # roles is evaluated against both of them and not twice against
+            # the first -- which is the whole shape of "VM Contributor plus
+            # Network Contributor".
+            wanted = arguments[-1]
+            return [definitions[int(wanted)]] if wanted.isdigit() else []
         raise AssertionError(f"the survey asked something unexpected: {head}")
 
     return run
@@ -182,12 +187,12 @@ class TestTheVerdict:
             report["is_not"]
         )
 
-    def test_a_reader_role_is_blocked_and_the_three_writes_are_named(self):
+    def test_a_reader_role_is_blocked_and_the_writes_are_named(self):
         report = surveyed(definitions=(READER,))
         assert report["verdict"] == module.VERDICT_BLOCKED
         named = " ".join(report["what_would_have_to_change"])
-        for action, _ in module.REQUIRED_ACTIONS:
-            assert action in named
+        for needed in module.actions_that_block():
+            assert needed.action in named
 
     def test_an_unregistered_provider_blocks_and_is_not_registered_by_the_survey(self):
         report = surveyed(provider="NotRegistered")
@@ -211,9 +216,10 @@ class TestTheVerdict:
 
 
 class TestReadingTheRoles:
-    def test_a_wildcard_role_permits_all_three_writes(self):
-        report = surveyed()
-        assert report["findings"]["permissions"]["answer"]["permits_all_three"] is True
+    def test_a_wildcard_role_permits_every_action_a_deployment_takes(self):
+        answer = surveyed()["findings"]["permissions"]["answer"]
+        assert answer["permits_every_action_a_deployment_would_take"] is True
+        assert answer["blocking_actions_not_permitted"] == []
 
     def test_a_not_action_takes_a_permission_back(self):
         narrowed = {
@@ -230,6 +236,173 @@ class TestReadingTheRoles:
     def test_no_principal_to_ask_about_is_unmeasured_rather_than_denied(self):
         report = module.survey(runner=az(), rbac=rbac, env={})
         assert report["verdict"] == module.VERDICT_NOT_MEASURED
+
+    def test_a_grant_held_through_a_group_is_asked_for_first(self):
+        asked = []
+
+        def run(arguments):
+            if " ".join(arguments[:2]) == "role assignment":
+                asked.append(list(arguments))
+            return az()(arguments)
+
+        module.survey(runner=run, rbac=rbac, env={"AZURE_CLIENT_ID": "p" * 36})
+        assert asked and "--include-groups" in asked[0]
+
+    def test_a_cli_that_will_not_take_include_groups_still_measures_and_says_so(self):
+        # The fallback exists so that an older CLI degrades to today's
+        # behaviour rather than turning the whole survey into not_measured.
+        # It must not degrade *silently*: this "no" gets quoted in a role
+        # request, and a no that never looked at group membership is weaker.
+        def run(arguments):
+            if "--include-groups" in arguments:
+                raise rbac.AzureReadFailure("role assignment list", exit_code=2)
+            return az(definitions=(READER,))(arguments)
+
+        report = module.survey(
+            runner=run, rbac=rbac, env={"AZURE_CLIENT_ID": "p" * 36}
+        )
+        assert report["findings"]["permissions"]["measured"] is True
+        assert "group membership" in report["findings"]["permissions"]["note"]
+
+    def test_a_group_aware_read_that_worked_adds_no_caveat(self):
+        assert surveyed(definitions=(READER,))["findings"]["permissions"]["note"] == ""
+
+
+# ── the list, held to the template it says it came from ───────────────────
+
+
+#: The two built-in definitions the minimal-change proposal names, transcribed
+#: from ``az role definition list`` output. Built-in definitions are the same
+#: in every tenant, which is why they can be pinned in a test that never calls
+#: Azure -- and why the proposal can be checked here rather than asserted in
+#: prose. Trimmed to the actions this template touches.
+VM_CONTRIBUTOR = {
+    "roleName": "Virtual Machine Contributor",
+    "permissions": [
+        {
+            "actions": [
+                "Microsoft.Compute/disks/write",
+                "Microsoft.Compute/virtualMachines/*",
+                "Microsoft.DevTestLab/schedules/*",
+                "Microsoft.Network/networkInterfaces/*",
+                "Microsoft.Network/networkSecurityGroups/join/action",
+                "Microsoft.Network/networkSecurityGroups/read",
+                "Microsoft.Network/publicIPAddresses/join/action",
+                "Microsoft.Network/publicIPAddresses/read",
+                "Microsoft.Network/virtualNetworks/read",
+                "Microsoft.Network/virtualNetworks/subnets/join/action",
+                "Microsoft.Resources/deployments/*",
+                "Microsoft.Resources/subscriptions/resourceGroups/read",
+            ],
+            "notActions": [],
+        }
+    ],
+}
+
+NETWORK_CONTRIBUTOR = {
+    "roleName": "Network Contributor",
+    "permissions": [
+        {
+            "actions": [
+                "Microsoft.Network/*",
+                "Microsoft.Resources/deployments/*",
+                "Microsoft.Resources/subscriptions/resourceGroups/read",
+            ],
+            "notActions": [],
+        }
+    ],
+}
+
+BICEP = REPOSITORY_ROOT / "infra" / "dev-host" / "main.bicep"
+DECLARATION = re.compile(
+    r"^resource\s+\w+\s+'(?P<type>[^@']+)@[^']*'\s*=\s*(?P<conditional>if\s*\()?",
+    re.MULTILINE,
+)
+
+
+class TestTheListIsTheTemplatesList:
+    """The survey is only worth running if it measures what a deploy performs.
+
+    Its first version named three writes, which was a reading of the template
+    rather than a reading *from* it: the security group, the virtual network,
+    the data disk and the auto-shutdown schedule were all missing, so an
+    identity could have been told it was clear and then failed at the first
+    resource. These tests take the list from the file.
+    """
+
+    @pytest.fixture
+    def declared(self):
+        found = {
+            match.group("type"): bool(match.group("conditional"))
+            for match in DECLARATION.finditer(BICEP.read_text(encoding="utf-8"))
+        }
+        assert found, "the template declares no resources, so this test is blind"
+        return found
+
+    def test_every_resource_the_template_declares_has_its_write_measured(self, declared):
+        measured = {needed.action for needed in module.actions_measured()}
+        for resource_type in declared:
+            assert f"{resource_type}/write" in measured
+
+    def test_a_resource_the_template_only_sometimes_creates_does_not_block(
+        self, declared
+    ):
+        conditional = {t for t, is_conditional in declared.items() if is_conditional}
+        assert conditional, "nothing in the template is conditional any more"
+        blocking = {needed.action for needed in module.actions_that_block()}
+        for resource_type in conditional:
+            assert f"{resource_type}/write" not in blocking
+
+    def test_the_only_subscription_scope_action_is_the_resource_group(self):
+        at_subscription = {
+            needed.action
+            for needed in module.actions_measured()
+            if needed.scope == module.SCOPE_SUBSCRIPTION
+        }
+        assert at_subscription == {
+            "Microsoft.Resources/subscriptions/resourceGroups/write"
+        }
+
+    def test_creating_the_group_first_removes_the_subscription_scope_ask(self):
+        # The whole reason the split is worth carrying: with the group already
+        # there, nothing left on the blocking list needs an assignment above
+        # the resource group.
+        for needed in module.actions_that_block():
+            assert needed.scope == module.SCOPE_RESOURCE_GROUP
+
+    def test_a_denied_conditional_action_is_reported_apart_from_the_ask(self):
+        report = surveyed(definitions=(READER,))
+        apart = " ".join(report["would_also_be_needed_under_other_options"])
+        assert "Microsoft.Network/publicIPAddresses/write" in apart
+        assert "Microsoft.Network/publicIPAddresses/write" not in " ".join(
+            report["what_would_have_to_change"]
+        )
+
+
+class TestTheMinimalChangeIsCheckedNotAsserted:
+    def test_virtual_machine_contributor_alone_is_not_enough(self):
+        answer = surveyed(definitions=(VM_CONTRIBUTOR,))["findings"]["permissions"][
+            "answer"
+        ]
+        assert answer["blocking_actions_not_permitted"] == [
+            "Microsoft.Network/networkSecurityGroups/write",
+            "Microsoft.Network/virtualNetworks/write",
+        ]
+
+    def test_the_two_roles_together_cover_every_blocking_action(self):
+        report = surveyed(definitions=(VM_CONTRIBUTOR, NETWORK_CONTRIBUTOR))
+        answer = report["findings"]["permissions"]["answer"]
+        assert answer["permits_every_action_a_deployment_would_take"] is True
+        assert report["verdict"] == module.VERDICT_WITHIN_PERMISSIONS
+
+    def test_neither_role_grants_the_group_write_so_the_group_comes_first(self):
+        report = surveyed(definitions=(VM_CONTRIBUTOR, NETWORK_CONTRIBUTOR))
+        permits = report["findings"]["permissions"]["answer"]["permits"]
+        assert permits["Microsoft.Resources/subscriptions/resourceGroups/write"] is False
+        assert report["verdict"] == module.VERDICT_WITHIN_PERMISSIONS
+        assert "resourceGroups/write" in " ".join(
+            report["would_also_be_needed_under_other_options"]
+        )
 
 
 # ── what it must not do, or say ───────────────────────────────────────────


### PR DESCRIPTION
## 무엇이 틀려 있었나

`azure_boot_host_survey.py`는 "배포가 수행하는 쓰기 세 개"를 잰다고 적혀 있었습니다. 그 셋은 `infra/dev-host/main.bicep`을 읽고 고른 것이지, 파일에서 가져온 것이 아니었습니다. 템플릿이 실제로 선언하는 리소스는 여섯 개입니다.

| bicep 줄 | 리소스 | 구버전 목록에 있었나 |
|---|---|---|
| :117 | `Microsoft.Network/networkSecurityGroups` | ✗ |
| :165 | `Microsoft.Network/virtualNetworks` | ✗ |
| :187 | `Microsoft.Network/publicIPAddresses` (`if (attachPublicIp)`) | ✗ |
| :199 | `Microsoft.Network/networkInterfaces` | ✓ |
| :219 | `Microsoft.Compute/disks` | ✗ |
| :234 | `Microsoft.Compute/virtualMachines` | ✓ |
| :326 | `Microsoft.DevTestLab/schedules` | ✗ |

여기에 배포 객체 자체(`Microsoft.Resources/deployments/write`)와 붙이기 권한(join) 셋이 빠져 있었습니다. 결과적으로 **조사를 통과하고도 첫 리소스에서 실패하는 신원**이 있을 수 있었습니다.

## 무엇이 바뀌었나

- 측정 대상이 3개 → **12개**. 쓰기 7개 + join 3개가 판정을 막고, 조건부 2개는 재되 막지 않습니다.
- 각 항목에 **범위**가 붙습니다. 막고 있는 항목은 **전부 리소스 그룹 범위**이고, 구독 범위는 `resourceGroups/write` 하나뿐인데 그것은 조건부입니다. 소유자가 리소스 그룹을 먼저 만들어 두면 요청에서 사라집니다.
- 역할 할당을 읽을 때 `--include-groups`를 먼저 시도하고, 받지 않는 CLI에서는 빼고 다시 읽은 뒤 그 사실을 `note`에 적습니다. 여기서 나온 "아니오"가 권한 요청의 근거로 인용되므로, 그룹 소속을 보지 않은 아니오는 더 약한 아니오입니다.
- `artifact_version` 1.0 → 1.1. `permits_all_three` → `permits_every_action_a_deployment_would_take`.

## 테스트

`TestTheListIsTheTemplatesList`가 **bicep 파일을 직접 읽어** 선언된 리소스마다 그 쓰기가 측정 목록에 있는지 확인합니다. 목록을 손으로 관리하다 다시 어긋나는 것을 막는 자리입니다.

`TestTheMinimalChangeIsCheckedNotAsserted`는 최소 변경안을 문장이 아니라 테스트로 둡니다. 두 내장 역할 정의는 테넌트와 무관하게 같으므로 Azure를 부르지 않고 고정할 수 있습니다.

- Virtual Machine Contributor 하나로는 `networkSecurityGroups/write`, `virtualNetworks/write` 둘이 빕니다.
- Network Contributor를 더하면 막는 항목 10개가 전부 덮이고 판정이 `creation_is_within_existing_permissions`로 바뀝니다.
- 둘 다 `resourceGroups/write`는 주지 않습니다. 그래서 그룹이 먼저입니다.

51 passed (기존 41 + 신규 10). azure/rbac 관련 전체 701 passed. mypy 0 errors.

## 하지 않은 것

읽기 전용 그대로입니다. 권한은 이름만 적고 수행하지 않습니다. 이 PR은 **무엇을 요청해야 하는지 정확해지는 변경**이지, 요청 자체가 아닙니다. 실제 측정값(모든 항목 `false`, 할당 2개)은 별도로 보고합니다.