### PR TITLE
채점 설정이 문제 순서를 저장소가 아니라 원본에서 가져오게 막습니다

### DIFF
--- a/batch-runner/tests/test_a_pinned_config_names_its_tasks_in_the_sources_order.py
+++ b/batch-runner/tests/test_a_pinned_config_names_its_tasks_in_the_sources_order.py
@@ -1,0 +1,152 @@
+"""A pinned grading config must name its tasks in the source's own order.
+
+`rerun_identity.task_ids` is an ordered list, not a set. `step8_grade.py`'s
+`filter_tasks_for_config` rebuilds the pinned selection from the source and
+refuses the config when the two orders differ:
+
+    if canonical_pinned_ids != pinned_ids:
+        raise ValueError(
+            "config pinned task selection must follow canonical source order"
+        )
+
+That guard runs at `step8_grade.py:2528`, which is *before* any judge call, so
+a wrong order already fails without spending anything on grading. What it does
+not do is fail cheaply: it fails inside a dispatched workflow, after checkout,
+setup and download, and burning a dispatch plus its wall-clock is expensive
+while a relay is holding the schedule. This sweep moves the same failure to
+test time, where it costs nothing at all.
+
+The canonical order is the source parquet's own row order.
+`core/repo_bootstrapper.py` refuses to bootstrap unless the concatenated
+shards hash to `CANONICAL_ORDERED_TASK_IDS_SHA256`, so that constant *is* the
+row order and this file imports it rather than restating the literal.
+
+The trap is live and it is not subtle in its cause, only in its appearance:
+`experiments/exp035_codex_foundry_full220.yaml` pins the same 220 task ids in
+a *different* order (they hash to `fa0e5d32...`). Copying that list into a
+grading config produces a file that is wrong from element 0 while looking
+completely correct — same count, same ids, no duplicates.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from core.inference_manifest import _ordered_task_ids_sha256
+from core.repo_bootstrapper import CANONICAL_ORDERED_TASK_IDS_SHA256
+
+BATCH_ROOT = Path(__file__).resolve().parents[1]
+GRADING_CONFIGS = BATCH_ROOT / "grading_configs"
+
+# The committed full-220 config doubles as this file's order reference. Every
+# test below first proves it still hashes to the bootstrapper's constant, so a
+# drifted reference fails loudly instead of silently redefining "canonical".
+CANONICAL_ORDER_REFERENCE = "regrade_exp003_v2_sol_max_score_excluded.yaml"
+
+EXPECTED_SOURCE_TASK_COUNT = 220
+
+
+def _pinned_task_ids(config_name: str) -> list[str] | None:
+    path = GRADING_CONFIGS / config_name
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    identity = data.get("rerun_identity")
+    if not isinstance(identity, dict):
+        return None
+    task_ids = identity.get("task_ids")
+    if task_ids is None:
+        return None
+    assert isinstance(task_ids, list), f"{config_name}: task_ids must be a list"
+    return task_ids
+
+
+def _canonical_order() -> list[str]:
+    task_ids = _pinned_task_ids(CANONICAL_ORDER_REFERENCE)
+    assert task_ids is not None, (
+        f"{CANONICAL_ORDER_REFERENCE} no longer pins task_ids, so this file has "
+        "lost its order reference. Point CANONICAL_ORDER_REFERENCE at another "
+        "committed config whose task_ids hash to "
+        f"{CANONICAL_ORDERED_TASK_IDS_SHA256}."
+    )
+    assert _ordered_task_ids_sha256(task_ids) == CANONICAL_ORDERED_TASK_IDS_SHA256, (
+        f"{CANONICAL_ORDER_REFERENCE} no longer matches the source parquet's row "
+        "order, so it cannot define canonical order for the other configs."
+    )
+    return task_ids
+
+
+def test_the_order_reference_is_the_sources_own_row_order() -> None:
+    """The reference config must still be the parquet order, not merely a list.
+
+    `repo_bootstrapper` raises when the concatenated source shards do not hash
+    to this constant, so matching it means matching the row order the grader,
+    the sharder and the report position labels all count from.
+    """
+    order = _canonical_order()
+    assert len(order) == EXPECTED_SOURCE_TASK_COUNT
+    assert len(set(order)) == EXPECTED_SOURCE_TASK_COUNT
+
+
+@pytest.mark.parametrize(
+    "config_name",
+    sorted(p.name for p in GRADING_CONFIGS.glob("*.yaml")),
+)
+def test_a_pinned_config_follows_the_sources_order(config_name: str) -> None:
+    """Every pinned list is an ordered subsequence of the canonical 220.
+
+    A config may pin any subset — the anchor and cohort configs pin 3, 4 and 10
+    tasks, the ceiling configs pin 30 and 185 — but it may not reorder them.
+    `filter_tasks_for_config` rebuilds the selection by walking the source in
+    row order, so anything but a strictly increasing subsequence is rejected.
+    """
+    task_ids = _pinned_task_ids(config_name)
+    if task_ids is None:
+        pytest.skip(f"{config_name} does not pin task_ids")
+
+    canonical = _canonical_order()
+    position = {task_id: index for index, task_id in enumerate(canonical)}
+
+    unknown = [task_id for task_id in task_ids if task_id not in position]
+    assert not unknown, (
+        f"{config_name} pins {len(unknown)} task id(s) that are not in the fixed "
+        f"{EXPECTED_SOURCE_TASK_COUNT}-task source: {unknown[:3]}"
+    )
+
+    positions = [position[task_id] for task_id in task_ids]
+    out_of_order = [
+        (index, task_ids[index])
+        for index in range(1, len(positions))
+        if positions[index] <= positions[index - 1]
+    ]
+    assert not out_of_order, (
+        f"{config_name} pins task ids out of canonical source order, first at "
+        f"index {out_of_order[0][0]} ({out_of_order[0][1]}). step8_grade rejects "
+        "this in the dispatched run; reorder the list to follow the source. Note "
+        "that experiments/exp035_codex_foundry_full220.yaml holds the same 220 "
+        "ids in a different order — do not copy a task list from an experiment "
+        "YAML into a grading config."
+    )
+
+
+@pytest.mark.parametrize(
+    "config_name",
+    sorted(p.name for p in GRADING_CONFIGS.glob("*.yaml")),
+)
+def test_a_full_length_pin_matches_the_canonical_digest_exactly(
+    config_name: str,
+) -> None:
+    """A config pinning all 220 must hash to the constant, not merely contain them.
+
+    The subsequence check above already forbids a reordering, but a full-length
+    pin can be compared against the bootstrapper's digest directly, which is the
+    same comparison `repo_bootstrapper` makes against the parquet itself.
+    """
+    task_ids = _pinned_task_ids(config_name)
+    if task_ids is None or len(task_ids) != EXPECTED_SOURCE_TASK_COUNT:
+        pytest.skip(f"{config_name} does not pin the full source")
+
+    digest = _ordered_task_ids_sha256(task_ids)
+    assert digest == CANONICAL_ORDERED_TASK_IDS_SHA256, (
+        f"{config_name} pins {EXPECTED_SOURCE_TASK_COUNT} task ids that hash to "
+        f"{digest}, not the source's {CANONICAL_ORDERED_TASK_IDS_SHA256}."
+    )


### PR DESCRIPTION
## 무엇을 막나

`rerun_identity.task_ids`는 **집합이 아니라 순서 있는 목록**입니다.
`step8_grade.py`의 `filter_tasks_for_config`가 원본을 행 순서로 훑어 선택을
다시 만든 뒤, 설정에 적힌 목록과 다르면 거절합니다.

```python
if canonical_pinned_ids != pinned_ids:
    raise ValueError("config pinned task selection must follow canonical source order")
```

**이 검사는 판정 호출 전에 돕니다**(`step8_grade.py:2528`). 그래서 순서가
틀려도 채점비가 나가지는 않습니다. 다만 **디스패치된 워크플로 안에서**
터집니다 — 체크아웃·셋업·다운로드를 다 하고 난 뒤입니다. 릴레이가 일정을
붙들고 있는 동안 디스패치 한 번과 그 시간을 버리는 값이고, 이 PR은 같은
실패를 **시험 시간으로** 옮깁니다. 여기서는 공짜입니다.

**"조용히 잘못 채점되는 것을 막는다"가 아닙니다.** 런타임 가드가 이미 그
일을 하고 있고, 이 PR이 사는 것은 실패 시점뿐입니다.

## 덫은 지금 살아 있습니다

`experiments/exp035_codex_foundry_full220.yaml`이 **같은 220개를 다른
순서로** 담고 있습니다(`fa0e5d32…`). 그 목록을 채점 설정에 옮겨 붙이면
개수도 id도 중복도 멀쩡한데 순서만 틀린 파일이 나옵니다. exp035 채점 설정은
마지막 구간이 `inference_revision`을 확정한 뒤에 쓰게 되어 있으므로
(`docs/run_records/grading_design.md`), 그때 이 검사가 이미 서 있습니다.

## 정본 순서는 어디서 오나

**원본 파케이의 행 순서**입니다. `core/repo_bootstrapper.py`가 샤드를 이어
붙인 해시가 `CANONICAL_ORDERED_TASK_IDS_SHA256`이 아니면 부트스트랩 자체를
거절합니다(`:1319`). 그래서 그 상수가 곧 행 순서이고, 이 시험은 문자열을
다시 박지 않고 **상수를 가져다 씁니다.**

순서 자체는 커밋된 220문제 설정(`regrade_exp003_v2_sol_max_score_excluded.yaml`)
에서 읽습니다. 다만 읽기 전에 **그 설정이 상수와 같은 해시인지 먼저
확인**하므로, 참조가 흔들리면 조용히 "정본"을 다시 정의하지 않고 그 자리에서
멈춥니다.

## 발동하는지 확인했습니다

검사가 한 번도 걸린 적 없으면 검사가 아닙니다. 세 가지로 확인했습니다.

| 넣은 것 | 결과 |
|---|---|
| exp035 실험 YAML의 220개 순서 | 부분수열 검사가 index 2에서 잡음 |
| 같은 목록의 해시 | `fa0e5d32…` ≠ `df1fcd64…`로 따로 잡음 |
| 3문제 부분집합의 자리를 둘 바꿈 | index 1에서 잡음 |
| 참조 설정 그대로 | 같은 하네스에서 통과 |

## 지금 통과 상태

```
11 passed, 18 skipped
```

설정 14개 중 순서를 박은 **8개가 전부 통과**하고, 그중 220개짜리 **2개는
상수와 정확히 일치**합니다. 나머지 6개는 `task_ids`를 안 박아서 건너뜁니다.
`grading_configs/*.yaml`을 **글롭으로 훑으므로** exp035 채점 설정이 들어오는
즉시 따로 등록하지 않아도 같이 검사합니다.

인접 묶음도 같이 돌렸습니다: `test_grading_config.py`,
`test_grader_hash_freeze.py`, `test_repo_bootstrapper_safety.py` 포함
**257 passed, 18 skipped**.

## 실행 중인 구간에 대한 영향

- `.github/workflows/batch-run.yml` 변경 **0개**
- `batch-runner/core` 변경 **0개**
- 단가표 변경 **0개**
- 실험 YAML 변경 **0개**
- 새 파일 1개(`batch-runner/tests/`)뿐이고, 도는 구간은 `batch-runner/`를
  0구간 개정판에 고정해 읽으므로 **34672457148이 읽는 파일 0개**입니다.