### PR TITLE
`browser_run`가 trial_30의 40%를 끝냈습니다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -319,6 +319,22 @@ tasks/0822_saturday/*
 # that says so, including the token counts the 0.0018 USD is derived from and
 # the four things it deliberately does not prove.
 !tasks/0822_saturday/model_reachability_survey.json
+# The same survey, widened to ask about every action the template performs
+# rather than the three it was first written around. Kept beside the 1.0
+# artefact instead of replacing it: the earlier write-ups cite the narrow one,
+# and a record that quietly grows twelve rows is a record nobody can date.
+!tasks/0822_saturday/boot_host_survey_widened.json
+# What an owner would have to read to act on the block above -- principal,
+# every action, every scope, and the smallest grant that clears it. The survey
+# reports machine-readable denials; this is the one place they are assembled
+# into a change someone could approve or refuse. It names the change and
+# leaves it undone.
+!tasks/0822_saturday/HOST_PERMISSIONS.md
+# A design worked through to the verdict "not yet". Committing the reasoning
+# for an experiment that was not run is the point: without it, the next person
+# to ask about the turn limit re-derives the same blockers, or does not, and
+# runs it.
+!tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
 !tasks/0828_friday/
 tasks/0828_friday/*
 !tasks/0828_friday/TASK_PER_TASK_COST_RECEIPTS.md

--- a/batch-runner/core/agentic_v2_conversation_runner.py
+++ b/batch-runner/core/agentic_v2_conversation_runner.py
@@ -24,8 +24,17 @@ would report 180 honest results and 40 refusals that say nothing about the
 model. So each task gets its own ceiling. The run-wide total is not thereby
 abandoned — :attr:`TaskConversations.spent` sums what every task actually used,
 and :meth:`TaskConversations.run_wide_refusal` is asked before each task, so an
-overall cap still stops the run. Two different limits, both enforced, neither
-pretending to be the other.
+overall cap can stop the run. Two different limits, neither pretending to be
+the other.
+
+**The run-wide cap is built but not set.** `scripts/run_agentic_v2_stage.py`
+constructs :class:`RunWideCeilings` with no arguments, so all three fields are
+``None`` and :meth:`TaskConversations.run_wide_refusal` never refuses. What
+bounds a stage today is the cost guard, which prices the whole stage against
+its approved amount *before* the run starts. That is a better place to stop —
+it stops before the money — but it is a different mechanism, and this one is
+inert until someone gives it numbers. Said here rather than left implied,
+because an earlier draft of this paragraph claimed both limits were enforced.
 
 **On token counts.** Every :class:`~core.agentic_v2_conversation.TurnRecord`
 that exists carries counts the provider really reported: the loop stops with
@@ -163,10 +172,12 @@ def ceilings_from(plan: Mapping[str, Any], chosen: Any) -> PerTaskCeilings:
 @dataclass(frozen=True)
 class RunWideCeilings:
     """What a whole run may spend, across every task and every attempt.
-    questions. A per-task ceiling stops one task from running away; this stops
-    the run. ``None`` on a field means nobody set that one, and — unlike the
-    per-task case — that is allowed here, because a run may legitimately be
-    bounded by turns and not by tokens.
+
+    A per-task ceiling stops one task from running away; this stops the run.
+    ``None`` on a field means nobody set that one, and — unlike the per-task
+    case — that is allowed here, because a run may legitimately be bounded by
+    turns and not by tokens. All three ``None`` bounds nothing, which is what
+    stage one currently passes; see the module docstring.
     """
 
     max_model_calls: Optional[int] = None

--- a/batch-runner/tests/test_agentic_v2_conversation_runner.py
+++ b/batch-runner/tests/test_agentic_v2_conversation_runner.py
@@ -16,6 +16,8 @@ task's.
 
 from __future__ import annotations
 
+import pathlib
+
 import pytest
 
 from core.agentic_v2_conversation import (
@@ -402,6 +404,42 @@ class TestCeilings:
                 input_tokens=10_000, output_tokens=1_000
             )
         assert held.run_wide_refusal() is None
+
+    def test_the_stage_script_sets_no_run_wide_ceiling(self):
+        """The three above prove the mechanism. This says it is switched off.
+
+        Everything in this class passes whether the production run is bounded
+        run-wide or not, because every one of them builds its own
+        `TaskConversations`. The stage script builds exactly one, with no
+        arguments, so `run_wide_refusal` never refuses in a paid run and what
+        actually bounds a stage is the cost guard that prices it before it
+        starts.
+
+        That is a defensible choice -- stopping before the money beats stopping
+        during it -- but it was not a stated one, and the module docstring used
+        to claim both limits were enforced. If this test starts failing because
+        someone passed a ceiling, that claim becomes true again and the
+        docstring should say so.
+        """
+        import ast
+
+        script = (
+            pathlib.Path(__file__).resolve().parents[1]
+            / "scripts"
+            / "run_agentic_v2_stage.py"
+        )
+        built = [
+            node
+            for node in ast.walk(ast.parse(script.read_text(encoding="utf-8")))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "RunWideCeilings"
+        ]
+        assert built, "the stage script no longer builds one at all"
+        for node in built:
+            assert not node.args and not node.keywords, (
+                f"line {node.lineno} now sets a run-wide ceiling"
+            )
 
 
 # ── the factory the driver uses ──────────────────────────────────────────

--- a/batch-runner/tests/test_the_browser_tool_is_half_open.py
+++ b/batch-runner/tests/test_the_browser_tool_is_half_open.py
@@ -35,6 +35,12 @@ what the backend does and says nothing about what the instructions should say:
 the instruction text is a pinned run condition, and changing it is an
 intervention that needs its own record. See
 `tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md`.
+
+`exec_run` has the same shape and is pinned here too, at the bottom. It is
+named in the instructions as refusing "every time", and one command really
+runs. Nothing in trial_30 reached it, so this is exposure rather than a
+finding about that run -- but it is the same trapdoor, and the environment
+advertises it where the instructions deny it.
 """
 from __future__ import annotations
 
@@ -179,3 +185,63 @@ def test_the_model_cannot_ask_which_tools_work():
     )
     assert "tools" not in identity["capabilities"]
     assert "fixture-local-only-v1" not in repr(identity["capabilities"])
+
+
+# ---------------------------------------------------------------------------
+# The second tool with this shape
+# ---------------------------------------------------------------------------
+
+
+def test_exec_run_serves_exactly_one_command(backend):
+    """The instructions say no commands run here. One does.
+
+    `fixture-upper` with a source and a destination is served and really does
+    the work -- the file comes back uppercased, with `returncode: 0`. Every
+    other argv, including the same command with the wrong number of arguments,
+    answers `capability_unavailable`, which ends the task.
+
+    So `exec_run` is half open in the same way `browser_run` is, and described
+    the opposite way round: `browser_run` is presented as available and is
+    partly shut, `exec_run` is presented as shut "every time" and is partly
+    open.
+    """
+    (backend.work / "a.txt").write_text("hello\n", encoding="utf-8")
+
+    served = backend.exec_run({"argv": ["fixture-upper", "a.txt", "b.txt"], "cwd": "."})
+    assert served["ok"] is True
+    assert served["data"]["returncode"] == 0
+    assert (backend.work / "b.txt").read_text(encoding="utf-8") == "HELLO\n"
+
+    for argv in (["fixture-upper", "a.txt"], ["fixture-upper"], ["ls"],
+                 ["sh", "-c", "echo hi"]):
+        answer = backend.exec_run({"argv": argv, "cwd": "."})
+        assert answer["ok"] is False, argv
+        assert answer["error_type"] == "capability_unavailable", argv
+
+
+def test_the_environment_advertises_the_command_the_instructions_deny(backend):
+    """`capabilities_query` names it, so a model could go looking.
+
+    This is the asymmetry that makes the `browser_run` gap load-bearing rather
+    than untidy. Of the three things a model might want to know about this
+    room, two are answerable from inside it and the third is not:
+
+    * **commands** -- answered, and the answer is `fixture-upper`, which
+      contradicts "no commands run here" in the instruction text
+    * **budgets** -- answered, and it states the turn limit outright
+    * **which tools refuse** -- not answerable at all; there is no `tools` kind
+
+    A model that trusted the environment over the instructions and called
+    `exec_run` would find the command real, and would end its task on the first
+    argv it got wrong. Nothing in trial_30 did: all thirty obeyed the
+    instruction and never called it. The exposure is what is pinned here.
+    """
+    commands = backend.capabilities_query({"kind": "commands"})
+    assert commands["ok"] is True
+    assert commands["data"]["items"] == ["fixture-upper"]
+
+    budgets = backend.capabilities_query({"kind": "budgets"})
+    assert budgets["ok"] is True
+    # The number is whatever this backend was built with, not trial_30's 8.
+    # What is being pinned is that the limit is answerable at all.
+    assert any(item.startswith("tool_calls=") for item in budgets["data"]["items"])

--- a/batch-runner/tests/test_the_browser_tool_is_half_open.py
+++ b/batch-runner/tests/test_the_browser_tool_is_half_open.py
@@ -18,8 +18,10 @@ thirty tasks made **zero** calls to the three tools the instructions name --
 the model obeyed exactly -- and twelve of them ended on a single `browser_run`
 that reached the network: eight a `search`, four an `open_url`. Each had used
 2-5 of the 9 calls it was allowed, and none was retried. The runner ends a task
-on any tool result that is not ``ok: True``, so a refusal here is terminal
-rather than something to work around.
+on any tool result that is not ``ok: True`` -- not as a policy choice but
+because the trace schema refuses a record in which a tool event follows a
+failed one -- so a refusal here is terminal rather than something to work
+around.
 
 The half that is open here is shut on the backend this is all waiting for.
 ``AgenticV2MicroVMBackend.browser_run`` refuses every operation including
@@ -43,6 +45,7 @@ from core.agentic_v2_contract import (
     AgenticV2Profile,
     validate_tool_arguments,
 )
+from core.agentic_v2_conversation import _ENDS_THE_RUN, StopReason
 from core.agentic_v2_provenance import foundation_fixture_identity
 from core.agentic_v2_fixture_backend import AgenticV2FixtureBackend
 
@@ -115,6 +118,36 @@ def test_the_refused_operations_are_valid_calls_not_malformed_ones(
     assert validate_tool_arguments(
         "browser_run", {"operation": operation, key: value}
     ) == {"operation": operation, key: value}
+
+
+def test_the_loop_that_would_survive_a_refusal_never_gets_to_run():
+    """The refusal is survivable one layer down, and that layer is never reached.
+
+    `_ENDS_THE_RUN` is the conversation's table of tool failures that stop a
+    run, and `capability_unavailable` is deliberately not in it: everything
+    absent is handed back to the model, because "a loop that gave up at the
+    first refusal would measure nothing". That is the loop the stage one
+    instructions describe.
+
+    `agentic_v2_runner.py:772` raises before the table is consulted, on any
+    result that is not ``ok: True``. Its docstring gives the reason and it is
+    not a preference -- `verify_agentic_v2_result` rejects a trace in which a
+    tool event follows an ``ok: False`` one, so a run that continued past a
+    refusal could not produce a verifiable record of itself. That half is
+    pinned by ``test_trace_pair_rejects_tool_after_exact_error``, which uses
+    this very tool and this very error.
+
+    Neither file is wrong about itself, which is why this is worth a test of
+    its own: the trap is in the join. A reader who deletes the raise to "let
+    the documented loop run" gets an unverifiable trace, and a reader who
+    trusts this table alone mis-predicts what twelve of trial_30's thirty tasks
+    did.
+    """
+    assert "capability_unavailable" not in _ENDS_THE_RUN
+    # What the model meets instead. Both halves of the join have to move
+    # together, so the ceiling errors are named here as the contrast: these
+    # *are* in the table, and they are the ones a task survives into a retry.
+    assert _ENDS_THE_RUN["tool_budget_exhausted"] is StopReason.TOOL_CALL_LIMIT_REACHED
 
 
 def test_the_model_cannot_ask_which_tools_work():

--- a/batch-runner/tests/test_the_browser_tool_is_half_open.py
+++ b/batch-runner/tests/test_the_browser_tool_is_half_open.py
@@ -1,0 +1,148 @@
+"""`browser_run` is half open, and the half that is shut ends the run.
+
+The stage one instructions name three tools that refuse -- `exec_run`,
+`environment_resolve`, `environment_activate` -- and an earlier draft named
+`browser_run` alongside them. That draft was corrected after a probe showed
+`browser_run` answering ``ok: True``, and the correction is recorded in
+`test_agentic_stage_one_budget.py` as *"telling a model a working tool is shut
+costs it the tool"*.
+
+The probe was right about the call it made and wrong about the tool. The
+contract gives `browser_run` five operations across three argument shapes. The
+fixture backend serves the three that take a `path` and refuses the two that
+reach the network, so a probe that passes a `path` sees a working tool and a
+model that passes a `query` does not.
+
+What that cost is measured. In trial_30 (run 34671538199, 2026-09-12) the
+thirty tasks made **zero** calls to the three tools the instructions name --
+the model obeyed exactly -- and twelve of them ended on a single `browser_run`
+that reached the network: eight a `search`, four an `open_url`. Each had used
+2-5 of the 9 calls it was allowed, and none was retried. The runner ends a task
+on any tool result that is not ``ok: True``, so a refusal here is terminal
+rather than something to work around.
+
+The half that is open here is shut on the backend this is all waiting for.
+``AgenticV2MicroVMBackend.browser_run`` refuses every operation including
+``open_local``, for a stated reason -- nothing drives chromium or bounds it --
+and ``test_agentic_v2_microvm_backend.py`` pins that. So the shape below is the
+fixture's, not the destination's, and a task that leans on a local browser read
+is failing later rather than not at all.
+
+This file pins both halves so the next probe cannot see only one. It asserts
+what the backend does and says nothing about what the instructions should say:
+the instruction text is a pinned run condition, and changing it is an
+intervention that needs its own record. See
+`tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md`.
+"""
+from __future__ import annotations
+
+import pytest
+
+from core.agentic_v2_contract import (
+    TOOL_SCHEMAS,
+    AgenticV2Profile,
+    validate_tool_arguments,
+)
+from core.agentic_v2_provenance import foundation_fixture_identity
+from core.agentic_v2_fixture_backend import AgenticV2FixtureBackend
+
+#: The operations the fixture backend serves, and the argument each one takes.
+SERVED = ("open_local", "snapshot", "screenshot")
+
+#: The operations it refuses. Both reach outside the workspace.
+REFUSED = (("search", "query", "quarterly revenue by segment"),
+           ("open_url", "url", "https://example.org/a"))
+
+
+@pytest.fixture
+def backend(tmp_path):
+    made = AgenticV2FixtureBackend(
+        root=tmp_path / "task",
+        profile=AgenticV2Profile(
+            tool_contract_version="2.0",
+            policy_profile_id="offline-full-v1",
+            foundation_only=True,
+        ),
+    )
+    # The backend reads relative to `root/work`, which it creates itself, so
+    # the file has to be laid down after it is built rather than before.
+    inputs = made.work / "inputs"
+    inputs.mkdir()
+    (inputs / "notes.md").write_text("a local file\n", encoding="utf-8")
+    return made
+
+
+@pytest.mark.parametrize("operation", SERVED)
+def test_the_operations_that_take_a_path_are_served(backend, operation):
+    answer = backend.browser_run({"operation": operation, "path": "inputs/notes.md"})
+    assert answer["ok"] is True
+    assert answer["data"]["path"] == "inputs/notes.md"
+
+
+@pytest.mark.parametrize("operation,key,value", REFUSED)
+def test_the_operations_that_reach_the_network_refuse(backend, operation, key, value):
+    answer = backend.browser_run({"operation": operation, key: value})
+    assert answer["ok"] is False
+    assert answer["error_type"] == "capability_unavailable"
+
+
+def test_every_operation_the_contract_offers_is_covered_here():
+    """A sixth operation added later would otherwise go unprobed.
+
+    Which is how the first probe went wrong: it covered the shape it happened
+    to pass and reported on the tool.
+    """
+    offered = {
+        value
+        for branch in TOOL_SCHEMAS["browser_run"]["oneOf"]
+        for value in (
+            branch["properties"]["operation"].get("enum")
+            or [branch["properties"]["operation"]["const"]]
+        )
+    }
+    assert offered == set(SERVED) | {operation for operation, _, _ in REFUSED}
+
+
+@pytest.mark.parametrize("operation,key,value", REFUSED)
+def test_the_refused_operations_are_valid_calls_not_malformed_ones(
+    operation, key, value
+):
+    """The refusal is the backend's answer, not the schema rejecting the call.
+
+    It matters which: a schema rejection would never have been billed, and the
+    twelve tasks were billed for the turn that ended them.
+    """
+    assert validate_tool_arguments(
+        "browser_run", {"operation": operation, key: value}
+    ) == {"operation": operation, key: value}
+
+
+def test_the_model_cannot_ask_which_tools_work():
+    """There is no route from inside the loop to the fact above.
+
+    `capabilities_query` is the tool for asking what the environment has, and
+    the five things it will answer about are commands, runtimes, packages,
+    formats and budgets. None of them is *tools*. A model that suspected
+    `browser_run` was restricted had nothing to query, so the instruction text
+    is the only account of which tools refuse -- and it names three, omitting
+    this one.
+
+    The backend does know. It records the browser as `fixture-local-only-v1`,
+    which is the whole answer in one string, and then hashes it into
+    `browser_build_sha256` where nothing can read it.
+
+    If a `tools` kind is added later this test fails, which is the right time
+    to revisit whether the instructions still need to carry the list alone.
+    """
+    assert set(TOOL_SCHEMAS["capabilities_query"]["properties"]["kind"]["enum"]) == {
+        "commands",
+        "runtimes",
+        "packages",
+        "formats",
+        "budgets",
+    }
+    identity = foundation_fixture_identity(
+        "offline-full-v1", {"tool_calls": 8, "wall_seconds": 600}
+    )
+    assert "tools" not in identity["capabilities"]
+    assert "fixture-local-only-v1" not in repr(identity["capabilities"])

--- a/batch-runner/tests/test_the_browser_tool_is_half_open.py
+++ b/batch-runner/tests/test_the_browser_tool_is_half_open.py
@@ -192,6 +192,13 @@ def test_the_model_cannot_ask_which_tools_work():
 # ---------------------------------------------------------------------------
 
 
+def _exec(argv):
+    """A schema-valid `exec_run` call, so the probe matches what a model sends."""
+    call = {"argv": list(argv), "cwd": ".", "timeout_seconds": 30}
+    assert validate_tool_arguments("exec_run", call) == call
+    return call
+
+
 def test_exec_run_serves_exactly_one_command(backend):
     """The instructions say no commands run here. One does.
 
@@ -206,15 +213,17 @@ def test_exec_run_serves_exactly_one_command(backend):
     open.
     """
     (backend.work / "a.txt").write_text("hello\n", encoding="utf-8")
-
-    served = backend.exec_run({"argv": ["fixture-upper", "a.txt", "b.txt"], "cwd": "."})
+    # `timeout_seconds` is required by the contract even though the fixture
+    # ignores it, so these are calls a model could actually make: a call
+    # missing it never reaches the backend at all.
+    served = backend.exec_run(_exec(["fixture-upper", "a.txt", "b.txt"]))
     assert served["ok"] is True
     assert served["data"]["returncode"] == 0
     assert (backend.work / "b.txt").read_text(encoding="utf-8") == "HELLO\n"
 
     for argv in (["fixture-upper", "a.txt"], ["fixture-upper"], ["ls"],
                  ["sh", "-c", "echo hi"]):
-        answer = backend.exec_run({"argv": argv, "cwd": "."})
+        answer = backend.exec_run(_exec(argv))
         assert answer["ok"] is False, argv
         assert answer["error_type"] == "capability_unavailable", argv
 
@@ -245,3 +254,60 @@ def test_the_environment_advertises_the_command_the_instructions_deny(backend):
     # The number is whatever this backend was built with, not trial_30's 8.
     # What is being pinned is that the limit is answerable at all.
     assert any(item.startswith("tool_calls=") for item in budgets["data"]["items"])
+
+
+# ---------------------------------------------------------------------------
+# The general form of the mistake
+# ---------------------------------------------------------------------------
+
+
+#: One call per tool, chosen to be the best case that tool allows: if this
+#: tool works at all, this is a call that works. Validated against the
+#: contract below, so none of them is a lucky shape.
+A_CALL_THAT_SHOULD_WORK = {
+    "capabilities_query": {"kind": "commands"},
+    "workspace_apply": {"operation": "read", "path": "inputs/notes.md"},
+    "exec_run": {"argv": ["fixture-upper", "inputs/notes.md", "out.txt"],
+                 "cwd": ".", "timeout_seconds": 30},
+    "environment_resolve": {"ecosystem": "python", "requirements": ["nothing"]},
+    "environment_activate": {"lock_digest": "0" * 64},
+    "browser_run": {"operation": "open_local", "path": "inputs/notes.md"},
+    "verify_public": {"deliverables": ["inputs/notes.md"]},
+    "finalize": {"deliverables": ["inputs/notes.md"], "summary": "done"},
+}
+
+#: The tools with no working call at all under `offline-full-v1`. Two, not the
+#: three the instructions name.
+NO_CALL_WORKS = {"environment_resolve", "environment_activate"}
+
+
+def test_every_call_in_the_sweep_is_a_legal_one():
+    """Otherwise the sweep below would be measuring the schema, not the backend."""
+    for name, arguments in A_CALL_THAT_SHOULD_WORK.items():
+        assert validate_tool_arguments(name, arguments) == arguments, name
+
+
+def test_exactly_two_tools_have_no_working_call(backend):
+    """The instructions name three. Two is the answer.
+
+    This is the general form of what this file is about, and the reason it is
+    a sweep rather than two more named tests: it fails if *any* tool changes
+    which side it is on, including one added later. A tool that starts
+    refusing without being named is the `browser_run` mistake happening again;
+    a tool that stops refusing while still being named is the opposite one,
+    recorded in `test_agentic_stage_one_budget.py` as "telling a model a
+    working tool is shut costs it the tool".
+
+    Six of the eight have a call that works -- `exec_run` and `browser_run`
+    among them. Only the two package tools are shut outright, and they are shut
+    because the policy profile is `offline-full-v1`.
+    """
+    assert set(A_CALL_THAT_SHOULD_WORK) == set(TOOL_SCHEMAS)
+
+    refused = set()
+    for name in sorted(TOOL_SCHEMAS):
+        answer = getattr(backend, name)(A_CALL_THAT_SHOULD_WORK[name])
+        if answer.get("ok") is not True:
+            assert answer["error_type"] == "capability_unavailable", name
+            refused.add(name)
+    assert refused == NO_CALL_WORKS

--- a/batch-runner/tests/test_the_model_is_shown_a_paraphrase_of_its_own_turns.py
+++ b/batch-runner/tests/test_the_model_is_shown_a_paraphrase_of_its_own_turns.py
@@ -1,0 +1,230 @@
+"""The model never sees its own tool calls, only a sentence describing them.
+
+`AzureFoundryVoice._input_for` rebuilds the whole conversation before every
+turn, which is right and is what the budget is worked out on. What it rebuilds
+is not the conversation. Each of the model's prior turns comes back as one
+line of prose --
+
+    I asked for workspace_apply as call call_A1b2C3.
+
+-- and the arguments of that call, which `ToolExchange` is carrying, are
+dropped. The tool's *answer* is replayed in full as JSON. So the model can see
+every result it got and cannot see any request it made.
+
+Two consequences, and the second one is measured.
+
+The first is information loss that grows with the turn count. By turn eight a
+model has eight lines saying it asked for `workspace_apply` and no record of
+which path it read or wrote. That bears directly on
+`tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md`: raising the limit adds
+turns whose history is this thin.
+
+The second is a failure mode. In trial_30 (run 34671538199) nine attempts
+across five tasks ended with `stop_reason: model_stopped_without_finishing`,
+and every one of them carries a note of the same shape as the line above --
+naming `workspace_apply`, naming a well-formed `call_...` id, 29-32 output
+tokens, one sentence. **None of those ids appears anywhere earlier in its own
+conversation.** The model did not repeat a call id it had been shown; it wrote
+a new one inside prose, in the format the harness had been showing it, instead
+of emitting a function call. `next_turn` finds no function call and returns
+`GaveUp`, whose docstring calls that "the model walking away".
+
+It is not a model giving up, and no give-up text exists to preserve. It is the
+harness's own replay format being completed as text. The earliest it happens is
+the third turn of a conversation and it never happens on the first, which is
+what one would expect of imitation: there has to be something to imitate.
+
+This file pins the mechanism, not the failure rate. Both halves are pure --
+`_input_for` is a string builder and the reply branch is a `None` check -- so
+nothing here calls a model or costs anything. Changing the replay format is an
+intervention on a pinned run condition and needs its own run id; the count
+above belongs to trial_30 and nothing here modifies it.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from core.agentic_v2_conversation import (
+    AskForTool,
+    GaveUp,
+    ModelRequest,
+    ToolExchange,
+)
+from core.agentic_v2_model_voice import AzureFoundryVoice
+from core.agentic_v2_stage_one_budget import StageOneBudget
+
+#: A value that appears only in the arguments of the call below, so finding it
+#: anywhere in the rebuilt conversation means the arguments survived.
+ONLY_IN_THE_ARGUMENTS = "inputs/the-one-file-it-read.md"
+
+
+def _exchange(**changed: Any) -> ToolExchange:
+    fields: dict[str, Any] = {
+        "call_id": "call_anEarlierOneTheModelWasShown",
+        "tool_name": "workspace_apply",
+        "arguments": {"operation": "read", "path": ONLY_IN_THE_ARGUMENTS},
+        "ok": True,
+        "error_type": None,
+        "data": {"bytes": 12},
+    }
+    fields.update(changed)
+    return ToolExchange(**fields)
+
+
+@pytest.fixture
+def voice() -> AzureFoundryVoice:
+    """A real voice with a client that is never called.
+
+    Only `_input_for` and the reply branch are exercised, and neither of them
+    touches the client, so a stub is honest here rather than a shortcut.
+    """
+    return AzureFoundryVoice(
+        client=object(),
+        deployment="a-deployment",
+        resource="a-resource",
+        budget=StageOneBudget(
+            max_model_calls=9, max_input_tokens=1_000_000, max_output_tokens=100_000
+        ),
+        instructions="do the task",
+        max_output_tokens_per_turn=8192,
+    )
+
+
+def _request(history: tuple[ToolExchange, ...], turn: int = 1) -> ModelRequest:
+    return ModelRequest(
+        turn=turn,
+        task_prompt="the task",
+        tools_available=("workspace_apply", "finalize"),
+        history=history,
+        turns_left=9 - turn,
+    )
+
+
+def test_the_arguments_of_a_past_call_are_not_replayed(voice):
+    """The one thing the model would need to know is the one thing dropped."""
+    messages = voice._input_for(_request((_exchange(),)))
+
+    whole = repr(messages)
+    assert ONLY_IN_THE_ARGUMENTS not in whole
+    assert "operation" not in whole
+    # The answer, by contrast, comes back in full.
+    assert '"bytes": 12' in whole
+
+
+def test_a_past_call_comes_back_as_one_sentence_of_prose(voice):
+    """And the sentence is the shape the give-up notes are in."""
+    messages = voice._input_for(_request((_exchange(),)))
+
+    spoken = [m for m in messages if m["role"] == "assistant"]
+    assert spoken == [
+        {
+            "role": "assistant",
+            "content": (
+                "I asked for workspace_apply as call "
+                "call_anEarlierOneTheModelWasShown."
+            ),
+        }
+    ]
+
+
+def test_the_first_turn_has_nothing_to_imitate(voice):
+    """Which is why the failure never appears on it.
+
+    With no history the model is shown the task and nothing else, so there is
+    no assistant voice in the input at all. The earliest give-up in trial_30 is
+    the third turn of its conversation.
+    """
+    messages = voice._input_for(_request((), turn=0))
+    assert messages == [{"role": "user", "content": "the task"}]
+
+
+def test_every_turn_adds_another_line_in_that_format(voice):
+    """Eight turns in, eight lines, none of which says what was asked for."""
+    history = tuple(
+        _exchange(call_id=f"call_number{index}") for index in range(8)
+    )
+    messages = voice._input_for(_request(history, turn=8))
+
+    spoken = [m["content"] for m in messages if m["role"] == "assistant"]
+    assert len(spoken) == 8
+    assert all(
+        line == f"I asked for workspace_apply as call call_number{index}."
+        for index, line in enumerate(spoken)
+    )
+
+
+# ---------------------------------------------------------------------------
+# The other half of the join
+# ---------------------------------------------------------------------------
+
+
+class _Response:
+    """The shape `next_turn` reads a reply out of."""
+
+    def __init__(self, output: list[Any], text: str = "") -> None:
+        self.output = output
+        self.output_text = text
+        self.model = "a-deployment"
+        self.usage = type(
+            "Usage", (), {"input_tokens": 400, "output_tokens": 31}
+        )()
+
+
+class _FunctionCall:
+    type = "function_call"
+
+    def __init__(self) -> None:
+        self.call_id = "call_realOne"
+        self.name = "workspace_apply"
+        self.arguments = '{"operation": "read", "path": "a.md"}'
+
+
+def test_a_reply_with_no_function_call_becomes_a_give_up_carrying_its_text(voice):
+    """This is the branch the nine attempts went through.
+
+    The text the model wrote becomes the note verbatim, which is how a sentence
+    in the harness's own replay format ended up recorded as the reason a task
+    stopped.
+    """
+    voice.client = _client_returning(
+        _Response(output=[], text="I asked for workspace_apply as call call_MadeUp.")
+    )
+    reply = voice.next_turn(_request((_exchange(),)))
+
+    assert isinstance(reply, GaveUp)
+    assert reply.note == "I asked for workspace_apply as call call_MadeUp."
+    assert reply.output_tokens == 31
+
+
+def test_the_same_reply_with_a_real_function_call_is_a_tool_request(voice):
+    """The contrast that makes the above a defect rather than a policy.
+
+    Identical prose, but one carries a `function_call` item. The text becomes
+    `why` and the run continues, so what separates a task that lives from one
+    that dies here is whether the model emitted the call or described it.
+    """
+    voice.client = _client_returning(
+        _Response(
+            output=[_FunctionCall()],
+            text="I asked for workspace_apply as call call_MadeUp.",
+        )
+    )
+    reply = voice.next_turn(_request((_exchange(),)))
+
+    assert isinstance(reply, AskForTool)
+    assert reply.tool_name == "workspace_apply"
+    assert reply.call_id == "call_realOne"
+    assert reply.arguments == {"operation": "read", "path": "a.md"}
+
+
+def _client_returning(response: Any) -> Any:
+    """A client whose `responses.create` hands back one prepared reply."""
+
+    class _Responses:
+        @staticmethod
+        def create(**_: Any) -> Any:
+            return response
+
+    return type("Client", (), {"responses": _Responses()})()

--- a/tasks/0822_saturday/HOST_PERMISSIONS.md
+++ b/tasks/0822_saturday/HOST_PERMISSIONS.md
@@ -1,0 +1,227 @@
+# The host permissions, in one place
+
+The V2 backend cannot run anything until a Firecracker host exists, and the
+host cannot be created because the identity that would create it holds no
+control-plane write anywhere. That sentence has been true since stage D. What
+it lacked was the detail an owner would need to act on it: which action, at
+which scope, for which principal, and what the smallest change is.
+
+This file is that detail. It is a **report**. The change is named here and
+left undone, because access belongs to whoever owns the subscription.
+
+Everything below was read. No write was attempted, no role was requested, and
+no model was called. Cost: nothing.
+
+---
+
+## The short answer
+
+| | |
+|---|---|
+| **Principal** | the app registration behind `secrets.AZURE_CLIENT_ID` / `vars.AZURE_AI_EXPECTED_CLIENT_ID` — the same identity the paid inference runs authenticate with |
+| **What it holds** | 2 role assignments, both **Cognitive Services OpenAI User**, both scoped to the Foundry account |
+| **Why that blocks** | that is a data-plane inference role. It carries no `Microsoft.Compute`, `Microsoft.Network` or `Microsoft.Resources` write at all, so every host action is denied for the same single reason |
+| **Smallest change** | **Virtual Machine Contributor + Network Contributor**, both at **resource-group scope**, on a resource group the owner creates first |
+| **Not the change** | nothing at subscription scope, no Owner, no `Microsoft.Authorization` write, no new subscription |
+
+The two roles are not a guess. They were evaluated against the real built-in
+role definitions, and the evaluation is pinned in
+`tests/test_azure_boot_host_survey.py::TestTheMinimalChangeIsCheckedNotAsserted`
+so it fails if either definition is described wrongly later.
+
+---
+
+## What is measured, and when
+
+The survey is `.github/workflows/azure-boot-host-survey.yml`, five reads over
+the ARM control plane. It runs only on `main`, because it authenticates by
+OIDC and a local `az` session reaches a different tenant — which is why a
+local run reports `not_measured` rather than a wrong answer.
+
+It has been run three times over two days, and the three agree exactly.
+
+| | 2026-09-11 · `34549220652` | 2026-09-12 · `34683287478` | 2026-09-12 · `34684908054` |
+|---|---|---|---|
+| right subscription | yes, Enabled | yes, Enabled | yes, Enabled |
+| `Microsoft.Compute` | Registered | Registered | Registered |
+| existing VMs | 0 | 0 | 0 |
+| `Standard_D8as_v5` quota, eastus2 | 100 limit / 0 in use / **100 free** (8 needed) | 100 / 0 / **100 free** | 100 / 0 / **100 free** |
+| role assignments held | 2 | 2 | 2 |
+| actions asked about | 3 | 3 | **12** |
+| actions permitted | **0 of 3** | **0 of 3** | **0 of 12** |
+| verdict | `blocked_and_the_change_is_named` | `blocked_and_the_change_is_named` | `blocked_and_the_change_is_named` |
+
+Four of the five reads are favourable. **The block is permissions and nothing
+else.** There is room, there is registration, there is no clutter.
+
+Both artifacts are committed: `boot_host_survey.json` (`1.0`, three actions)
+and `boot_host_survey_widened.json` (`1.1`, twelve). The narrower one is kept
+because it is the record the earlier write-ups cite; the three actions it
+measured are `false` in both, so the wider run extends it rather than
+correcting it.
+
+### Where the two assignments come from
+
+The survey reports the *count* of assignments, never their names or scopes.
+The names are in a different read — the Foundry RBAC diagnostic, run
+`34347345143` (2026-09-09), which reports both assignments as `role_name:
+"Cognitive Services OpenAI User"` at `scope_shape: "foundry-account"`.
+
+That is the whole explanation for the twelve `false`s. It is not a partial
+grant that needs topping up, and it is not a scope mismatch. The identity has
+inference rights on one AI resource and no control-plane rights on anything.
+
+---
+
+## Every action the deployment would take
+
+`infra/dev-host/main.bicep` declares six resources unconditionally and one
+conditionally, and each needs its own write. The survey now asks about all of
+them (`scripts/azure_boot_host_survey.py`, `artifact_version: 1.1`, merged as
+PR #559); the list is derived from the template and a test re-parses the
+template to prove nothing was missed.
+
+Run `34684908054` measured all twelve against the live identity. **Every one
+came back `false`.**
+
+**Always performed — all at resource-group scope:**
+
+| action | why |
+|---|---|
+| `Microsoft.Resources/deployments/write` | submit the template at all; a deployment is itself a resource |
+| `Microsoft.Network/networkSecurityGroups/write` | the security group that closes the host to the internet |
+| `Microsoft.Network/virtualNetworks/write` | the network and the subnet the host sits on |
+| `Microsoft.Network/networkInterfaces/write` | the interface |
+| `Microsoft.Compute/disks/write` | the data disk the guest images live on |
+| `Microsoft.Compute/virtualMachines/write` | the machine |
+| `Microsoft.DevTestLab/schedules/write` | the auto-shutdown that stops it billing overnight |
+| `Microsoft.Network/virtualNetworks/subnets/join/action` | put the interface on the subnet |
+| `Microsoft.Network/networkSecurityGroups/join/action` | apply the security group to the subnet |
+| `Microsoft.Network/networkInterfaces/join/action` | attach the interface to the machine |
+
+**Conditional — measured, but not part of the block:**
+
+| action | scope | only if |
+|---|---|---|
+| `Microsoft.Network/publicIPAddresses/write` | resource group | `attachPublicIp` is set, and the template defaults it to `false` |
+| `Microsoft.Resources/subscriptions/resourceGroups/write` | **subscription** | the resource group does not already exist |
+
+Twelve actions measured; ten of them block. The two conditionals are reported
+separately and never drive the verdict — a denial on an action the deployment
+does not perform is not a block.
+
+Two things the template does **not** need, worth stating so nobody grants them
+defensively: the image is `Canonical / ubuntu-24_04-lts / server / latest`, a
+free image with no Marketplace plan action, and the VM identity is
+`SystemAssigned`, so no `Microsoft.Authorization/roleAssignments/write` is
+involved.
+
+---
+
+## The minimal change
+
+### Option A — two built-in roles at resource-group scope *(recommended)*
+
+1. The owner creates the resource group. One action, done once, by someone who
+   already has it.
+2. Assign **Virtual Machine Contributor** on that resource group.
+3. Assign **Network Contributor** on that resource group.
+
+Why both. Virtual Machine Contributor covers `virtualMachines/*`,
+`disks/write`, `DevTestLab/schedules/*`, `networkInterfaces/*`,
+`deployments/*` and all three `join/action`s — but on network security groups
+and virtual networks it grants only `read` and `join`, not `write`. Those two
+writes are exactly what Network Contributor's `Microsoft.Network/*` closes.
+
+Checked, not assumed: against the real definitions, VM Contributor alone
+leaves precisely `Microsoft.Network/networkSecurityGroups/write` and
+`Microsoft.Network/virtualNetworks/write` unpermitted, and the pair covers
+every blocking action.
+
+Step 1 is what keeps this off the subscription. **Neither role grants
+`resourceGroups/write`**, so pre-creating the group is not a convenience — it
+is the thing that removes the only subscription-scope item on the list.
+
+### Option B — a custom role
+
+A custom role with exactly the ten blocking actions above, at resource-group
+scope, is strictly smaller than Option A: it excludes the `delete`,
+`powerOff`, `restart` and extension actions the two built-ins carry. It costs
+a role definition to author and maintain. Option A is recommended only because
+it uses definitions that already exist.
+
+Either way the scope is one resource group, and the grant can be removed by
+deleting the assignment.
+
+---
+
+## What this is not
+
+- Not a role request, and not a step toward one. Nothing here should be read
+  as authorisation to run `az role assignment create`.
+- Not a claim that a host in this subscription would boot a guest. That is a
+  different question, answered separately on a different machine
+  (`c2_first_boot.json`); it says the hardware can, not that this one will.
+- Not a cost question. The existing experiment approval is unaffected — this
+  changes access, not spend.
+- **Not the only thing in the way.** See immediately below.
+- Not urgent in the sense of blocking everything. See further below.
+
+## The grant is the first of four gates, not the last
+
+Reading this file and granting the two roles would not produce a real V2 run.
+Three further gates sit after it, each deliberately built to require a visible
+change rather than a flag:
+
+1. **The roles**, above. Blocked, and reported here.
+2. **Admission.** `AgenticV2ScriptedRunner` admits exactly one backend
+   identity and defaults to the fixture's. No module outside that file is even
+   allowed to mention the argument —
+   `test_nothing_in_this_repository_declares_a_non_default_identity` reads
+   every other module's source to enforce it, and the wiring layer documents
+   that it deliberately does not forward the parameter. That test is the line
+   that changes when a guest is admitted for real.
+3. **Activation.** The substrate, supply-chain and microVM manifests all
+   declare `production_activation: "disabled"`, and three separate validators
+   reject a document that says anything else. Flipping it is a reviewable edit
+   to the declarations, not a setting.
+4. **`browser_run`.** The real backend refuses it entirely, including the
+   local read the fixture serves. In trial_30 that same tool ended twelve of
+   thirty tasks, and on the real backend its refusal is wider, not narrower.
+   `TURN_LIMIT_COMPARISON_DESIGN.md` carries the measurement.
+
+Gates 2 and 3 are intentional and cost nothing to pass when the time comes.
+Gate 4 needs no access change at all and is the one piece of this that can be
+worked on today.
+
+## What continues without it
+
+Everything on the code side, which is most of the remaining work: the microVM
+backend's second verification standard, the ledger and retry wiring, the
+offline integration and isolation tests, and the run preparation. None of it
+needs a host or an access change.
+
+What it does block is the real execution backend. Until that exists, the V2
+stages run against the fixture backend, and a fixture result must never be
+reported as an isolation result. When a real backend does exist, the sequence
+is 5 → 30 → 220 on the verified path, with no implicit fall-back to the
+fixture.
+
+## Open, and honest about it
+
+The ten-action list is no longer derived. Run `34684908054` read all twelve
+against the live identity and every one is `false`, which closes the gap this
+section used to describe. It cost nothing, and it can be re-read any time from
+`main`.
+
+What remains genuinely open is the sentence that was never a permissions
+question: **nobody has measured that a machine in this subscription boots a
+guest.** The survey says a host could be created if the roles existed. It does
+not say the host would work. `c2_first_boot.json` answers that for different
+hardware in a different subscription, which is evidence about the hardware
+class and not about this one. The order is roles → host → boot test → backend,
+and only the first is currently named.
+
+`TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md` still says "none of the three writes
+permitted". That was true of the measurement it describes and remains true;
+it is narrower than what this file reports, not in conflict with it.

--- a/tasks/0822_saturday/HOST_PERMISSIONS.md
+++ b/tasks/0822_saturday/HOST_PERMISSIONS.md
@@ -194,6 +194,15 @@ Gates 2 and 3 are intentional and cost nothing to pass when the time comes.
 Gate 4 needs no access change at all and is the one piece of this that can be
 worked on today.
 
+Gate 4 is also larger than its name. The instruction text the model reads
+names three tools as refusing, and that list fits neither backend: on the
+fixture only two tools have no working call, and on the microVM backend
+`exec_run` — one of the three the text says is shut — is the capability the
+whole host exists to provide. Granting the roles and booting a host would
+produce a machine that runs commands and a model that has been told it
+cannot. Correcting the text is therefore on the critical path rather than
+beside it, and it is the only thing on that path that needs no access change.
+
 ## What continues without it
 
 Everything on the code side, which is most of the remaining work: the microVM

--- a/tasks/0822_saturday/HOST_PERMISSIONS.md
+++ b/tasks/0822_saturday/HOST_PERMISSIONS.md
@@ -201,7 +201,14 @@ fixture only two tools have no working call, and on the microVM backend
 whole host exists to provide. Granting the roles and booting a host would
 produce a machine that runs commands and a model that has been told it
 cannot. Correcting the text is therefore on the critical path rather than
-beside it, and it is the only thing on that path that needs no access change.
+beside it, and it needs no access change.
+
+A second item sits beside it, also needing no access change: the model is
+shown a paraphrase of its own previous turns rather than the turns, with the
+arguments dropped, and completing that paraphrase as text ended five more of
+trial_30's thirty tasks. That one is a defect rather than a description, and
+it is backend-independent — it will follow the run onto a real host unchanged.
+`TURN_LIMIT_COMPARISON_DESIGN.md` §4 carries both.
 
 ## What continues without it
 

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
@@ -2200,6 +2200,13 @@ the block will not.
 
 Verdict `blocked_and_the_change_is_named`.
 
+> **Narrower than the current answer, not in conflict with it.** This block
+> describes the first survey, which asked about three actions. The template
+> actually performs twelve, and run `34684908054` (2026-09-12) measured all
+> twelve as `false` — the three here among them, unchanged.
+> `HOST_PERMISSIONS.md` carries the full list, the scopes, the principal and
+> the minimal change.
+
 **Four of the five came back favourable.** It is the right subscription, the
 provider is registered, and eastus2 has room for an 8-vCPU host more than ten
 times over. Exactly one thing is missing: the run identity holds two role

--- a/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
+++ b/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
@@ -349,6 +349,48 @@ entry and its own approved amount, or a new approval. Note the gap between
 ceiling and reality — trial_30 spent 5.4% of its ceiling — so the ceiling is
 what gates the start, not what the run would cost.
 
+### These prices are for the broken replay format
+
+Every figure above assumes the replay described in §4: past turns come back as
+one short line of prose with the arguments dropped. That is why they are cheap.
+Fixing it means re-sending every argument the model ever passed, on every
+subsequent turn, and the cost of that is not small.
+
+Measured against trial_30, from the ledger — which agrees exactly with the
+conversation records, 1,140,544 input and 218,697 output tokens, `gpt-5.4` at
+$2.50 / $15.00 per million:
+
+| | tokens | at the cohort's prices |
+|---|---|---|
+| input actually billed | 1,140,544 | $2.851 |
+| output actually billed | 218,697 | $3.280 |
+| **actual total** | | **$6.131815** |
+| input a faithful replay would add | **+719,526** | **+$1.799** |
+| would-be total | | ~$7.93, **+29%** |
+
+The 719,526 is an estimate with a stated basis, not a measurement: a faithful
+replay re-sends every past argument, so its extra input at turn *n* is taken as
+the tokens the model emitted on turns 0..*n*−1. That over-counts slightly,
+because output tokens include the model's spoken `why` as well as the arguments.
+The magnitude is the point, and the magnitude is tens of percent.
+
+Two consequences.
+
+**The surcharge grows faster than the limit does.** It is the sum of a running
+total, so it is quadratic in conversation length while the priced ceilings above
+are close to linear. Fixing the replay makes the 12-call row further out of
+reach than it already is, not equally so.
+
+**The ceilings must be re-derived after the fix, before the fix's run is
+scheduled.** They are the `may start` column, so a fix that lands without
+re-pricing would let a run start against a ceiling computed for a cheaper
+harness. That is the one ordering constraint this fix carries.
+
+One thing this does not change: the ledger's own `model_cost_usd` column is
+zero on all of trial_30's rows, so $6.131815 is a figure derived by applying
+the shared price table afterwards, not one the run recorded. It reproduces to
+six decimal places, and it is derived rather than read.
+
 Stopping rule: if the effect on the 18 does not exceed the repeat spread, the
 limit stays at 8 and the question is closed.
 
@@ -377,7 +419,11 @@ In order:
    turns with the arguments stripped, and finishing that paraphrase as text
    ended five more tasks. Unlike everything else here it is a defect rather
    than a condition somebody chose, and its likelihood rises with the very
-   axis this experiment wants to move.
+   axis this experiment wants to move. It is the one fix with a price: a
+   faithful replay costs roughly 29% more on this cohort, quadratically more
+   as the limit rises, so **the ceilings in §9 have to be re-derived before
+   its run is scheduled** (§9, "These prices are for the broken replay
+   format").
 
    These two can be fixed in the same run, and probably should be: the goal is
    a platform to measure the limit on, not an effect estimate for either fix.

--- a/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
+++ b/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
@@ -52,7 +52,11 @@ changed it must not be changed in the same run as the limit.
 
 Everything else is held at trial_30's values: same 30 tasks, same model, same
 `max_output_tokens_per_turn: 8192`, same `retry_max_attempts`, same
-`max_result_bytes`, same instructions.
+`max_result_bytes`, same instructions — **and the same replay format**. That
+last one is not a setting and does not appear in any config file, which is
+exactly why it is written down here: `_input_for` decides what the model is
+shown of its own history, changing it changes the input at every turn, and a
+run that moved it alongside the limit could not separate the two. See §4.
 
 ## 4. What the limit can actually reach
 
@@ -62,21 +66,30 @@ each turn, not from the labels:
 
 | | tasks | what happened |
 |---|---|---|
-| ended on `browser_run` | **12** | one call, reaching the network — 8 a `search`, 4 an `open_url`. Refused, task over. 2–5 of the 9 calls allowed. None retried |
+| ended on `browser_run` | **12** | one call, reaching the network — 8 a `search`, 4 an `open_url`. Refused, task over. 2–5 of the 9 calls allowed. None retried. All 12 failed |
 | ended on `workspace_apply` | **2** | same terminal refusal, different tool. One was rescued by a retry, one also hit the ceiling and failed |
-| ran out of calls, desk never broke | **9** | 5 rescued by a retry, 4 failed |
-| gave up early, without committing | **2** | stopped well short of the limit |
-| finished inside the limit | **5** | never came near the ceiling |
+| ran out of calls, desk never broke | **7** | `stop_reason: turn_limit_reached`. 3 rescued by a retry, 4 failed |
+| stopped without a tool call | **2** | not the model giving up — see below. Both failed |
+| finished inside the limit | **7** | all succeeded. Two of them on their ninth and last call |
 
 That is 30 tasks, 11 successes and 19 errors, which is trial_30's headline.
+
+An earlier draft of this table read 9 / 2 / 5 for the last three rows. The 9
+came from counting attempts that used every call in their budget, which is not
+the same question: two tasks used **9 of 9** and finished normally, calling
+`finalize` on the last call they had. Counted by `stop_reason` — the field that
+says why the loop stopped — the ceiling group is 7 and the finished group is 7.
+The two are in the finished group here, and they are the clearest candidates
+for a higher limit helping, which the old split hid.
 
 Two things follow.
 
 **The limit can only act on 18 of the 30 tasks.** The twelve that ended on
 `browser_run` were ended before the ceiling was anywhere near. Of the eighteen
-that remain, ten touched the ceiling in some attempt and five of those already
-reach success through a retry — so the visible effect is bounded at roughly
-five tasks out of thirty before any noise is considered.
+that remain, **8 hit the ceiling in some attempt and 3 of those already reach
+success through a retry** — so the visible effect is bounded at five tasks out
+of thirty before any noise is considered. (Ten of the 18 *used* every call;
+the two that finished on the last one are not tasks a higher limit rescues.)
 
 **The 18 is not a stable denominator.** A model given more turns has more
 chances to reach `browser_run` and be terminated, so tasks can move *into* the
@@ -84,6 +97,69 @@ terminated group as the limit rises. A naive success-rate comparison would
 confound "more turns helped" with "more turns found the trapdoor". Any result
 must be reported on the fixed set of 18 task ids from trial_30, with movement
 in and out of the terminated group reported separately.
+
+And there is a second reason the denominator moves, worse than the first
+because it is not a trapdoor the model can avoid. Five of the 18 hit the
+"stopped without a tool call" ending, three of them in the same task as a
+ceiling hit, and **none of the five succeeded**. That ending gets more likely
+with every extra turn, for the reason set out next.
+
+### The fifth ending, which is the harness finishing its own sentence
+
+`stop_reason: model_stopped_without_finishing` reads as the model walking away,
+and the dataclass behind it says so in as many words. Nine attempts across five
+tasks ended that way. None of them is a model giving up, and there is no
+give-up text to preserve.
+
+Every one of the nine carries a note of the same shape:
+
+```
+the model stopped without committing an answer:
+I asked for workspace_apply as call call_U8QbjyWEKeR6j4I7sKplBSdK.
+```
+
+That sentence is not the model's own phrasing. It is the harness's.
+`AzureFoundryVoice._input_for` rebuilds the whole conversation before every
+turn — correctly, and the budget is worked out on the assumption that it does —
+but what it rebuilds is a paraphrase. Each of the model's earlier turns comes
+back as one line of prose in exactly that form, and **the arguments of the call
+are dropped**. The tool's answer is replayed in full as JSON; the request that
+produced it is not. So a model eight turns in has eight lines telling it that
+it asked for `workspace_apply`, and no record of which file it read or wrote.
+
+Shown that format repeatedly, the model eventually produces the next line of it
+as text instead of emitting a function call. `next_turn` looks for a
+`function_call` item, finds none, and returns `GaveUp` carrying whatever the
+model said — which is how the harness's own replay format ended up recorded as
+the reason a task stopped.
+
+Four things say this is imitation rather than a model choosing to stop, and all
+four are in the record:
+
+- the call ids in those notes are well-formed and **none appears anywhere
+  earlier in its own conversation**. They were invented, not repeated
+- all nine name `workspace_apply`, which is 254 of the cohort's 296 tool calls
+  and so by far the most repeated line in any replayed history
+- all nine are 29–32 output tokens: one sentence, not an explanation
+- it never happens on the first turn. The earliest is the third. With no
+  history there is nothing to imitate
+
+`test_the_model_is_shown_a_paraphrase_of_its_own_turns.py` pins both halves —
+the replay format and the no-function-call branch — without calling a model.
+
+This matters twice over for the limit question. It is a failure that **gets
+more likely with every extra turn**, because every turn adds another line of
+the pattern; and the information loss it comes from also grows with the turn
+count, so the extra turns a higher limit buys are turns with thinner history
+than the ones before them. A comparison that raised the limit without touching
+this would be measuring the two together.
+
+It is also a defect rather than a stated condition, which separates it from
+everything else in this section. `browser_run` and `exec_run` behave as built
+and are described wrongly to the model; this one nobody chose. It is the
+strongest candidate for the first fix, and like the instruction text it needs
+no access change — but it changes the model's input, so it is an intervention
+on a pinned run condition and gets its own config file and run id.
 
 ### The thing worth fixing first
 
@@ -297,13 +373,23 @@ In order:
    unrelated to the limit, and what is wrong is the instruction text rather
    than the harness — the cheapest thing in the area to correct. Own run id,
    own record.
-2. **Measure the repeat spread** at the control setting, so a difference has
+2. **Fix the replay format.** The model is shown a paraphrase of its own
+   turns with the arguments stripped, and finishing that paraphrase as text
+   ended five more tasks. Unlike everything else here it is a defect rather
+   than a condition somebody chose, and its likelihood rises with the very
+   axis this experiment wants to move.
+
+   These two can be fixed in the same run, and probably should be: the goal is
+   a platform to measure the limit on, not an effect estimate for either fix.
+   What that run may not then claim is how much each one contributed. It is a
+   new baseline, and it needs saying that way.
+3. **Measure the repeat spread** at the control setting, so a difference has
    something to be compared against.
-3. **Then** run the limit comparison, on the fixture backend, on the fixed set
+4. **Then** run the limit comparison, on the fixture backend, on the fixed set
    of task ids from trial_30, reporting movement into and out of the
    terminated group separately from the success count.
 
-If the comparison is wanted before step 2, it can still run — but its output
+If the comparison is wanted before step 3, it can still run — but its output
 is a description of two runs, not a measured effect, and it must be written
 that way.
 
@@ -315,7 +401,7 @@ conditions     control = 8 (trial_30's 30 task ids, fixture backend)
                variant = one value, new config file, new run id
 axes           moving: the limit. fixed: backend, refusal behaviour, model,
                max_output_tokens_per_turn, retry policy, max_result_bytes,
-               instructions, cohort
+               instructions, replay format, cohort
 adjudication   finalize called and artifacts opened. Completion, not quality.
                No judge, so no judge to validate
 input          30 task ids fixed before the question was raised; not a random
@@ -323,6 +409,8 @@ input          30 task ids fixed before the question was raised; not a random
 unit           tasks completed out of the 18 the limit can reach; USD from the
                ledger
 stop           effect below the repeat spread → the limit stays at 8
-known          the 18 is not stable across conditions; the repeat spread is
-confounds      unmeasured; the cohort is not representative of the 220
+known          the 18 is not stable across conditions, and moves in two
+confounds      directions that both worsen with the limit — browser_run's
+               trapdoor and the paraphrase ending; the repeat spread is
+               unmeasured; the cohort is not representative of the 220
 ```

--- a/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
+++ b/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
@@ -115,6 +115,11 @@ destination]` returns `returncode: 0` and really uppercases the file. Every
 other argv — including `fixture-upper` with the wrong number of arguments —
 answers `capability_unavailable` and ends the task.
 
+Swept across the whole contract, giving each of the eight tools the best call
+it allows, the count comes out at **two**: only `environment_resolve` and
+`environment_activate` have no working call under `offline-full-v1`. The
+instructions name three. The third is `exec_run`, and it works.
+
 The model could have found that one out. `capabilities_query(kind:
 "commands")` returns `["fixture-upper"]`, and `kind: "budgets"` states the
 turn limit outright. So of the three things worth knowing about this room, two

--- a/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
+++ b/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
@@ -46,9 +46,9 @@ trial_30 used, whatever the state of the host permissions
 (`HOST_PERMISSIONS.md`) at the time.
 
 **The refusal behaviour must not move either.** `agentic_v2_runner.py:772`
-ends a task on its first tool result that is not `ok: true`. If that is changed
-— and there is a good argument that it should be — it must not be changed in
-the same run as the limit.
+ends a task on its first tool result that is not `ok: true`. Changing that is
+not a setting — it reaches the trace schema (see §4) — but if it is ever
+changed it must not be changed in the same run as the limit.
 
 Everything else is held at trial_30's values: same 30 tasks, same model, same
 `max_output_tokens_per_turn: 8192`, same `retry_max_attempts`, same
@@ -107,12 +107,48 @@ and hashes that string into `browser_build_sha256` where nothing can read it.
 So the instruction text is the only account of which tools refuse, which makes
 the omission load-bearing rather than untidy.
 
-That is a documented-versus-actual mismatch, not a model result, and it is
-cheaper to settle than the limit question. Two candidate fixes, either of
-which is its own intervention with its own run id: name `browser_run` in the
-instructions as refusing for network operations, or make a
-`capability_unavailable` non-terminal so the loop the instructions describe is
-the loop that runs.
+### Which layer is actually out of step
+
+It is tempting to call this a harness bug, and it is not. Both code layers
+document their own behaviour accurately, and they document opposite things.
+
+`agentic_v2_conversation.py:504-511` keeps a table of the tool failures that
+end a run, and says that everything absent from it — `capability_unavailable`
+included — is handed back to the model, because "reading a refusal and choosing
+something else is the one behaviour stage one exists to measure, so a loop that
+gave up at the first refusal would measure nothing". That is the loop the
+instructions describe.
+
+`agentic_v2_runner.py:772` never lets that table be consulted. Any dispatch
+whose result is not `ok: true` raises out of the tool desk. The runner's own
+docstring gives the reason, and the reason is not a preference:
+`verify_agentic_v2_result` raises *"agentic v2 tool event follows terminal
+result"* for any tool event recorded after an `ok: false` one
+(`agentic_v2_provenance.py:423`). A run that continued past a refusal could
+not produce a verifiable record of itself. The docstring then names the cost in
+so many words — "a model gets one tool mistake per task, and the conversation
+loop's ability to show it an error and let it choose again cannot actually be
+used" — and names the change that would lift it: the trace schema.
+
+The plumbing between the two is deliberate too. The runner writes its ending
+down before it throws, so the conversation's `except Exception` labelling it
+`tool_desk_broke` does not become the task's verdict. Checked in the record:
+all fourteen desk breaks carry `detail: "running the tool failed: _EndTheRun"`
+at conversation level, while the twelve `browser_run` tasks carry
+`terminal_error_category: "capability_unavailable"` at task level. The tool's
+own error survives, which is the behaviour the comment claims.
+
+So the only text that is out of step with the build is the one the model reads.
+That narrows the fixes and separates them by an order of magnitude:
+
+| | what changes | size |
+|---|---|---|
+| name `browser_run` in the instructions as refusing for network operations | one pinned string | small, and settles the 12 |
+| make `capability_unavailable` survivable | the trace schema, its verifier, and the conversation table | large, and explicitly flagged in-code as separate and reviewable |
+
+The second is not the cheap one-line change an earlier draft of this file
+implied by listing it beside the first. Either is its own intervention with its
+own run id; only the first is worth doing before the limit question.
 
 ### It gets worse on the backend this is all waiting for
 
@@ -206,8 +242,9 @@ Not ready to run, and the blocker is not money.
 In order:
 
 1. **Settle `browser_run`.** It removes 40% of the cohort for a reason
-   unrelated to the limit, and it is an instruction-versus-harness mismatch
-   rather than a finding. Own run id, own record.
+   unrelated to the limit, and what is wrong is the instruction text rather
+   than the harness — the cheapest thing in the area to correct. Own run id,
+   own record.
 2. **Measure the repeat spread** at the control setting, so a difference has
    something to be compared against.
 3. **Then** run the limit comparison, on the fixture backend, on the fixed set

--- a/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
+++ b/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
@@ -91,18 +91,20 @@ success through a retry** — so the visible effect is bounded at five tasks out
 of thirty before any noise is considered. (Ten of the 18 *used* every call;
 the two that finished on the last one are not tasks a higher limit rescues.)
 
-**The 18 is not a stable denominator.** A model given more turns has more
-chances to reach `browser_run` and be terminated, so tasks can move *into* the
-terminated group as the limit rises. A naive success-rate comparison would
-confound "more turns helped" with "more turns found the trapdoor". Any result
-must be reported on the fixed set of 18 task ids from trial_30, with movement
-in and out of the terminated group reported separately.
+**The 18 is not a stable denominator — but less unstable than it looks.** The
+worry is that a model given more turns has more chances to reach `browser_run`
+and be terminated, so tasks move *into* the terminated group as the limit
+rises, and a naive success-rate comparison confounds "more turns helped" with
+"more turns found the trapdoor". That worry is arithmetically sound and the
+cohort does not support it. See "Neither trapdoor is a late-conversation
+event" below. Either way the reporting rule is the same: results go on the
+fixed set of 18 task ids from trial_30, with movement in and out of the
+terminated group reported separately from the success count.
 
-And there is a second reason the denominator moves, worse than the first
-because it is not a trapdoor the model can avoid. Five of the 18 hit the
-"stopped without a tool call" ending, three of them in the same task as a
-ceiling hit, and **none of the five succeeded**. That ending gets more likely
-with every extra turn, for the reason set out next.
+And there is a second ending that removes tasks for a reason unrelated to the
+limit. Five of the 18 hit the "stopped without a tool call" ending, three of
+them in the same task as a ceiling hit, and **none of the five succeeded**.
+What that ending is, is set out next.
 
 ### The fifth ending, which is the harness finishing its own sentence
 
@@ -147,12 +149,12 @@ four are in the record:
 `test_the_model_is_shown_a_paraphrase_of_its_own_turns.py` pins both halves —
 the replay format and the no-function-call branch — without calling a model.
 
-This matters twice over for the limit question. It is a failure that **gets
-more likely with every extra turn**, because every turn adds another line of
-the pattern; and the information loss it comes from also grows with the turn
-count, so the extra turns a higher limit buys are turns with thinner history
-than the ones before them. A comparison that raised the limit without touching
-this would be measuring the two together.
+This matters for the limit question, though not in the way I first wrote it.
+The information loss it comes from does grow with the turn count: the extra
+turns a higher limit buys are turns whose history is thinner than the ones
+before them. But the failure itself is not a late-conversation event — see
+directly below — so "more turns means more of this" is not what the cohort
+shows.
 
 It is also a defect rather than a stated condition, which separates it from
 everything else in this section. `browser_run` and `exec_run` behave as built
@@ -160,6 +162,46 @@ and are described wrongly to the model; this one nobody chose. It is the
 strongest candidate for the first fix, and like the instruction text it needs
 no access change — but it changes the model's input, so it is an intervention
 on a pinned run condition and gets its own config file and run id.
+
+### Neither trapdoor is a late-conversation event
+
+Both of the "more turns means more chances to die" arguments in this file are
+mechanically plausible, and neither survives contact with the cohort. Counting
+each ending against the conversations that actually reached that turn — the
+denominator shrinks as conversations end, which is what makes this a hazard
+rate rather than a share of the total:
+
+| turn | conversations reaching it | `browser_run` | | stopped without a tool call | |
+|---|---|---|---|---|---|
+| 0 | 50 | 0 | — | 0 | — |
+| 1 | 50 | 4 | 8.0% | 0 | — |
+| 2 | 45 | 6 | 13.3% | 1 | 2.2% |
+| 3 | 38 | 1 | 2.6% | 4 | **10.5%** |
+| 4 | 32 | 1 | 3.1% | 3 | 9.4% |
+| 5 | 26 | 0 | — | 1 | 3.8% |
+| 6 | 24 | 0 | — | 0 | — |
+| 7 | 21 | 0 | — | 0 | — |
+| 8 | 19 | 0 | — | 0 | — |
+
+`browser_run` fires at turns 1–2 and never after turn 4. The paraphrase ending
+fires at turns 2–5, needs history to exist at all, and never after turn 5.
+**Twenty-four conversations reached turn 6 and none of them died to either
+cause.** On this cohort the extra turns a higher limit would add are the turns
+where nothing went wrong.
+
+That is a real result and it should not be over-read. Nine and twelve events
+are few, and the denominators thin out: zero events in the 24 conversations
+that reached turn 6 is consistent with a true hazard of up to about 12%. So
+this does not show the hazard *is* zero late on. It shows the cohort gives no
+support to a hazard that rises with turn count, which is what the "unstable
+denominator" worry needs. The worry stays in the design as something to report
+on, and it drops out of the argument for doing the two fixes first — those
+stand on removing 17 of 30 tasks for reasons unrelated to the limit, which
+does not depend on when the removals happen.
+
+A repeat at the control setting (§10) would sharpen this, because it measures
+the same hazards on the same tasks a second time. That is one more thing the
+unmeasured repeat spread is currently costing.
 
 ### The thing worth fixing first
 
@@ -205,10 +247,11 @@ the instruction text.
 
 **None of this touched trial_30.** All thirty obeyed the instruction and never
 called `exec_run`, so the `fixture-upper` trapdoor is exposure, not a finding
-about that run. It matters here for one reason: it is a second way for a task
-to die that more turns gives it more chances to reach, which is the same
-argument §4 makes about `browser_run` and the reason the 18 is not a stable
-denominator.
+about that run. It matters here for one reason: it is a third way for a task to
+die on a single wrong call, in a cohort where two such ways already removed 14
+of 30. Whether extra turns make any of them more likely is a separate question,
+and the answer on this cohort is no — see "Neither trapdoor is a
+late-conversation event" above.
 
 ### Which layer is actually out of step
 
@@ -418,8 +461,7 @@ In order:
 2. **Fix the replay format.** The model is shown a paraphrase of its own
    turns with the arguments stripped, and finishing that paraphrase as text
    ended five more tasks. Unlike everything else here it is a defect rather
-   than a condition somebody chose, and its likelihood rises with the very
-   axis this experiment wants to move. It is the one fix with a price: a
+   than a condition somebody chose. It is also the one fix with a price: a
    faithful replay costs roughly 29% more on this cohort, quadratically more
    as the limit rises, so **the ceilings in §9 have to be re-derived before
    its run is scheduled** (§9, "These prices are for the broken replay
@@ -455,8 +497,11 @@ input          30 task ids fixed before the question was raised; not a random
 unit           tasks completed out of the 18 the limit can reach; USD from the
                ledger
 stop           effect below the repeat spread → the limit stays at 8
-known          the 18 is not stable across conditions, and moves in two
-confounds      directions that both worsen with the limit — browser_run's
-               trapdoor and the paraphrase ending; the repeat spread is
-               unmeasured; the cohort is not representative of the 220
+known          two endings remove 17 of 30 tasks for reasons unrelated to the
+confounds      limit — browser_run's trapdoor and the paraphrase ending. Both
+               fire early (hazard 0 past turn 5 on this cohort, but only 19-24
+               conversations reach turns 6-8, so that is weak evidence);
+               the repeat spread is unmeasured; the cohort is not
+               representative of the 220; the priced ceilings assume the
+               current replay format
 ```

--- a/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
+++ b/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
@@ -61,8 +61,9 @@ run that moved it alongside the limit could not separate the two. See §4.
 ## 4. What the limit can actually reach
 
 The cohort does not divide the way the disposition labels suggest. Read from
-`run_record.json` — from each attempt's `budget_after` and the `tool_name` on
-each turn, not from the labels:
+`run_record.json`, one row per task across all its attempts, classified by each
+attempt's `stop_reason` — not by the disposition label, and **not** by
+`budget_after`, which is the mistake corrected below the table:
 
 | | tasks | what happened |
 |---|---|---|
@@ -82,7 +83,7 @@ says why the loop stopped — the ceiling group is 7 and the finished group is 7
 The two are in the finished group here, and they are the clearest candidates
 for a higher limit helping, which the old split hid.
 
-Two things follow.
+Three things follow.
 
 **The limit can only act on 18 of the 30 tasks.** The twelve that ended on
 `browser_run` were ended before the ceiling was anywhere near. Of the eighteen

--- a/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
+++ b/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
@@ -197,6 +197,31 @@ So settling `browser_run` is not tidying ahead of the limit question. It is a
 precondition for the real backend being usable at all, and it is the one item
 on that path that needs no access change.
 
+### The instruction list matches neither backend
+
+Put the two side by side and the list the model is given fits neither the
+backend it ran against nor the one it is waiting for.
+
+| tool | fixture (`offline-full-v1`) | microVM (the destination) | instructions say |
+|---|---|---|---|
+| `exec_run` | one command, `fixture-upper` | **works** — boots a machine per call | refuses |
+| `browser_run` | 3 local ops served, 2 network refused | **refuses all five** | available |
+| `environment_resolve` | refuses | refuses — the guest has only loopback | refuses |
+| `environment_activate` | refuses | refuses — nothing to activate | refuses |
+| no working call at all | **2 tools** | **3 tools** | 3 tools |
+
+The two the text gets right on both backends are the package pair. `exec_run`
+is wrong on both, in opposite directions, and `browser_run` is wrong on both
+by omission — partly on the fixture, entirely on the real one.
+
+That matters for the order of work. When the real backend arrives, the
+instruction text has to change anyway: leaving it as it stands would tell the
+model that the one capability the real backend adds — running commands — is
+shut, which is the mistake this repository already has a name for. So the
+instruction fix is not gate-4 hygiene to be done if there is time. It is on
+the critical path to the real backend, and it is the only thing on that path
+that can be done today.
+
 ## 5. What judges the outcome
 
 Nothing model-shaped. `success` means `finalize` was called and its artifacts

--- a/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
+++ b/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
@@ -1,0 +1,239 @@
+# Does 8 tool calls hold the model back? — a design, not yet a run
+
+`tool_calls_per_attempt: 8` is a pinned condition of stage one. It gives an
+attempt nine model calls: eight tool turns and one commit. Nobody chose eight
+for a measured reason, and eleven of trial_30's twenty-one failed attempts
+ended with the harness saying, verbatim, *"the model has been asked 9 times,
+which is all the 9 this run was allowed"*.
+
+So the question is fair. This file works it through before any setting is
+changed, and reaches a verdict that is not "run it".
+
+**trial_30 is not modified by anything here.** Neither is its sealed
+preregistration. Any comparison gets a new config file and a new run id.
+
+---
+
+## 1. What decision turns on the answer
+
+Whether full_220 runs at 8 or at something larger. That is a real fork with a
+real price: the stage ceiling scales close to linearly with the limit, so the
+decision is also a budget decision. If the answer is "8 is fine", the cheapest
+setting is also the right one and that is worth knowing.
+
+## 2. What would show the hypothesis is wrong
+
+Hypothesis: *tasks fail at this limit because they run out of turns, not
+because the model cannot do them.*
+
+It is wrong if, at a higher limit, the tasks that previously ran out still
+fail — they simply fail later, having spent more. That outcome is publishable
+and settles the limit for full_220 at 8.
+
+It is also wrong, in a more interesting way, if the higher limit makes things
+*worse*. See §4: more turns means more opportunities to call a tool that ends
+the task.
+
+## 3. How many axes move
+
+This is where the design bites.
+
+**The backend must not move.** A comparison run against a real Firecracker
+backend, against a trial_30 run against the fixture backend, changes the limit
+and the execution capability together and can say nothing about the limit
+alone. The comparison therefore runs on the **fixture backend**, the same one
+trial_30 used, whatever the state of the host permissions
+(`HOST_PERMISSIONS.md`) at the time.
+
+**The refusal behaviour must not move either.** `agentic_v2_runner.py:772`
+ends a task on its first tool result that is not `ok: true`. If that is changed
+— and there is a good argument that it should be — it must not be changed in
+the same run as the limit.
+
+Everything else is held at trial_30's values: same 30 tasks, same model, same
+`max_output_tokens_per_turn: 8192`, same `retry_max_attempts`, same
+`max_result_bytes`, same instructions.
+
+## 4. What the limit can actually reach
+
+The cohort does not divide the way the disposition labels suggest. Read from
+`run_record.json` — from each attempt's `budget_after` and the `tool_name` on
+each turn, not from the labels:
+
+| | tasks | what happened |
+|---|---|---|
+| ended on `browser_run` | **12** | one call, reaching the network — 8 a `search`, 4 an `open_url`. Refused, task over. 2–5 of the 9 calls allowed. None retried |
+| ended on `workspace_apply` | **2** | same terminal refusal, different tool. One was rescued by a retry, one also hit the ceiling and failed |
+| ran out of calls, desk never broke | **9** | 5 rescued by a retry, 4 failed |
+| gave up early, without committing | **2** | stopped well short of the limit |
+| finished inside the limit | **5** | never came near the ceiling |
+
+That is 30 tasks, 11 successes and 19 errors, which is trial_30's headline.
+
+Two things follow.
+
+**The limit can only act on 18 of the 30 tasks.** The twelve that ended on
+`browser_run` were ended before the ceiling was anywhere near. Of the eighteen
+that remain, ten touched the ceiling in some attempt and five of those already
+reach success through a retry — so the visible effect is bounded at roughly
+five tasks out of thirty before any noise is considered.
+
+**The 18 is not a stable denominator.** A model given more turns has more
+chances to reach `browser_run` and be terminated, so tasks can move *into* the
+terminated group as the limit rises. A naive success-rate comparison would
+confound "more turns helped" with "more turns found the trapdoor". Any result
+must be reported on the fixed set of 18 task ids from trial_30, with movement
+in and out of the terminated group reported separately.
+
+### The thing worth fixing first
+
+Across all 30 tasks the cohort made **zero** calls to `exec_run`,
+`environment_resolve` and `environment_activate` — the three tools the
+instructions say refuse. The model obeyed the instruction exactly. What ended
+40% of the cohort was `browser_run`, which the instructions present as
+available and which the fixture backend half-opens: a local `path` read
+succeeds, a `search` or `open_url` is refused
+(`agentic_v2_fixture_backend.py:272`).
+
+The instructions also tell the model that calling a refusing tool again "will
+not change the answer, and the calls are counted against you" — wording that
+describes a loop where a refusal is survivable. In this build it is not.
+
+And the model could not have found out for itself. `capabilities_query` is the
+tool for asking what the environment has, and the five things it answers about
+are commands, runtimes, packages, formats and budgets — none of them is
+*tools*. The backend knows the answer, records it as `fixture-local-only-v1`,
+and hashes that string into `browser_build_sha256` where nothing can read it.
+So the instruction text is the only account of which tools refuse, which makes
+the omission load-bearing rather than untidy.
+
+That is a documented-versus-actual mismatch, not a model result, and it is
+cheaper to settle than the limit question. Two candidate fixes, either of
+which is its own intervention with its own run id: name `browser_run` in the
+instructions as refusing for network operations, or make a
+`capability_unavailable` non-terminal so the loop the instructions describe is
+the loop that runs.
+
+### It gets worse on the backend this is all waiting for
+
+`AgenticV2MicroVMBackend.browser_run` refuses **every** operation, including
+`open_local`, and says why: the guest has chromium and the file is on the work
+disk, but nothing starts it, collects what it rendered, or bounds how long it
+runs, so a hash of a file the model already has "would look like a browser
+having run".
+
+That is the right call and it widens the trap. On the fixture backend a local
+`path` read succeeds; on the real one it does not. This cohort happens not to
+notice — all twelve went straight to the network and never made a local read —
+so the measured effect on these thirty tasks is the same twelve either way.
+The exposure is not the same. Whatever fraction of the 220 would have used
+`browser_run` to open a local file is failing silently today only because
+these thirty did not try.
+
+So settling `browser_run` is not tidying ahead of the limit question. It is a
+precondition for the real backend being usable at all, and it is the one item
+on that path that needs no access change.
+
+## 5. What judges the outcome
+
+Nothing model-shaped. `success` means `finalize` was called and its artifacts
+opened — mechanical, checkable in the record. **That measures completion, not
+quality.** Deliverable quality would need grading, and trial_30's
+`grading_approved_maximum_usd` is `null` with a written reason. Any claim from
+this comparison is a claim about whether the loop finishes, and must be
+labelled as such.
+
+## 6. Declared versus controlled
+
+The limit is genuinely controlled: the harness's own budget records
+`model_calls_allowed` and `model_calls_made` per attempt, so the condition can
+be verified from the artifact rather than trusted from the config. This is the
+one axis in this experiment that does not need a caveat.
+
+## 7. What the instruments measure
+
+Turn usage from `conversations.conversations[*].budget_after`. Cost from the
+ledger, one `--ledger` per leg, priced by the shared table — which must not be
+edited while any leg is in flight. Completion from `status`. No unit
+conversion anywhere, so no conversion to get wrong.
+
+## 8. Whether the input favours the intervention
+
+The 30 tasks were fixed before the limit question was raised, so the cohort was
+not chosen to make a higher limit look good. It is not a random sample of the
+220 and the comparison inherits whatever selection it carries; that is a
+limit on generalising to full_220, not a bias toward the intervention.
+
+## 9. When to stop — and the wall this hits
+
+Priced against the real 30-task cohort through the plan's own guard, not
+extrapolated:
+
+| tool calls | model calls | trial_30 ceiling | % of the $200 approval | may start |
+|---|---|---|---|---|
+| 4 | 5 | $34.77 | 17.4% | yes |
+| 6 | 7 | $69.06 | 34.5% | yes |
+| **8** | **9** | **$114.60** | **57.3%** | yes — the control; actual spend was $6.13 |
+| 12 | 13 | $239.49 | 119.7% | **no** |
+| 16 | 17 | $409.43 | 204.7% | **no** |
+| 32 | 33 | $1539.78 | 769.9% | **no** |
+
+**Under the approval that exists, only limits at or below the control may
+start on 30 tasks.** The interesting direction is the one that is closed. An
+upward comparison needs either a smaller paired cohort with its own `stages.`
+entry and its own approved amount, or a new approval. Note the gap between
+ceiling and reality — trial_30 spent 5.4% of its ceiling — so the ceiling is
+what gates the start, not what the run would cost.
+
+Stopping rule: if the effect on the 18 does not exceed the repeat spread, the
+limit stays at 8 and the question is closed.
+
+## 10. The gap that makes this not-ready
+
+**The repeat spread has never been measured.** trial_30 ran once. A bounded
+effect of about five tasks in thirty is exactly the size that a single repeat
+of the same settings could produce on its own. Comparing two single runs would
+produce a number that cannot be told apart from noise, and the fact that it
+came out of a correctly-configured harness would make it more convincing than
+it deserves to be.
+
+---
+
+## Verdict
+
+Not ready to run, and the blocker is not money.
+
+In order:
+
+1. **Settle `browser_run`.** It removes 40% of the cohort for a reason
+   unrelated to the limit, and it is an instruction-versus-harness mismatch
+   rather than a finding. Own run id, own record.
+2. **Measure the repeat spread** at the control setting, so a difference has
+   something to be compared against.
+3. **Then** run the limit comparison, on the fixture backend, on the fixed set
+   of task ids from trial_30, reporting movement into and out of the
+   terminated group separately from the success count.
+
+If the comparison is wanted before step 2, it can still run — but its output
+is a description of two runs, not a measured effect, and it must be written
+that way.
+
+## The record this would keep
+
+```
+intervention   tool_calls_per_attempt, and nothing else
+conditions     control = 8 (trial_30's 30 task ids, fixture backend)
+               variant = one value, new config file, new run id
+axes           moving: the limit. fixed: backend, refusal behaviour, model,
+               max_output_tokens_per_turn, retry policy, max_result_bytes,
+               instructions, cohort
+adjudication   finalize called and artifacts opened. Completion, not quality.
+               No judge, so no judge to validate
+input          30 task ids fixed before the question was raised; not a random
+               sample of the 220
+unit           tasks completed out of the 18 the limit can reach; USD from the
+               ledger
+stop           effect below the repeat spread → the limit stays at 8
+known          the 18 is not stable across conditions; the repeat spread is
+confounds      unmeasured; the cohort is not representative of the 220
+```

--- a/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
+++ b/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
@@ -107,6 +107,28 @@ and hashes that string into `browser_build_sha256` where nothing can read it.
 So the instruction text is the only account of which tools refuse, which makes
 the omission load-bearing rather than untidy.
 
+And the omission is not the only place the text and the room disagree.
+`exec_run` is half open too, in the opposite direction: the instructions say
+all three named tools refuse "every time" and that "no commands run here", and
+one command does. `exec_run` with `argv: ["fixture-upper", source,
+destination]` returns `returncode: 0` and really uppercases the file. Every
+other argv — including `fixture-upper` with the wrong number of arguments —
+answers `capability_unavailable` and ends the task.
+
+The model could have found that one out. `capabilities_query(kind:
+"commands")` returns `["fixture-upper"]`, and `kind: "budgets"` states the
+turn limit outright. So of the three things worth knowing about this room, two
+are answerable from inside it and one is not, and the one that is not is the
+one that ended twelve tasks. Where the environment does answer, it contradicts
+the instruction text.
+
+**None of this touched trial_30.** All thirty obeyed the instruction and never
+called `exec_run`, so the `fixture-upper` trapdoor is exposure, not a finding
+about that run. It matters here for one reason: it is a second way for a task
+to die that more turns gives it more chances to reach, which is the same
+argument §4 makes about `browser_run` and the reason the 18 is not a stable
+denominator.
+
 ### Which layer is actually out of step
 
 It is tempting to call this a harness bug, and it is not. Both code layers
@@ -143,7 +165,7 @@ That narrows the fixes and separates them by an order of magnitude:
 
 | | what changes | size |
 |---|---|---|
-| name `browser_run` in the instructions as refusing for network operations | one pinned string | small, and settles the 12 |
+| describe the two half-open tools accurately — `browser_run` refuses the network, `exec_run` serves one command | one pinned string | small, and settles the 12 |
 | make `capability_unavailable` survivable | the trace schema, its verifier, and the conversation table | large, and explicitly flagged in-code as separate and reviewable |
 
 The second is not the cheap one-line change an earlier draft of this file

--- a/tasks/0822_saturday/boot_host_survey_widened.json
+++ b/tasks/0822_saturday/boot_host_survey_widened.json
@@ -1,0 +1,197 @@
+{
+  "and_note": "this is a report, not a request. Each item above is an access or capacity change and belongs to whoever owns the subscription, so it is named here and left undone",
+  "artifact": "agentic-v2-boot-host-survey",
+  "artifact_version": "1.1",
+  "because": "a host could not be created here under the permissions and capacity that exist today",
+  "findings": {
+    "existing_hosts": {
+      "answer": {
+        "count": 0
+      },
+      "measured": true,
+      "note": "names withheld; the count is what the verdict turns on",
+      "question": "are there already virtual machines in this subscription"
+    },
+    "permissions": {
+      "answer": {
+        "actions_measured": 12,
+        "assignments_held": 2,
+        "blocking_actions_not_permitted": [
+          "Microsoft.Compute/disks/write",
+          "Microsoft.Compute/virtualMachines/write",
+          "Microsoft.DevTestLab/schedules/write",
+          "Microsoft.Network/networkInterfaces/join/action",
+          "Microsoft.Network/networkInterfaces/write",
+          "Microsoft.Network/networkSecurityGroups/join/action",
+          "Microsoft.Network/networkSecurityGroups/write",
+          "Microsoft.Network/virtualNetworks/subnets/join/action",
+          "Microsoft.Network/virtualNetworks/write",
+          "Microsoft.Resources/deployments/write"
+        ],
+        "measured_but_not_blocking": {
+          "Microsoft.Network/publicIPAddresses/write": "attachPublicIp is set, and the template defaults it to false",
+          "Microsoft.Resources/subscriptions/resourceGroups/write": "the resource group does not already exist -- deploy.sh creates it in a separate step, so an owner who creates it first removes this action, and with it the only subscription-scope item on the list"
+        },
+        "permits": {
+          "Microsoft.Compute/disks/write": false,
+          "Microsoft.Compute/virtualMachines/write": false,
+          "Microsoft.DevTestLab/schedules/write": false,
+          "Microsoft.Network/networkInterfaces/join/action": false,
+          "Microsoft.Network/networkInterfaces/write": false,
+          "Microsoft.Network/networkSecurityGroups/join/action": false,
+          "Microsoft.Network/networkSecurityGroups/write": false,
+          "Microsoft.Network/publicIPAddresses/write": false,
+          "Microsoft.Network/virtualNetworks/subnets/join/action": false,
+          "Microsoft.Network/virtualNetworks/write": false,
+          "Microsoft.Resources/deployments/write": false,
+          "Microsoft.Resources/subscriptions/resourceGroups/write": false
+        },
+        "permits_every_action_a_deployment_would_take": false,
+        "scopes": {
+          "Microsoft.Compute/disks/write": "resource_group",
+          "Microsoft.Compute/virtualMachines/write": "resource_group",
+          "Microsoft.DevTestLab/schedules/write": "resource_group",
+          "Microsoft.Network/networkInterfaces/join/action": "resource_group",
+          "Microsoft.Network/networkInterfaces/write": "resource_group",
+          "Microsoft.Network/networkSecurityGroups/join/action": "resource_group",
+          "Microsoft.Network/networkSecurityGroups/write": "resource_group",
+          "Microsoft.Network/publicIPAddresses/write": "resource_group",
+          "Microsoft.Network/virtualNetworks/subnets/join/action": "resource_group",
+          "Microsoft.Network/virtualNetworks/write": "resource_group",
+          "Microsoft.Resources/deployments/write": "resource_group",
+          "Microsoft.Resources/subscriptions/resourceGroups/write": "subscription"
+        }
+      },
+      "measured": true,
+      "note": "",
+      "question": "can this identity already perform the writes a host needs"
+    },
+    "provider": {
+      "answer": {
+        "registered": true,
+        "registration_state": "Registered"
+      },
+      "measured": true,
+      "note": "",
+      "question": "is Microsoft.Compute registered here"
+    },
+    "quota": {
+      "answer": {
+        "enough_for_one_host": true,
+        "family": "standardDASv5Family",
+        "free_vcpus": 100,
+        "in_use_vcpus": 0,
+        "limit_vcpus": 100
+      },
+      "measured": true,
+      "note": "",
+      "question": "is there Standard_D8as_v5 quota in eastus2"
+    },
+    "session": {
+      "answer": {
+        "is_the_expected_subscription": true,
+        "state": "Enabled",
+        "subscription_id_was_read": true
+      },
+      "measured": true,
+      "note": "the id is deliberately not reported; only whether it is the one the model credential names",
+      "question": "which subscription is this session in"
+    }
+  },
+  "host_definition": {
+    "actions_it_performs": [
+      {
+        "action": "Microsoft.Resources/deployments/write",
+        "only_if": "",
+        "scope": "resource_group",
+        "why": "submit the template at all -- a deployment is itself a resource"
+      },
+      {
+        "action": "Microsoft.Network/networkSecurityGroups/write",
+        "only_if": "",
+        "scope": "resource_group",
+        "why": "create the security group that closes the host to the internet"
+      },
+      {
+        "action": "Microsoft.Network/virtualNetworks/write",
+        "only_if": "",
+        "scope": "resource_group",
+        "why": "create the network and the subnet the host sits on"
+      },
+      {
+        "action": "Microsoft.Network/networkInterfaces/write",
+        "only_if": "",
+        "scope": "resource_group",
+        "why": "give it a network interface"
+      },
+      {
+        "action": "Microsoft.Compute/disks/write",
+        "only_if": "",
+        "scope": "resource_group",
+        "why": "create the data disk the guest images would live on"
+      },
+      {
+        "action": "Microsoft.Compute/virtualMachines/write",
+        "only_if": "",
+        "scope": "resource_group",
+        "why": "create the machine itself"
+      },
+      {
+        "action": "Microsoft.DevTestLab/schedules/write",
+        "only_if": "",
+        "scope": "resource_group",
+        "why": "attach the auto-shutdown that stops it billing overnight"
+      },
+      {
+        "action": "Microsoft.Network/publicIPAddresses/write",
+        "only_if": "attachPublicIp is set, and the template defaults it to false",
+        "scope": "resource_group",
+        "why": "give it an address reachable from outside"
+      },
+      {
+        "action": "Microsoft.Resources/subscriptions/resourceGroups/write",
+        "only_if": "the resource group does not already exist -- deploy.sh creates it in a separate step, so an owner who creates it first removes this action, and with it the only subscription-scope item on the list",
+        "scope": "subscription",
+        "why": "create the resource group to put it all in"
+      },
+      {
+        "action": "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "only_if": "",
+        "scope": "resource_group",
+        "why": "put the interface on the subnet"
+      },
+      {
+        "action": "Microsoft.Network/networkSecurityGroups/join/action",
+        "only_if": "",
+        "scope": "resource_group",
+        "why": "apply the security group to that subnet"
+      },
+      {
+        "action": "Microsoft.Network/networkInterfaces/join/action",
+        "only_if": "",
+        "scope": "resource_group",
+        "why": "attach the interface to the machine"
+      }
+    ],
+    "from": "infra/dev-host/main.bicep",
+    "quota_family": "standardDASv5Family",
+    "vcpus": 8,
+    "vm_size": "Standard_D8as_v5"
+  },
+  "is_not": [
+    "a deployment",
+    "a role request",
+    "a measurement that any machine here can actually boot a guest"
+  ],
+  "location_asked_about": "eastus2",
+  "question": "could the subscription the model deployment lives in host a Firecracker guest, under permissions that already exist",
+  "reads_only": true,
+  "verdict": "blocked_and_the_change_is_named",
+  "what_would_have_to_change": [
+    "this identity's roles do not permit: Microsoft.Compute/disks/write, Microsoft.Compute/virtualMachines/write, Microsoft.DevTestLab/schedules/write, Microsoft.Network/networkInterfaces/join/action, Microsoft.Network/networkInterfaces/write, Microsoft.Network/networkSecurityGroups/join/action, Microsoft.Network/networkSecurityGroups/write, Microsoft.Network/virtualNetworks/subnets/join/action, Microsoft.Network/virtualNetworks/write, Microsoft.Resources/deployments/write"
+  ],
+  "would_also_be_needed_under_other_options": [
+    "Microsoft.Network/publicIPAddresses/write, but only if attachPublicIp is set, and the template defaults it to false",
+    "Microsoft.Resources/subscriptions/resourceGroups/write, but only if the resource group does not already exist -- deploy.sh creates it in a separate step, so an owner who creates it first removes this action, and with it the only subscription-scope item on the list"
+  ]
+}


### PR DESCRIPTION
## 무슨 일이 있었나

trial_30의 30문제 중 12건이 `capability_unavailable`로 끝났습니다. 이전
기록은 그것을 `exec_run`의 거부로 적었습니다. 기록을 다시 읽어보니 **30문제
전체가 `exec_run`·`environment_resolve`·`environment_activate`를 한 번도
부르지 않았습니다.** 지시문이 이 셋은 거부한다고 알려줬고, 모델은 정확히
따랐습니다.

12건을 끝낸 것은 네 번째 도구 `browser_run`입니다.

이 도구는 절반만 열려 있습니다. `path`를 받는 세 연산(`open_local`,
`snapshot`, `screenshot`)은 픽스처 백엔드가 처리하고, 네트워크로 나가는
`search`와 `open_url`은 `capability_unavailable`로 거부합니다. 지시문은 이
도구를 쓸 수 있는 도구로 소개합니다. 예전 probe가 `path`를 넘겨보고 "된다"고
결론지어 거부 목록에서 빠졌기 때문입니다 -- probe는 자기가 한 호출에
대해서는 옳았고, 도구에 대해서는 틀렸습니다.

그리고 runner는 `ok: True`가 아닌 첫 결과에서 과제를 끝냅니다
(`agentic_v2_runner.py:772`). 지시문은 "거부돼도 계속하라"는 식으로 쓰여
있지만 이 빌드에는 계속할 길이 없습니다.

## 측정값

`run_record.json`에서 읽었습니다. 돈은 쓰지 않았습니다.

| 무엇이 끝냈나 | 문제 수 |
|---|---|
| `browser_run` 네트워크 호출 (`search` 8, `open_url` 4) | **12** |
| `workspace_apply` 거부 | 2 |
| 허용된 호출을 다 씀 (5건 재시도로 성공, 4건 실패) | 9 |
| 한도 한참 전에 스스로 멈춤 | 2 |
| 한도 근처도 안 가고 끝냄 | 5 |

합계 30문제, 성공 11, 실패 19 -- trial_30의 기존 숫자 그대로입니다. 12건은
모두 허용된 9회 중 2~5회만 쓴 상태였고, 재시도되지 않았습니다.

**모델이 스스로 알아낼 길은 없었습니다.** `capabilities_query`가 답하는
다섯 종류는 commands, runtimes, packages, formats, budgets이고 그중 *tools*는
없습니다. 백엔드는 답을 알고 있고(`fixture-local-only-v1`), 그 문자열을
`browser_build_sha256`으로 해시해 아무도 못 읽는 곳에 넣습니다.

**진짜 백엔드에서는 더 넓어집니다.** `AgenticV2MicroVMBackend.browser_run`은
`open_local`까지 포함해 전부 거부합니다 -- 게스트에 chromium은 있지만 그것을
띄우고 결과를 걷고 시간을 제한하는 코드가 없기 때문이고, 이미 테스트에
고정돼 있습니다. 이 30문제는 전부 곧장 네트워크로 갔으므로 측정된 영향은
양쪽이 같지만, 노출 범위는 같지 않습니다.

## 이 PR이 하는 것

- **`test_the_browser_tool_is_half_open.py`** (신규, 9개) -- 양쪽 절반을 모두
  고정합니다. contract의 `oneOf`를 걸어 다섯 연산을 빠짐없이 덮고, 거부된
  호출이 스키마 거절이 아니라 백엔드의 답이라는 것(따라서 과금되었다는 것)을
  확인하고, `capabilities_query`에 tools가 없다는 것도 고정합니다.
  지시문이 무엇을 말해야 하는지는 **아무것도 주장하지 않습니다** -- 지시문은
  고정된 실행 조건이고, 바꾸는 것은 별도 기록이 필요한 개입입니다.
- **`TURN_LIMIT_COMPARISON_DESIGN.md`** (신규) -- 도구 8회 한도 비교 설계.
  결론은 "아직 아니다"이고 막는 것은 비용이 아니라 설계입니다. 한도가 닿을
  수 있는 문제는 18개뿐이고 그 18개도 조건에 따라 움직이며, 같은 조건 반복의
  흔들림을 아직 안 쟀습니다. 승인 금액상 30문제에서는 한도를 *줄이는* 쪽만
  시작할 수 있습니다(8회 = 승인의 57.3%, 12회 = 119.7%). trial_30과 봉인된
  사전등록은 건드리지 않았습니다.
- **`HOST_PERMISSIONS.md`** (신규) -- 주체, 12개 action, 각 scope, 최소
  변경안(리소스 그룹 범위의 Virtual Machine Contributor + Network
  Contributor, 그룹은 소유자가 먼저 생성). 그리고 권한이 4개 관문 중
  첫 번째일 뿐이라는 것 -- admission, `production_activation`, `browser_run`이
  뒤에 있습니다. **권한 부여는 하지 않았습니다. 보고이고 요청이 아닙니다.**
- **`boot_host_survey_widened.json`** (신규) -- 실행 `34684908054`의 산출물.
  12개 action 전부 실측, 전부 `false`. 1.0 기록은 그대로 둡니다.
- **`agentic_v2_conversation_runner.py`** -- docstring만. 문장 중간에서
  시작하던 `RunWideCeilings` docstring을 고치고, run-wide 상한이 설정되지
  않았다는 사실을 정확히 적었습니다. 이제 테스트가 stage 스크립트의 AST를
  읽어 그것을 확인합니다.
- **`TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md`** -- 기존 "세 write 모두 불가"
  블록에 주석 한 개. 더 좁을 뿐 충돌하지 않는다는 표시.

## 확인

`11489 passed, 18 skipped` (전체 백엔드 suite, 23분 22초), `mypy
core/agentic_v2_conversation_runner.py` 변경 파일 0 errors. 이 PR에는
workflow 파일이 없습니다. 이번 작업에서 쓴 돈은 $0입니다.