### PR TITLE
어떤 문장도 두 백엔드에 동시에 참일 수 없습니다

### DIFF
--- a/batch-runner/tests/test_the_standing_instructions_fit_neither_backend.py
+++ b/batch-runner/tests/test_the_standing_instructions_fit_neither_backend.py
@@ -1,0 +1,215 @@
+"""The instruction text is wrong about both backends, in opposite directions.
+
+The design document's first ordered step is "settle `browser_run`", on the
+reading that what is wrong is the instruction text rather than the harness --
+"the cheapest thing in the area to correct". That reading is right about where
+the defect is and wrong about how cheap it is, and this file is what changed my
+mind.
+
+The plan's `instructions:` block is a hand-written paragraph naming three tools
+that refuse. Measured against the two backends that exist:
+
+* on the **fixture**, `exec_run` is named as refusing and is half open -- one
+  argv really works. `browser_run` is *not* named and half of it refuses, and a
+  refusal ends the task, so the tool the text is silent about is the one that
+  ended twelve of trial_30's thirty.
+* on the **microvm**, it is the other way round. `browser_run` refuses *every*
+  operation including `open_local`, which the fixture serves; and `exec_run`,
+  named as refusing "every time", boots a machine and runs the command.
+
+So there is no wording that is true of both. Editing the paragraph fixes the
+fixture run and breaks the run it is a rehearsal for. The correction that holds
+is to derive the refusal list from whichever backend is mounted -- which is a
+change to how the prompt is built, not a change to a paragraph.
+
+There is a fourth thing the text gets wrong, and it is the one that costs
+tasks. It says a repeated refusal is wasteful:
+
+    Calling them again will not change the answer, and the calls are counted
+    against you.
+
+The run does not count a refusal against you. It ends on it --
+`agentic_v2_runner.py` raises `_EndTheRun` for *any* result that is not
+`ok: true`. A model reading that sentence would believe a refused call costs
+one of its nine and that it may go on; what actually happens is that the task
+is over. None of that is visible from inside the room: `capabilities_query`
+answers about commands, runtimes, packages, formats and budgets, and has no
+`tools` kind (pinned in `test_the_browser_tool_is_half_open.py`).
+
+**Nothing here changes a condition.** Fixing any of it means a new plan file
+and a new run id, and trial_30 keeps the instructions it ran under. This file
+only pins what the current text claims against what the two backends do, so
+that a change to either side has to be deliberate.
+
+Offline: a fixture backend in a temp directory and a paragraph of text. No
+model call, no network, no spend.
+"""
+from __future__ import annotations
+
+import pytest
+
+from core.agentic_v2_contract import AgenticV2Profile
+from core.agentic_v2_fixture_backend import AgenticV2FixtureBackend
+from core.agentic_v2_microvm_backend import AgenticV2MicroVMBackend
+from core.agentic_v2_stage_one_budget import (
+    STAGE_ONE_PLAN_PATH,
+    load_stage_one_plan,
+)
+
+#: The tools the paragraph names as refusing "every time".
+NAMED_AS_REFUSING = ("exec_run", "environment_resolve", "environment_activate")
+
+#: The one argv the fixture's `exec_run` really serves.
+THE_COMMAND_THAT_WORKS = ["fixture-upper", "a.txt", "b.txt"]
+
+
+@pytest.fixture(scope="module")
+def instructions() -> str:
+    """The paragraph the model is actually shown, from the plan the run reads.
+
+    Whitespace is collapsed to single spaces. Where the lines happen to wrap is
+    not part of what this file pins, and leaving the wrapping in place makes
+    every check below silently sensitive to a re-flow of the paragraph.
+    """
+    text = str(load_stage_one_plan(STAGE_ONE_PLAN_PATH).get("instructions") or "")
+    assert text.strip(), "the plan carries no instruction text to check"
+    return " ".join(text.split())
+
+
+@pytest.fixture
+def fixture_backend(tmp_path):
+    made = AgenticV2FixtureBackend(
+        root=tmp_path / "task",
+        profile=AgenticV2Profile(
+            tool_contract_version="2.0",
+            policy_profile_id="offline-full-v1",
+            foundation_only=True,
+        ),
+    )
+    (made.work / "inputs").mkdir()
+    (made.work / "inputs" / "notes.md").write_text("a local file\n", encoding="utf-8")
+    (made.work / "a.txt").write_text("hello\n", encoding="utf-8")
+    return made
+
+
+def _microvm_browser(operation: str):
+    """What `AgenticV2MicroVMBackend.browser_run` answers, without a machine.
+
+    The method refuses before it looks at anything: it reads `operation`, drops
+    it, and returns. So it can be asked without a built backend, a manifest or
+    a host, which is the only reason this comparison can be made offline at
+    all. If it ever grows a branch that needs `self`, this raises instead of
+    asserting -- and that would itself be the news, because the docstring's
+    claim is that both branches refuse.
+    """
+    return AgenticV2MicroVMBackend.browser_run(
+        None, {"operation": operation, "path": "page.html"}
+    )
+
+
+# ---------------------------------------------------------------------------
+# What the paragraph claims
+# ---------------------------------------------------------------------------
+
+
+def test_the_text_names_three_tools_and_not_the_browser(instructions):
+    """The list is the thing under test, so read it rather than assume it."""
+    for tool in NAMED_AS_REFUSING:
+        assert tool in instructions, f"{tool} is no longer named as refusing"
+    assert "Three of them refuse in this run" in instructions
+
+    head, _, _ = instructions.partition("YOUR INPUT FILES")
+    assert "browser_run" not in head.split("Three of them refuse")[1], (
+        "browser_run has been added to the refusal paragraph -- if that is "
+        "deliberate, this file's premise has changed and the rest of it needs "
+        "rewriting rather than re-running"
+    )
+
+
+def test_the_text_tells_the_model_a_refusal_is_survivable(instructions):
+    """"counted against you" describes a cost. The run ends instead.
+
+    This is the sentence that matters most, because a model that believed it
+    would spend a call finding out and then discover the task was already over.
+    """
+    assert "the calls are counted against you" in instructions
+    for ending in ("ends the task", "ends your task", "the task is over",
+                   "you will not get another turn"):
+        assert ending not in instructions, (
+            "the text now warns that a refusal is terminal, which is the fix "
+            "this file exists to argue for -- update the file, not the assert"
+        )
+
+
+# ---------------------------------------------------------------------------
+# What the fixture backend does
+# ---------------------------------------------------------------------------
+
+
+def test_on_the_fixture_a_named_tool_is_half_open(fixture_backend):
+    """`exec_run` is named as refusing every time. One argv really works."""
+    served = fixture_backend.exec_run(
+        {"argv": list(THE_COMMAND_THAT_WORKS), "cwd": ".", "timeout_seconds": 30}
+    )
+    assert served["ok"] is True
+    assert (fixture_backend.work / "b.txt").read_text(encoding="utf-8") == "HELLO\n"
+
+
+def test_on_the_fixture_the_unnamed_tool_is_the_one_that_refuses(fixture_backend):
+    """`browser_run` is silent in the text and shut on the network half."""
+    refused = fixture_backend.browser_run(
+        {"operation": "search", "query": "quarterly revenue by segment"}
+    )
+    assert refused["ok"] is False
+    assert refused["error_type"] == "capability_unavailable"
+
+    served = fixture_backend.browser_run(
+        {"operation": "open_local", "path": "inputs/notes.md"}
+    )
+    assert served["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# The two backends, side by side
+# ---------------------------------------------------------------------------
+
+
+def test_the_same_sentence_cannot_be_true_of_both_backends(fixture_backend):
+    """`open_local` is served by one and refused by the other.
+
+    This is the whole argument for deriving the text instead of writing it.
+    Whatever a hand-written paragraph says about `browser_run`, it is wrong on
+    one of the two runs, and the one it would be wrong on after an edit is the
+    real backend.
+    """
+    on_the_fixture = fixture_backend.browser_run(
+        {"operation": "open_local", "path": "inputs/notes.md"}
+    )
+    on_the_machine = _microvm_browser("open_local")
+
+    assert on_the_fixture["ok"] is True
+    assert on_the_machine["ok"] is False
+    assert on_the_machine["error_type"] == "capability_unavailable"
+
+
+@pytest.mark.parametrize("operation", ["search", "open_url", "open_local"])
+def test_the_machine_refuses_the_browser_outright(operation):
+    """Including the local one, which needs no network. By design."""
+    assert _microvm_browser(operation) == {
+        "ok": False,
+        "error_type": "capability_unavailable",
+    }
+
+
+def test_the_machine_implements_the_command_tool_the_text_denies():
+    """`exec_run` is real on the microvm; the text says it refuses every time.
+
+    Checked by asking whether the class overrides it, rather than by running
+    it: running it boots a machine, which is exactly what this suite must not
+    do. The fixture's version and the machine's version being different
+    functions is the fact worth holding.
+    """
+    assert (
+        AgenticV2MicroVMBackend.exec_run is not AgenticV2FixtureBackend.exec_run
+    )
+    assert "boot" in (AgenticV2MicroVMBackend.exec_run.__doc__ or "").lower()

--- a/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
+++ b/tasks/0822_saturday/TURN_LIMIT_COMPARISON_DESIGN.md
@@ -522,6 +522,19 @@ produce a number that cannot be told apart from noise, and the fact that it
 came out of a correctly-configured harness would make it more convincing than
 it deserves to be.
 
+Money is not what is stopping it. trial_30 billed **$6.131815** against a
+ceiling of $141.61, because most of its attempts ended early; what a repeat
+would bill is unknown for the same reason its outcome is, which is the point
+of measuring it, but it is bounded by that same $141.61 against the $200 the
+plan approves. So the gate passes a repeat — and would pass a third and a
+fourth, because `agentic_v2_stage_one_budget.py` prices the run in front of it
+and reads no record of what the stage has already spent. The plan's own words
+for the figure are *"a whole-run figure, not a rate"*, which settles that $200
+approved for one cohort cannot be carried to another and says nothing about
+the same cohort run twice. The ceiling is the thing being approved, so two
+repeats draw $283.22 of approval against a number written once. That is a
+question for whoever approves it, not one the gate will ask.
+
 ---
 
 ## Verdict
@@ -532,8 +545,20 @@ In order:
 
 1. **Settle `browser_run`.** It removes 40% of the cohort for a reason
    unrelated to the limit, and what is wrong is the instruction text rather
-   than the harness — the cheapest thing in the area to correct. Own run id,
-   own record.
+   than the harness. It is not, as an earlier revision of this document said,
+   the cheapest thing in the area to correct. **No wording is true of both
+   backends**: the fixture serves `open_local` and refuses the network half,
+   while the microvm refuses the browser outright — `open_local` included —
+   and implements the `exec_run` the text says refuses every time. An edit
+   that fixes the rehearsal breaks the run the rehearsal is for. What holds is
+   to build the refusal list from whichever backend is mounted, which is a
+   change to how the prompt is assembled rather than to a paragraph.
+
+   And the sentence that costs the most is not a list at all. *"the calls are
+   counted against you"* tells the model a refusal is survivable and costs one
+   of its nine; `agentic_v2_runner.py` ends the task on the first one. Own run
+   id, own record — the instruction text is a pinned condition, and trial_30
+   keeps the one it ran under.
 2. **Fix the replay format.** The model is shown a paraphrase of its own
    turns with the arguments stripped, and finishing that paraphrase as text
    ended five more tasks. Unlike everything else here it is a defect rather


### PR DESCRIPTION
## 무엇을 고쳤나

PR #566의 후속입니다. 설계 문서 「판정」 절의 1단계가 틀렸다는 것을 증거와
함께 고치고, 3단계(반복 폭 측정)를 막고 있는 것이 돈이 아니라는 점을
적습니다.

## 1. 안내 문구는 두 백엔드 중 어느 쪽에도 맞지 않습니다

앞선 개정판은 `browser_run` 문제를 **"이 근처에서 가장 싸게 고칠 수 있는
것"** — 즉 문단 하나를 고치면 되는 일 — 로 적었습니다. 결함이 어디 있는지는
맞았고, 얼마나 싼지는 틀렸습니다.

| 도구 | 픽스처 | 마이크로VM | 문구가 말하는 것 |
|---|---|---|---|
| `exec_run` | `fixture-upper` 한 줄은 **실행됨** | 머신을 띄워 **실행됨** | 매번 거부 |
| `browser_run` | 로컬 3개 서빙, 네트워크 2개 거부 | `open_local` 포함 **전부 거부** | (언급 없음) |

같은 문단이 양쪽에 참일 수 없습니다. `open_local` 하나만 봐도 한쪽은
서빙하고 한쪽은 거부합니다. **예행연습을 맞추는 편집은 그 예행연습의
대상인 실행을 틀어놓습니다.** 유지되는 교정은 거부 목록을 붙어 있는
백엔드에서 만들어내는 것이고, 그것은 문단이 아니라 프롬프트 조립 방식의
변경입니다.

그리고 가장 비싼 문장은 목록이 아닙니다.

> Calling them again will not change the answer, and **the calls are counted
> against you.**

거부당해도 호출 하나를 쓸 뿐 계속 갈 수 있다고 읽힙니다. 실제로는
`agentic_v2_runner.py`가 `ok: true`가 아닌 **모든** 결과에서 `_EndTheRun`을
올립니다. 첫 거부에서 과제가 끝납니다. 그리고 방 안에서는 이것을 알아낼
방법이 없습니다 — `capabilities_query`에는 `tools` 종류가 없습니다.

## 2. 반복 폭 측정을 막는 것은 돈이 아닙니다

trial_30은 상한 $141.61에 대해 실제로 **$6.131815**를 청구했습니다. 대부분의
시도가 일찍 끝났기 때문입니다. 반복이 얼마를 청구할지는 그 결과가 어떻게
나올지와 **같은 이유로** 모르고, 그게 바로 재려는 대상입니다. 다만 같은
$141.61로 묶이고 승인된 $200 안에 듭니다.

그래서 관문은 반복을 통과시킵니다. 세 번째도 네 번째도 통과시킵니다.
`agentic_v2_stage_one_budget.py`는 눈앞의 실행 하나만 값을 매기고 **그 단계가
이미 얼마를 썼는지 읽지 않습니다** (모듈 전체에 `ledger` / `spent` /
`cumulative` 참조 0건). 계획이 그 금액에 붙인 말은 *"a whole-run figure, not a
rate"* 인데, 이는 한 코호트의 $200을 다른 코호트로 옮겨 쓸 수 없다는 뜻이지
**같은 코호트를 두 번 돌리는 것에 대해서는 아무 말도 하지 않습니다.**

승인 대상은 상한이므로, 반복 두 번은 한 번 적어 둔 숫자에 $283.22의 승인을
끌어다 쓰는 셈입니다. 관문이 물을 질문이 아니라 승인하는 사람이 답할
질문이고, 그래서 실행이 아니라 문서에 적었습니다.

## 무엇을 바꾸지 않았나

- **조건은 하나도 바꾸지 않습니다.** 안내 문구도, 백엔드도, 상한도
  그대로입니다. 고치려면 새 plan 파일(`--plan`)과 새 실행 ID가 필요하고
  trial_30은 자기가 돌았던 문구를 그대로 유지합니다.
- **어떤 상한도 낮추지 않습니다.**
- 지출 없음. 모델 호출 없음. 네트워크 없음.

## 검증

```
tests/test_the_standing_instructions_fit_neither_backend.py  9 passed
tests/test_the_gate_prices_one_turn_fewer_than_the_run_takes.py  8 passed
17 passed in 1.15s
```

새 테스트 9개는 임시 디렉터리의 픽스처 백엔드와 문단 하나만 읽습니다.
마이크로VM 쪽은 `browser_run`이 인자를 보기 전에 거부하므로 머신 없이
물어볼 수 있고, `exec_run`은 **실행하지 않고** 클래스가 재정의했는지만
확인합니다 — 실행하면 머신이 뜨고, 그것이 이 스위트가 절대 하지 말아야 할
일이기 때문입니다.
