### PR TITLE
틀린 추론 sha를 고정한 채점 설정이 판정기가 생기기 전에 막히도록 순서를 고정합니다

### DIFF
--- a/batch-runner/tests/test_a_wrong_pin_is_refused_before_the_judge_exists.py
+++ b/batch-runner/tests/test_a_wrong_pin_is_refused_before_the_judge_exists.py
@@ -1,0 +1,153 @@
+"""A grading config that pins the wrong inference revision must cost nothing.
+
+``rerun_identity.inference_revision`` is already checked twice, and both checks
+have tests. ``validate_grading_config`` rejects anything that is not 40 lowercase
+hex, so a placeholder never loads; ``_validate_pinned_rerun_identity`` rejects a
+well-formed sha that does not match the revision the grader actually resolved
+from the inference results it downloaded, which is what catches a sha that was
+copied from the wrong run.
+
+What nothing checked is *where in ``main()`` the second one sits*. It is the
+position, not the comparison, that decides whether a wrong pin is a free mistake
+or a paid one: the same ``ValueError`` raised after the first judge call is an
+invoice, and the judge on the sol_max path is deliberately unpriced, so that
+invoice could not even be stated in dollars afterwards. Today the check runs
+immediately after task filtering and roughly eight hundred lines before the
+``Grader`` is constructed, so a mismatch returns ``1`` having asked nothing.
+
+This matters right now for a config that does not exist yet. exp035's grading
+config cannot pin a real ``inference_revision`` until the final relay leg runs
+step 7 and uploads the filled parquet -- the round is mid-relay, intermediate
+legs skip steps 3 through 7, and there is no sha to write. The rule is to leave
+it unwritten rather than guess one. This test is what makes the opposite
+mistake cheap if it is ever made anyway: a guessed sha is refused before the
+judge exists, for zero calls. If the check ever drifts below the ``Grader``,
+that stops being true silently, which is the failure this file exists to catch.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+STEP8 = Path(__file__).resolve().parents[1] / "step8_grade.py"
+
+#: The call that compares the config's pinned identity against what the
+#: downloaded inference actually says about itself.
+PIN_CHECK = "_validate_pinned_rerun_identity"
+
+#: Constructing this is the first thing in ``main()`` that can reach a paid
+#: model. ``Grader._classify`` is an attribute read on the class and appears
+#: earlier in the file, outside ``main()``; only a call whose callee is the
+#: bare name counts as building one.
+JUDGE_BUILD = "Grader"
+
+#: The call that actually spends. Kept separate from the construction so that
+#: moving one without the other still fails here.
+JUDGE_CALL = "grade_task"
+
+
+def _main_body() -> ast.FunctionDef:
+    tree = ast.parse(STEP8.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "main":
+            return node
+    raise AssertionError("step8_grade.py has no module-level main()")
+
+
+def _lines_of(kind: str) -> list[int]:
+    """Line numbers inside ``main()`` where one landmark occurs."""
+    lines = []
+    for node in ast.walk(_main_body()):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if kind == PIN_CHECK or kind == JUDGE_BUILD:
+            if isinstance(func, ast.Name) and func.id == kind:
+                lines.append(node.lineno)
+        elif isinstance(func, ast.Attribute) and func.attr == kind:
+            lines.append(node.lineno)
+    return sorted(lines)
+
+
+@pytest.mark.parametrize("landmark", [PIN_CHECK, JUDGE_BUILD, JUDGE_CALL])
+def test_main_still_contains_the_landmark_the_ordering_is_measured_between(
+    landmark: str,
+):
+    """Without this, a rename would make the ordering test vacuously true.
+
+    An ``ast`` search that finds nothing returns an empty list, and ``min()``
+    of an empty list is the kind of failure that gets "fixed" by adding a
+    default. Each landmark is asserted present on its own so that the failure
+    names which one moved.
+    """
+    assert _lines_of(landmark), (
+        f"main() no longer calls {landmark!r}. The ordering guarantee below is "
+        "measured between this and the pinned-identity check, so it cannot be "
+        "checked until this is pointed at whatever replaced it."
+    )
+
+
+def test_a_wrong_pin_is_refused_before_any_judge_is_built():
+    """The refusal has to happen while the run is still free.
+
+    ``_validate_pinned_rerun_identity`` raising is already covered for all four
+    pinned fields, including ``inference_revision``. What is asserted here is
+    only that ``main()`` reaches it first -- before it builds a ``Grader`` and
+    before it asks one to grade anything.
+    """
+    pin_check = min(_lines_of(PIN_CHECK))
+    judge_build = min(_lines_of(JUDGE_BUILD))
+    judge_call = min(_lines_of(JUDGE_CALL))
+
+    assert pin_check < judge_build, (
+        f"step8_grade.main() builds a Grader at line {judge_build} but does "
+        f"not check the pinned rerun identity until line {pin_check}. A config "
+        "pinning the wrong inference_revision would be refused after the judge "
+        "exists rather than before it."
+    )
+    assert pin_check < judge_call, (
+        f"step8_grade.main() calls grade_task at line {judge_call} before "
+        f"checking the pinned rerun identity at line {pin_check}. A wrong pin "
+        "would be paid for and then rejected."
+    )
+
+
+def test_the_pin_check_is_not_reached_only_on_some_paths():
+    """Running early is worth nothing if it can be skipped.
+
+    The test above compares line numbers, which answers "before the judge?"
+    but not "at all?". Wrapping the call in ``if args.strict:`` or
+    ``if not args.resume:`` would keep every line number where it is and still
+    leave the default path unchecked, so a guessed sha would reach the judge
+    on the ordinary invocation and be caught only on the one nobody uses.
+
+    ``try``/``except`` is not a branch in this sense -- it is the shape the
+    call already has, and it re-raises as ``return 1`` rather than skipping.
+    A conditional, a loop, or a ``match`` arm is.
+    """
+    skippable = (ast.If, ast.For, ast.AsyncFor, ast.While, ast.Match)
+    body = _main_body()
+
+    def enclosing(node: ast.AST, ancestry: tuple) -> list[str]:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.Call):
+                func = child.func
+                if isinstance(func, ast.Name) and func.id == PIN_CHECK:
+                    return [type(a).__name__ for a in ancestry]
+            deeper = enclosing(
+                child,
+                ancestry + (child,) if isinstance(child, skippable) else ancestry,
+            )
+            if deeper:
+                return deeper
+        return []
+
+    branches = enclosing(body, ())
+
+    assert branches == [], (
+        f"main() reaches {PIN_CHECK} only inside {branches}. The pinned "
+        "identity would go unchecked on any path that skips that branch, so a "
+        "guessed inference_revision could reach the judge on the default "
+        "invocation no matter how early the call is written."
+    )


### PR DESCRIPTION
## 무엇을 고정하나

`step8_grade.py`의 `main()`에서 **고정값 검사가 판정기보다 앞에 있다**는 것만
`ast`로 고정합니다. 비교 로직은 건드리지 않습니다 — 이미 테스트가 있습니다.

검사되지 않던 것은 그 검사의 **위치**입니다. 비교가 아니라 위치가 "틀린
고정값이 공짜인가 청구되는가"를 정합니다. 첫 판정 호출 뒤에 올라오는 같은
`ValueError`는 청구서이고, sol_max 경로의 판정기는 일부러 단가가 없어서 그
청구서는 나중에 금액으로 적을 수조차 없습니다.

지금은 문제 거르기 직후, `Grader` 생성보다 약 800줄 앞에서 돌기 때문에
불일치가 **아무것도 묻지 않고** `1`을 돌려줍니다. 이 PR은 그 상태를 고정합니다.

## 세 가지를 본다

| 검사 | 무엇을 막나 |
|---|---|
| 순서 | 고정값 검사가 `Grader` 생성보다도, `grade_task` 호출보다도 앞이다 |
| 표지 | 순서를 재는 기준 셋이 `main()`에 아직 있다 |
| 무조건 | 그 호출이 `if`/`for`/`while`/`match` 안에 있지 않다 |

**표지**가 따로 필요한 이유는, 이름이 바뀌면 `ast` 검색이 빈 목록을 돌려주고
순서 검사가 그 위에서 참이 되어 버리기 때문입니다. 어느 표지가 움직였는지
실패 메시지가 이름을 대도록 셋을 따로 세웁니다.

**무조건**이 따로 필요한 이유는, 일찍 도는 것이 건너뛸 수 있으면 값이 없기
때문입니다. `if args.strict:`로 감싸면 줄 번호는 전부 그대로인데 기본 경로만
검사를 안 거칩니다. `try`/`except`는 이미 가진 모양이고 건너뛰지 않으므로
분기로 세지 않습니다.

## 실제로 깨지는지 확인했다

통과하는 순서 검사는 자기가 말하는 그 드리프트에서 실패해 보이기 전까지
아무것도 증명하지 못합니다. 저장소 파일은 건드리지 않고 `/tmp`의 사본을 셋으로
변형해 확인했습니다.

| 변형 | 결과 |
|---|---|
| 검사 바로 앞에 `Grader(config)`를 넣는다 | 순서 검사 실패 |
| 검사를 지운다 | 표지 검사 실패 |
| `if args.strict:`로 감싼다 | 무조건 검사 실패 (순서 검사는 통과 — 그래서 둘이 따로 필요합니다) |

변형은 전부 `/tmp/pin_guard_mutations/`에만 씁니다. 저장소 원본은 한 번도
쓰이지 않으므로 동시에 도는 다른 pytest를 오염시키지 않습니다.

## 왜 지금인가

아직 없는 설정 때문입니다. exp035 채점 설정은 마지막 구간이 step 7을 돌려
parquet을 올리기 전까지 진짜 `inference_revision`을 고정할 수 없습니다. 회차가
중계 중이고 중간 구간은 step 3~7을 건너뛰므로 **적을 sha가 없습니다.** 규칙은
지어내지 말고 비워 두는 것이고, 그 규칙은 지킵니다.

이 PR은 그래도 지어낸 값이 들어갔을 때 그 실수가 **판정기가 생기기 전에, 호출
0회로** 끝나게 만듭니다. 검사가 언젠가 `Grader` 아래로 내려가면 그 보장이
소리 없이 사라지는데, 이 파일이 잡는 것이 그 실패입니다.

## 안전

- 모델 호출 **0회**. `ast` 파싱만 합니다
- `batch-runner/core` 변경 **0개**
- `.github/workflows/batch-run.yml`·단가표 변경 **0개**
- 실행 중인 구간(34685779030)이 읽는 파일 변경 **0개**
- 새 파일 하나만 추가합니다. `step8_grade.py`는 읽기만 합니다

로컬 `pytest tests/test_a_wrong_pin_is_refused_before_the_judge_exists.py
tests/test_grading_config.py` 94개 통과, 전체 묶음 11,495개 통과입니다.
