### PR TITLE
채점 설정이 선언하는 채점 방식을 전부 훑어서 검사합니다

### DIFF
--- a/batch-runner/tests/test_grading_config.py
+++ b/batch-runner/tests/test_grading_config.py
@@ -16,6 +16,13 @@ from core.inference_manifest import _ordered_task_ids_sha256
 INFERENCE_SHA = "a" * 40
 GRADER_SOURCE_HASH = "b" * 64
 
+# Resolved from ``__file__`` rather than the CWD-relative path the rest of this
+# file uses, because a parametrize argument is built at collection time. A glob
+# that came back empty would turn a sweep into one skipped placeholder instead
+# of a failure, which is easy to miss among the other skips.
+GRADING_CONFIGS = Path(__file__).resolve().parents[1] / "grading_configs"
+SHIPPED_CONFIG_NAMES = sorted(p.name for p in GRADING_CONFIGS.glob("*.yaml"))
+
 
 def _valid_config(tmp_path: Path) -> dict:
     prompt = tmp_path / "prompt.md"
@@ -214,28 +221,62 @@ def test_grade_workflow_defaults_to_v2_sol_max():
     )
 
 
-@pytest.mark.parametrize(
-    "filename",
-    [
-        "default_v2.yaml",
-        "default_v2_sol_max.yaml",
-        "default_v2_mini.yaml",
-        "default_v2_tight.yaml",
-        "regrade_exp003_v2_mini_score_excluded.yaml",
-        "regrade_exp003_v2_sol_max_score_excluded.yaml",
-        "validation_exp003_v2_sol_max_anchor4.yaml",
-        "validation_v2_mini_cohort3.yaml",
-        "validation_v2_mini_cohort10.yaml",
-    ],
-)
-def test_active_configs_declare_safe_precheck_v2(filename: str):
-    path = Path("grading_configs") / filename
+def test_the_shipped_config_sweep_actually_found_configs():
+    """An empty sweep must fail, not quietly collect nothing.
+
+    ``SHIPPED_CONFIG_NAMES`` feeds a parametrize, so an empty list would
+    collapse the sweep below into a single skipped placeholder. That reads as
+    "nothing to check" rather than "the configs were not found".
+    """
+    assert SHIPPED_CONFIG_NAMES, f"no *.yaml configs under {GRADING_CONFIGS}"
+    assert "default_v2_sol_max.yaml" in SHIPPED_CONFIG_NAMES
+
+
+@pytest.mark.parametrize("filename", SHIPPED_CONFIG_NAMES)
+def test_every_shipped_config_declares_the_regime_the_grader_implements(
+    filename: str,
+):
+    """No shipped config may advertise a grading regime the code does not run.
+
+    Neither key is read at runtime — ``precheck_patterns_version`` is recorded
+    "as identity metadata only", and ``grades_per_task: 3`` was dead config
+    that was removed rather than wired. So this guards provenance, not
+    behaviour: ``hash_config`` is a sha256 over the file's raw bytes and lands
+    in the grade filename as ``cfg_{config_hash}``, so a config that declares
+    the wrong regime files a real grade under a false identity.
+
+    Both declarations record decisions that were made after being wrong once.
+    The automatic natural-language prechecks were disabled outright when Stage
+    A attempt 1 produced seven invalid extension-only verdicts; every filename,
+    extension, worksheet, count, page and word criterion now reaches the judge,
+    and ``v1`` names the regime that produced those verdicts. ``grades_per_task``
+    claimed three verdicts per rubric item while the implementation gave one —
+    removing it moved config identities but added no repeat grading and no paid
+    calls, and re-adding it would buy none either. Both are false claims, not
+    expensive ones.
+
+    This sweeps every config rather than naming them. The list it replaced had
+    drifted to 9 of the 14 committed configs, and a new config was covered only
+    if someone remembered to add its name. ``_archive_v1/`` is deliberately out
+    of scope — it keeps the superseded configs for cache-key reproducibility,
+    and 5 of its 6 record ``v1`` on purpose — which the non-recursive glob
+    already excludes; widening it to ``rglob`` would pull in 6 more and fail.
+    """
+    path = GRADING_CONFIGS / filename
     data = yaml.safe_load(path.read_text(encoding="utf-8"))
 
     validate_grading_config(data)
 
-    assert data["grader"]["precheck_patterns_version"] == "v2"
-    assert "grades_per_task" not in data["grader"]
+    assert data["grader"]["precheck_patterns_version"] == "v2", (
+        f"{filename} declares the retired precheck regime. The prechecks it "
+        "names no longer exist in the grader, so the declaration would put a "
+        "regime that scored seven invalid verdicts into this grade's identity."
+    )
+    assert "grades_per_task" not in data["grader"], (
+        f"{filename} declares grades_per_task. The grader produces one final "
+        "verdict per rubric item; nothing reads this key, so it would claim "
+        "repeat grading that does not happen."
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 무엇을 바꿨나

`test_active_configs_declare_safe_precheck_v2`가 검사할 파일 이름 9개를 손으로
적어두고 있었습니다. 커밋된 설정은 14개입니다. 5개가 검사 밖에 있었고, 새로
만드는 설정은 누군가 이름을 추가해야만 검사에 들어왔습니다.

`grading_configs/*.yaml`을 훑는 parametrize로 바꿨습니다. 검사 대상이 9개에서
14개로 늘고, 새로 넣는 설정은 손대지 않아도 들어옵니다. 곧 만들 exp035 채점
설정이 바로 그 자리입니다.

새로 들어온 5개:

- `cost_smoke_exp026c_v2_gpt54.yaml`
- `gold_audio_repeat_v2_sol_max.yaml`
- `gold_ceiling_185_v2_sol_max.yaml`
- `gold_ceiling_30_v2_sol_max.yaml`
- `gold_smoke_audio_v2_sol_max.yaml`

## 이 검사가 막는 것은 출처이지 동작이 아닙니다

두 열쇠 모두 **실행 중에는 아무도 읽지 않습니다.** 찾아보고 확인했습니다.

- `precheck_patterns_version` — 활성 설정 14개, `_archive_v1/` 6개,
  이 시험 파일, CHANGELOG에만 나옵니다. CHANGELOG가 "as identity metadata
  only"라고 적어 두었습니다.
- `grades_per_task` — `.github/agents/grading-engineer.md`, CHANGELOG,
  이 시험 파일에만 나옵니다. "Dead config recorded, not modified… (unwired)"
  상태로 제거된 것입니다.

그래도 검사할 값이 있는 이유는 `hash_config`가 **파일 바이트를 그대로
해시**하기 때문입니다(`step8_grade.py:97-99`). 그 값이 채점 결과 파일 이름의
`cfg_{config_hash}`가 되고 `run_id`에도 들어갑니다. 틀린 방식을 선언한 설정은
**실제 채점을 거짓 신원으로 남깁니다.**

**반복 채점이나 추가 과금을 막는 검사가 아닙니다.** `grades_per_task`를 다시
넣어도 판정은 항목당 한 번이고 호출은 늘지 않습니다. 둘 다 틀린 주장이지
비싼 주장이 아닙니다.

두 선언 모두 **한 번 틀린 뒤에 내린 결정**을 기록한 것입니다. 자연어 사전검사는
Stage A 1차에서 확장자만 보고 내린 무효 판정 7건이 나오자 통째로 껐고, `v1`은
그 판정을 낸 방식의 이름입니다.

## 훑기가 비면 실패합니다

`SHIPPED_CONFIG_NAMES`는 parametrize에 들어가므로 **수집 시점에** 정해집니다.
목록이 비면 검사가 실패하는 것이 아니라 **건너뛴 자리 하나**로 접힙니다.
이 파일에는 이미 18개가 건너뛰고 있어서 눈에 띄지 않습니다.

- 경로를 CWD가 아니라 `__file__` 기준으로 잡았습니다.
- `test_the_shipped_config_sweep_actually_found_configs`를 같이 넣어 빈 훑기를
  실패로 만듭니다.

## `_archive_v1/`은 일부러 밖입니다

캐시 키 재현과 v2 대조용으로 남긴 것이고, **6개 중 5개가 의도적으로 `v1`을**
적고 있습니다(`_archive_v1/default_gpt5pro.yaml` 하나만 v2입니다). 재귀하지
않는 glob이 이미 걸러내고 있고, `rglob`으로 넓히면 6개가 더 들어와 그대로
실패합니다. 주장이 아니라 세어 본 값입니다.

## 확인

- `tests/test_grading_config.py` → **89 passed** (1.82s)
- 설정 시험 두 파일 → **100 passed, 18 skipped** (2.11s)
- `--collect-only` → parametrize id **14개** (9 → 14)
- 전체 backend suite → **11,496 passed, 36 skipped, 46 deselected** (24분 25초)
- 두 단언이 실제로 발동하는지는 **원본을 고치지 않고** 메모리 위 사본으로
  확인했습니다. 손대지 않은 참조는 통과, `v1`은 발동, `grades_per_task`를 다시
  넣으면 발동.

## 실행 중인 구간에 대한 영향

- `batch-runner/core` 변경 **0개**
- `.github/workflows/batch-run.yml`·단가표 변경 **0개**
- 실행 중인 exp035 릴레이 구간이 읽는 파일 변경 **0개**

바뀐 파일은 `batch-runner/tests/test_grading_config.py` 하나입니다.