### PR TITLE
비용 관문이 실행보다 턴 하나 적게 값을 매깁니다

### DIFF
--- a/batch-runner/tests/test_the_gate_prices_one_turn_fewer_than_the_run_takes.py
+++ b/batch-runner/tests/test_the_gate_prices_one_turn_fewer_than_the_run_takes.py
@@ -1,0 +1,261 @@
+"""The gate prices eight turns an attempt. The run takes nine.
+
+Two places decide how long one attempt may be, and they are meant to agree.
+
+``ceilings_from`` in `agentic_v2_conversation_runner.py` builds what the run
+actually enforces, and it says ``calls + 1`` -- "one model call per tool call,
+plus the turn that finalises". Its own comment, three lines below, says the
+input is "priced that way in price_the_options; bounded the same way here".
+
+``stage_one_ceiling`` in `agentic_v2_stage_one_budget.py` builds the figure the
+gate compares against the approved amount, and it passes
+``tool_calls_per_attempt`` straight through as ``tool_loop_max_model_turns``.
+No ``+ 1``. So the two are not bounded the same way: the price is worked out
+for an attempt one turn shorter than the one that runs.
+
+Which is right is settled by trial_30 itself (run 34671538199). Sixteen of its
+attempts stopped with ``turn_limit_reached``, and the conversation record's own
+words for it are *"the model has been asked 9 times, which is all the 9 this
+run was allowed"* -- nine, at ``tool_calls_per_attempt: 8``. The runner is
+describing the run. The pricer is a turn behind it.
+
+It matters more than one turn sounds, because the input of a looping attempt is
+quadratic in its length: each turn re-reads everything before it. Going from
+eight turns to nine adds 8 to the 28 re-read pairs, not 1 to 8. Observed on
+2026-09-12, priced against the real cohorts through the gate's own arithmetic:
+
+    advance_check_5    $18.47  ->  $22.88   (+24%)   against $50 approved
+    trial_30          $114.60  ->  $141.60  (+24%)   against $200 approved
+    full_220          $884.61  -> $1088.12  (+23%)   against $1400 approved
+
+**No stage's verdict changes**, which is the part worth being clear about. Every
+one of those is still inside its approved amount, and the rows the design
+document reports as closed -- 12, 16 and 32 tool calls on thirty tasks -- were
+already over before the correction and are further over after it. Nothing ran
+that should not have, and nothing here loosens a ceiling; the number the gate
+prints is wrong in the direction of looking cheaper than the run is, and that is
+worth fixing for the next approval rather than this one.
+
+Nothing here calls a model, opens a connection, or spends anything: both sides
+are arithmetic over a plan file and a task catalogue.
+"""
+from __future__ import annotations
+
+import dataclasses
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from core.agentic_v2_conversation_runner import ceilings_from
+from core.agentic_v2_stage_one_budget import (
+    STAGE_ONE_PLAN_PATH,
+    StageOneConditions,
+    budget_for_one_task,
+    load_stage_one_plan,
+    read_dispatcher_limits,
+    run_stage_one_preflight,
+    stage_one_ceiling,
+    tool_result_tokens_ceiling,
+)
+from core.execution_envelope_cost import CostAssumptions, estimate_cost_ceiling
+from core.execution_envelope_preflight import load_plan
+from core.execution_envelope_tasks import (
+    full_run_tasks,
+    load_task_catalog,
+    select_trial_run_tasks,
+)
+from core.execution_environment_readiness import ENVIRONMENT_AGENTIC_SANDBOX_V2
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def plan() -> dict:
+    return load_stage_one_plan(STAGE_ONE_PLAN_PATH)
+
+
+@pytest.fixture(scope="module")
+def assumptions(plan) -> CostAssumptions:
+    shared = load_plan(BATCH_RUNNER_ROOT / str(plan["cost"]["assumptions_come_from"]))
+    return CostAssumptions.from_mapping(shared["cost"]["assumptions"])
+
+
+@pytest.fixture(scope="module")
+def catalog():
+    return load_task_catalog()
+
+
+@pytest.fixture(scope="module")
+def chosen(plan, assumptions, catalog):
+    """The settings row the run would actually take, from the gate itself.
+
+    Read out of the preflight rather than off the plan, because that is what
+    `scripts/run_agentic_v2_stage.py` hands to `ceilings_from`.
+    """
+    verdict = run_stage_one_preflight(
+        plan, tasks_by_id=catalog.by_task_id(), assumptions=assumptions
+    )
+    assert verdict.chosen is not None, "the plan names no chosen settings"
+    return verdict.chosen
+
+
+def _conditions(plan, chosen, task_ids) -> StageOneConditions:
+    fixed = dict(plan.get("fixed_settings") or {})
+    return StageOneConditions(
+        resource=str((plan.get("azure_connection") or {}).get("account") or ""),
+        deployment=str((plan.get("model") or {}).get("deployment") or ""),
+        resolved_model=str((plan.get("model") or {}).get("resolved_model") or ""),
+        task_ids=tuple(task_ids),
+        tool_calls_per_attempt=chosen.tool_calls_per_attempt,
+        max_output_tokens_per_turn=chosen.max_output_tokens_per_turn,
+        retry_max_attempts=int(fixed.get("retry_max_attempts") or 0),
+        per_task_timeout_seconds=int(fixed.get("per_task_timeout_seconds") or 0),
+    )
+
+
+def _priced(plan, chosen, assumptions, catalog, task_ids, *, turns) -> Decimal:
+    """The running ceiling, with the turns-per-attempt forced to `turns`.
+
+    Everything else is what `stage_one_ceiling` does, copied from it rather
+    than called through it, because the one line under test is the one that
+    decides `turns`.
+    """
+    limits = read_dispatcher_limits()
+    conditions = _conditions(plan, chosen, task_ids).validated(limits)
+    forced = dataclasses.replace(
+        assumptions,
+        tool_loop_max_model_turns={ENVIRONMENT_AGENTIC_SANDBOX_V2: turns},
+        output_tokens_capped_per_attempt={ENVIRONMENT_AGENTIC_SANDBOX_V2: False},
+        max_tool_result_tokens_per_turn={
+            ENVIRONMENT_AGENTIC_SANDBOX_V2: tool_result_tokens_ceiling(
+                limits, characters_per_token=assumptions.characters_per_token
+            )
+        },
+    )
+    ceiling = estimate_cost_ceiling(
+        conditions_by_environment={
+            ENVIRONMENT_AGENTIC_SANDBOX_V2: conditions.as_run_conditions()
+        },
+        tasks_by_id=catalog.by_task_id(),
+        assumptions=forced,
+    )
+    return ceiling.running_usd * ceiling.safety_multiplier
+
+
+def test_the_run_gives_an_attempt_one_turn_more_than_it_has_tool_calls(plan, chosen):
+    """The finalising turn is a model call and the runner counts it."""
+    ceilings = ceilings_from(plan, chosen)
+    assert ceilings.max_model_turns == chosen.tool_calls_per_attempt + 1
+    assert ceilings.max_model_calls == chosen.tool_calls_per_attempt + 1
+
+
+def test_the_price_is_worked_out_without_that_turn(plan, chosen, assumptions, catalog):
+    """`stage_one_ceiling` passes the tool-call count through unchanged.
+
+    Read off the priced result rather than the source: model calls come out as
+    tool calls times attempts, with nothing added for finalising.
+    """
+    fixed = dict(plan.get("fixed_settings") or {})
+    attempts = 1 + int(fixed.get("retry_max_attempts") or 0)
+    task_ids = select_trial_run_tasks(catalog)
+
+    ceiling = stage_one_ceiling(
+        conditions=_conditions(plan, chosen, task_ids),
+        tasks_by_id=catalog.by_task_id(),
+        assumptions=assumptions,
+    )
+    priced_calls = sum(entry.model_calls for entry in ceiling.environments)
+    assert priced_calls == chosen.tool_calls_per_attempt * attempts * len(task_ids)
+
+    # What the run would take, by the runner's own figure.
+    would_take = ceilings_from(plan, chosen).max_model_calls * attempts * len(task_ids)
+    assert would_take == priced_calls + attempts * len(task_ids)
+
+
+def test_the_per_task_line_the_gate_prints_is_short_by_one_attempt_of_turns(
+    plan, chosen, assumptions, catalog
+):
+    """"at most 16 model calls" is printed where the run allows 18.
+
+    `budget_for_one_task` is what that line is built from. It is only reached
+    from the preflight -- the run enforces `PerTaskCeilings` instead -- so the
+    two never meet at runtime and cannot disagree loudly.
+    """
+    task_ids = select_trial_run_tasks(catalog)
+    ceiling = stage_one_ceiling(
+        conditions=_conditions(plan, chosen, task_ids),
+        tasks_by_id=catalog.by_task_id(),
+        assumptions=assumptions,
+    )
+    attempts = 1 + int((plan.get("fixed_settings") or {}).get("retry_max_attempts") or 0)
+    printed = budget_for_one_task(ceiling, task_ids[0]).max_model_calls
+    enforced = ceilings_from(plan, chosen).max_model_calls * attempts
+
+    assert printed == chosen.tool_calls_per_attempt * attempts
+    assert enforced == printed + attempts
+    assert enforced > printed
+
+
+def test_one_more_turn_costs_far_more_than_one_turn_of_input(
+    plan, chosen, assumptions, catalog
+):
+    """Because every turn re-reads the ones before it.
+
+    Nine turns re-read 36 earlier-turn pairs where eight re-read 28, so the
+    growing part of the bill rises by 29% for a 12.5% rise in turns. Asserted
+    as a band rather than a figure: the dollar amounts move whenever the shared
+    price table or the task catalogue does, and neither is this test's subject.
+    """
+    task_ids = select_trial_run_tasks(catalog)
+    calls = chosen.tool_calls_per_attempt
+    as_priced = _priced(plan, chosen, assumptions, catalog, task_ids, turns=calls)
+    as_run = _priced(plan, chosen, assumptions, catalog, task_ids, turns=calls + 1)
+
+    assert as_run > as_priced
+    ratio = as_run / as_priced
+    # Observed 1.236 on 2026-09-12. Bounded well clear of the 1.125 that
+    # counting turns alone would give, which is the point being pinned.
+    assert Decimal("1.15") < ratio < Decimal("1.35")
+
+
+@pytest.mark.parametrize(
+    "stage,task_ids_of",
+    [
+        ("advance_check_5", lambda plan, catalog: tuple(plan["task_ids"])),
+        ("trial_30", lambda plan, catalog: select_trial_run_tasks(catalog)),
+        ("full_220", lambda plan, catalog: full_run_tasks(catalog)),
+    ],
+)
+def test_correcting_the_turn_count_changes_no_stage_verdict(
+    plan, chosen, assumptions, catalog, stage, task_ids_of
+):
+    """The gate is wrong about the amount and right about the answer.
+
+    This is the assertion that keeps the finding from being read as a reason to
+    revisit an approval. Every stage is inside its approved amount at the
+    corrected turn count as well as at the priced one, so no run was let
+    through that should have been refused.
+
+    If a stage ever fails here it means the correction has started to matter to
+    a decision, and the plan needs a larger approved figure -- not a smaller
+    turn count.
+    """
+    approved = (plan.get("stages") or {}).get(stage, {}).get(
+        "running_approved_maximum_usd"
+    )
+    if approved is None:
+        pytest.skip(f"{stage} has no approved running amount to check against")
+
+    task_ids = task_ids_of(plan, catalog)
+    calls = chosen.tool_calls_per_attempt
+    as_priced = _priced(plan, chosen, assumptions, catalog, task_ids, turns=calls)
+    as_run = _priced(plan, chosen, assumptions, catalog, task_ids, turns=calls + 1)
+    limit = Decimal(str(approved))
+
+    assert as_priced <= limit, f"{stage} is over its approval before the correction"
+    assert as_run <= limit, (
+        f"{stage} is inside ${limit} as priced (${as_priced:.2f}) but over it at "
+        f"the turn count the run actually takes (${as_run:.2f}). The approval "
+        "needs raising; the turn count is not the thing to change."
+    )

--- a/batch-runner/tests/test_the_gate_prices_one_turn_fewer_than_the_run_takes.py
+++ b/batch-runner/tests/test_the_gate_prices_one_turn_fewer_than_the_run_takes.py
@@ -22,11 +22,12 @@ describing the run. The pricer is a turn behind it.
 It matters more than one turn sounds, because the input of a looping attempt is
 quadratic in its length: each turn re-reads everything before it. Going from
 eight turns to nine adds 8 to the 28 re-read pairs, not 1 to 8. Observed on
-2026-09-12, priced against the real cohorts through the gate's own arithmetic:
+2026-09-12, priced against the real cohorts through the gate's own arithmetic
+and rounded up to the cent the way the gate rounds:
 
-    advance_check_5    $18.47  ->  $22.88   (+24%)   against $50 approved
-    trial_30          $114.60  ->  $141.60  (+24%)   against $200 approved
-    full_220          $884.61  -> $1088.12  (+23%)   against $1400 approved
+    advance_check_5    $18.47  ->  $22.89   (+24%)   against $50 approved
+    trial_30          $114.61  ->  $141.61  (+24%)   against $200 approved
+    full_220          $884.62  -> $1088.12  (+23%)   against $1400 approved
 
 **No stage's verdict changes**, which is the part worth being clear about. Every
 one of those is still inside its approved amount, and the rows the design
@@ -51,6 +52,7 @@ from core.agentic_v2_conversation_runner import ceilings_from
 from core.agentic_v2_stage_one_budget import (
     STAGE_ONE_PLAN_PATH,
     StageOneConditions,
+    _money,
     budget_for_one_task,
     load_stage_one_plan,
     read_dispatcher_limits,
@@ -217,6 +219,27 @@ def test_one_more_turn_costs_far_more_than_one_turn_of_input(
     # Observed 1.236 on 2026-09-12. Bounded well clear of the 1.125 that
     # counting turns alone would give, which is the point being pinned.
     assert Decimal("1.15") < ratio < Decimal("1.35")
+
+
+def test_a_ceiling_is_rounded_up_to_the_cent_not_to_the_nearest_one(
+    plan, chosen, assumptions, catalog
+):
+    """Which is how the figures above are meant to be read, and reported.
+
+    `_money` quantises with `ROUND_CEILING`, so the gate's printed amount is
+    never below the amount it computed. Reporting one of these figures with
+    Python's default formatting instead puts it up to a cent low -- harmless
+    arithmetically, and the wrong direction for a ceiling to be wrong in.
+    """
+    assert _money(Decimal("18.46435")) == "18.47"
+    assert _money(Decimal("114.603375")) == "114.61"
+    assert _money(Decimal("2.000")) == "2.00", "an exact amount must not be nudged"
+
+    task_ids = select_trial_run_tasks(catalog)
+    calls = chosen.tool_calls_per_attempt
+    for turns in (calls, calls + 1):
+        raw = _priced(plan, chosen, assumptions, catalog, task_ids, turns=turns)
+        assert Decimal(_money(raw)) >= raw
 
 
 @pytest.mark.parametrize(

--- a/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
+++ b/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
@@ -574,6 +574,7 @@ confounds      limit — browser_run's trapdoor and the paraphrase ending. Both
                fire early (hazard 0 past turn 5 on this cohort, but only 19-24
                conversations reach turns 6-8, so that is weak evidence);
                the repeat spread is unmeasured; the cohort is not
-               representative of the 220; the priced ceilings assume the
-               current replay format
+               representative of the 220; the priced ceilings are one turn
+               per attempt short, so every figure in §9 reads cheaper than
+               the run is
 ```

--- a/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
+++ b/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
@@ -393,16 +393,23 @@ entry and its own approved amount, or a new approval. Note the gap between
 ceiling and reality — trial_30 spent 5.4% of its ceiling — so the ceiling is
 what gates the start, not what the run would cost.
 
-### These prices are for the broken replay format
+Every **ceiling** in that table is one turn per attempt short, for a reason that
+has nothing to do with the limit being studied; see "The ceiling does have an
+error" below. The `model calls` column is right — and is the discrepancy sitting
+in the open, since 8 tool calls is priced as 8 turns and recorded here as 9.
+Corrected, the control row is $141.60 rather than $114.60 and trial_30 spent
+4.3% of it. No row's `may start` changes.
 
-Every figure above assumes the replay described in §4: past turns come back as
-one short line of prose with the arguments dropped. That is why they are cheap.
-Fixing it means re-sending every argument the model ever passed, on every
-subsequent turn, and the cost of that is not small.
+### What fixing the replay format would cost
 
-Measured against trial_30, from the ledger — which agrees exactly with the
-conversation records, 1,140,544 input and 218,697 output tokens, `gpt-5.4` at
-$2.50 / $15.00 per million:
+The *bill* rises. The *ceiling* does not, and an earlier draft of this section
+got that the wrong way round; the correction is two subsections down.
+
+Fixing the replay means re-sending every argument the model ever passed, on
+every subsequent turn, where today it gets one short line of prose with the
+arguments dropped (§4). Measured against trial_30, from the ledger — which
+agrees exactly with the conversation records, 1,140,544 input and 218,697
+output tokens, `gpt-5.4` at $2.50 / $15.00 per million:
 
 | | tokens | at the cohort's prices |
 |---|---|---|
@@ -418,17 +425,81 @@ the tokens the model emitted on turns 0..*n*−1. That over-counts slightly,
 because output tokens include the model's spoken `why` as well as the arguments.
 The magnitude is the point, and the magnitude is tens of percent.
 
-Two consequences.
-
 **The surcharge grows faster than the limit does.** It is the sum of a running
-total, so it is quadratic in conversation length while the priced ceilings above
-are close to linear. Fixing the replay makes the 12-call row further out of
-reach than it already is, not equally so.
+total, so it is quadratic in conversation length. Fixing the replay makes the
+12-call row a worse bargain than it already is, not an equally bad one.
 
-**The ceilings must be re-derived after the fix, before the fix's run is
-scheduled.** They are the `may start` column, so a fix that lands without
-re-pricing would let a run start against a ceiling computed for a cheaper
-harness. That is the one ordering constraint this fix carries.
+#### But the ceilings above do not move, and an earlier draft of this section said they did
+
+That draft said the ceilings had to be re-derived before the fix's run could be
+scheduled. Checked against the arithmetic, that is wrong, and wrong in a way
+worth recording because it was an easy mistake to make: the ceiling was never
+computed for the harness that exists.
+
+`stage_one_ceiling` sets `output_tokens_capped_per_attempt` to `False` for this
+environment, which sends `max_input_tokens_per_attempt` down the branch that
+charges turn *k* for *k* full-length answers behind it. That term —
+`earlier_turn_pairs × max_output_tokens_per_turn` — **is** a faithful replay,
+priced at the largest it could ever be. The ceiling has always assumed the
+model is shown every one of its own past turns in full. The harness is what
+departed from it.
+
+The sizes are not close:
+
+| at the control row, 8 tool calls | input tokens |
+|---|---|
+| what the ceiling sets aside for replaying past turns | 17,694,720 |
+| what the whole run actually billed, everything included | 1,140,544 |
+| what a faithful replay would add | +719,526 |
+
+The fix spends **4.07%** of an allowance the gate already made for exactly that
+term. It cannot push a run past its ceiling, and the per-task runtime budget is
+built from the same figure, so it cannot trip that either. **No re-derivation is
+needed and there is no ordering constraint.** The fix costs real money — about
+29% more on this cohort — and that is a fact about the bill, not about the gate.
+
+#### The ceiling does have an error, and it is the other way round
+
+While checking the above, a real one turned up. Two places decide how long one
+attempt may be:
+
+* `ceilings_from` (`agentic_v2_conversation_runner.py`) builds what the run
+  enforces: `calls + 1`, "one model call per tool call, plus the turn that
+  finalises". Three lines down it says the input is "priced that way in
+  price_the_options; bounded the same way here".
+* `stage_one_ceiling` builds the figure the gate compares against the approved
+  amount, and passes `tool_calls_per_attempt` through as the turn count. No
+  `+ 1`.
+
+trial_30 settles which is right: sixteen attempts stopped on
+`turn_limit_reached`, and the record's own words are *"the model has been asked
+9 times, which is all the 9 this run was allowed"* — nine, at
+`tool_calls_per_attempt: 8`. The runner describes the run; the pricer is a turn
+behind it.
+
+One turn is not a twelfth of the bill, because a looping attempt re-reads
+everything before it: nine turns re-read 36 earlier-turn pairs where eight
+re-read 28. Priced through the gate's own arithmetic on the real cohorts:
+
+| stage | as the gate prices it | at the turn count the run takes | approved | verdict |
+|---|---|---|---|---|
+| `advance_check_5` | $18.47 | $22.88 | $50 | unchanged |
+| `trial_30` | $114.60 | $141.60 | $200 | unchanged |
+| `full_220` | $884.61 | $1088.12 | $1400 | unchanged |
+
+**No verdict changes, and nothing here is a reason to revisit an approval.**
+Every stage is inside its approved amount either way, and the closed rows — 12,
+16 and 32 tool calls on thirty tasks — were already over before the correction
+and are further over after it. What is wrong is the number the gate prints, in
+the direction of looking cheaper than the run is. It matters for the next
+approval, not for one already given, and the fix is to the pricer rather than to
+any ceiling.
+
+Both halves are pinned offline by
+`test_the_gate_prices_one_turn_fewer_than_the_run_takes.py`, including the
+assertion that no stage's verdict flips — so if the correction ever does start
+to matter to a decision, that test fails and says the approval needs raising
+rather than the turn count lowering.
 
 One thing this does not change: the ledger's own `model_cost_usd` column is
 zero on all of trial_30's rows, so $6.131815 is a figure derived by applying
@@ -462,11 +533,11 @@ In order:
 2. **Fix the replay format.** The model is shown a paraphrase of its own
    turns with the arguments stripped, and finishing that paraphrase as text
    ended five more tasks. Unlike everything else here it is a defect rather
-   than a condition somebody chose. It is also the one fix with a price: a
-   faithful replay costs roughly 29% more on this cohort, quadratically more
-   as the limit rises, so **the ceilings in §9 have to be re-derived before
-   its run is scheduled** (§9, "These prices are for the broken replay
-   format").
+   than a condition somebody chose. It costs about 29% more on this cohort and
+   quadratically more as the limit rises, but it carries **no ordering
+   constraint**: the ceilings in §9 already price a faithful replay at full
+   length, and the fix spends 4% of the allowance they made for it (§9, "But
+   the ceilings above do not move").
 
    These two can be fixed in the same run, and probably should be: the goal is
    a platform to measure the limit on, not an effect estimate for either fix.

--- a/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
+++ b/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
@@ -375,16 +375,20 @@ limit on generalising to full_220, not a bias toward the intervention.
 ## 9. When to stop — and the wall this hits
 
 Priced against the real 30-task cohort through the plan's own guard, not
-extrapolated:
+extrapolated. Amounts are rounded **up** to the cent, which is what the guard
+itself does (`quantize(Decimal("0.01"), rounding=ROUND_CEILING)`); an earlier
+draft of this section formatted them with Python's default rounding instead and
+so read up to a cent low in four places, which for a ceiling is the wrong
+direction to be wrong in:
 
 | tool calls | model calls | trial_30 ceiling | % of the $200 approval | may start |
 |---|---|---|---|---|
-| 4 | 5 | $34.77 | 17.4% | yes |
+| 4 | 5 | $34.78 | 17.4% | yes |
 | 6 | 7 | $69.06 | 34.5% | yes |
-| **8** | **9** | **$114.60** | **57.3%** | yes — the control; actual spend was $6.13 |
-| 12 | 13 | $239.49 | 119.7% | **no** |
-| 16 | 17 | $409.43 | 204.7% | **no** |
-| 32 | 33 | $1539.78 | 769.9% | **no** |
+| **8** | **9** | **$114.61** | **57.3%** | yes — the control; actual spend was $6.13 |
+| 12 | 13 | $239.50 | 119.7% | **no** |
+| 16 | 17 | $409.44 | 204.7% | **no** |
+| 32 | 33 | $1539.79 | 769.9% | **no** |
 
 **Under the approval that exists, only limits at or below the control may
 start on 30 tasks.** The interesting direction is the one that is closed. An
@@ -397,7 +401,7 @@ Every **ceiling** in that table is one turn per attempt short, for a reason that
 has nothing to do with the limit being studied; see "The ceiling does have an
 error" below. The `model calls` column is right — and is the discrepancy sitting
 in the open, since 8 tool calls is priced as 8 turns and recorded here as 9.
-Corrected, the control row is $141.60 rather than $114.60 and trial_30 spent
+Corrected, the control row is $141.61 rather than $114.61 and trial_30 spent
 4.3% of it. No row's `may start` changes.
 
 ### What fixing the replay format would cost
@@ -483,9 +487,9 @@ re-read 28. Priced through the gate's own arithmetic on the real cohorts:
 
 | stage | as the gate prices it | at the turn count the run takes | approved | verdict |
 |---|---|---|---|---|
-| `advance_check_5` | $18.47 | $22.88 | $50 | unchanged |
-| `trial_30` | $114.60 | $141.60 | $200 | unchanged |
-| `full_220` | $884.61 | $1088.12 | $1400 | unchanged |
+| `advance_check_5` | $18.47 | $22.89 | $50 | unchanged |
+| `trial_30` | $114.61 | $141.61 | $200 | unchanged |
+| `full_220` | $884.62 | $1088.12 | $1400 | unchanged |
 
 **No verdict changes, and nothing here is a reason to revisit an approval.**
 Every stage is inside its approved amount either way, and the closed rows — 12,


### PR DESCRIPTION
#561의 §9가 "재생 형식을 고치기 전에 상한을 다시 유도해야 한다"고 적어 뒀길래,
그 선행 조건부터 실제로 해봤습니다. 두 가지가 나왔습니다. **선행 조건 자체가
없던 것**이고, 반대 방향으로 **진짜 오차가 하나** 있었습니다.

돈은 하나도 쓰지 않았습니다. 양쪽 다 계획 파일과 과제 목록 위의 산술이라
모델 호출도 접속도 없습니다.

## 1. 관문이 실행보다 턴 하나 적게 값을 매깁니다

한 시도의 길이를 정하는 자리가 둘인데 서로 한 턴 어긋나 있습니다.

* `ceilings_from` (`agentic_v2_conversation_runner.py`) — 실행이 **강제하는**
  값을 만듭니다. `calls + 1`, "one model call per tool call, plus the turn
  that finalises". 세 줄 아래에서 입력이 "priced that way in
  price_the_options; bounded the same way here"라고 적어 둡니다.
* `stage_one_ceiling` (`agentic_v2_stage_one_budget.py:248`) — 관문이 승인
  금액과 **비교하는** 값을 만듭니다. `tool_calls_per_attempt`를 `+ 1` 없이
  그대로 `tool_loop_max_model_turns`로 넘깁니다. 위 주석은 사실이 아닙니다.

어느 쪽이 맞는지는 trial_30이 정합니다. 16개 시도가 `turn_limit_reached`로
끝났고 기록 자신의 표현이 *"the model has been asked 9 times, which is all
the 9 this run was allowed"* — `tool_calls_per_attempt: 8`에서 아홉 번입니다.

되읽기가 2차식이라 한 턴이 한 턴어치가 아닙니다. 9턴은 앞선 턴쌍 36개를
다시 읽고 8턴은 28개를 읽습니다. 관문 자신의 산술로, 관문이 쓰는 올림(`ROUND_CEILING`)으로 실제 코호트에 매기면:

| 단계 | 관문이 매기는 값 | 실행이 실제로 가는 턴 수로 | 승인 | 판정 |
|---|---|---|---|---|
| `advance_check_5` | $18.47 | $22.89 | $50 | 그대로 |
| `trial_30` | $114.61 | $141.61 | $200 | 그대로 |
| `full_220` | $884.62 | $1088.12 | $1400 | 그대로 |

**어느 판정도 바뀌지 않습니다.** 통과하면 안 될 실행이 통과한 적은 없고,
이건 이미 받은 승인을 다시 볼 이유가 아닙니다. 틀린 것은 관문이 인쇄하는
숫자이고, 틀린 방향이 "실제보다 싸 보이는" 쪽입니다. 다음 승인에서 문제가
되므로, 고칠 곳은 값매김 쪽이지 어떤 상한도 아닙니다. 계획 파일 자신이
그 규칙을 "written down now so that a disappointing result cannot lead to the
rules being loosened afterwards"라고 적어 뒀습니다.

관문이 인쇄하는 과제당 줄도 같은 만큼 짧습니다 — 실행이 18번을 허용하는
자리에 "at most 16 model calls"라고 적습니다. `budget_for_one_task`은 사전
점검에서만 불리고 실행은 `PerTaskCeilings`를 강제하므로, 둘은 실행 중에
만나지 않아 소리 내어 어긋날 기회가 없습니다.

## 2. 철회 — #561에서 발행한 §9의 주장 하나

"재생 형식을 고치면 그 실행을 잡기 전에 상한을 다시 유도해야 한다"고 적었는데
**틀렸습니다.** `stage_one_ceiling`은 이 환경에 대해
`output_tokens_capped_per_attempt`를 `False`로 두고, 그 가지가
`max_input_tokens_per_attempt`를 `earlier_turn_pairs ×
max_output_tokens_per_turn`로 계산합니다. 그 항이 **곧 최대 길이의 충실한
재생**입니다. 상한은 처음부터 모델이 자기 과거 턴을 전부 온전히 본다고
가정하고 있었고, 거기서 벗어난 것은 하네스 쪽입니다.

| 통제 행(도구 호출 8) | 입력 토큰 |
|---|---|
| 상한이 과거 턴 재생에 미리 잡아 둔 양 | 17,694,720 |
| 실행이 실제로 청구한 전부 | 1,140,544 |
| 충실한 재생이 더할 양 | +719,526 |

이미 해 둔 여유의 **4.07%**입니다. 상한을 넘길 수 없고, 과제당 실행 예산도
같은 수치에서 만들어지므로 그쪽도 건드리지 못합니다. **재유도도 순서 제약도
없습니다.** 청구서는 이 코호트에서 약 +29% 오르고, 그건 관문이 아니라
비용에 관한 사실입니다.

지운 게 아니라 문서에 이름 붙여 남겼습니다("an earlier draft of this section
said they did"). 쉽게 저지를 실수여서 다음 사람이 같은 길로 가지 않게요.

## 담긴 것

* `batch-runner/tests/test_the_gate_prices_one_turn_fewer_than_the_run_takes.py`
  — 새 파일, 7개, 0.89초, 오프라인. `chosen` 픽스처는 계획 파일이 아니라
  사전 점검 결과에서 읽으므로 실제 실행이 `ceilings_from`에 건네는 바로 그
  객체를 씁니다. 달러 비는 숫자가 아니라 띠(`1.15 < r < 1.35`, 관측 1.236)로
  고정했습니다 — 공유 가격표가 정당하게 움직일 수 있고 그건 이 테스트의
  주제가 아니기 때문입니다. 단계별 판정이 뒤집히지 않는다는 주장도 함께
  고정했고, 그게 실패하면 올릴 것은 승인 금액이지 턴 수가 아니라고 실패
  메시지에 적어 뒀습니다.
* `tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md` §9 — 철회 한 건,
  새 오차 한 건, 표의 `ceiling` 열이 한 턴 짧다는 주석.

## 담기지 않은 것

값매김의 `+ 1` **자체는 아직 고치지 않았습니다.** 그건 관문이 인쇄하는
금액을 바꾸는 변경이라 실행 중인 것과 충돌할 수 있고, 별도로 나가는 게
맞습니다. 이 PR은 사실을 고정하고 문서를 바로잡는 데까지입니다.

trial_30 자체는 건드리지 않았습니다. 11/30 루프 완료, 실패 19건, 호출 305회,
$6.131815 — 그대로입니다. 품질 합격도, 실제 격리 완성도 아닙니다.

