### PR TITLE
거부 목록을 붙어 있는 백엔드에서 만들어냅니다 (아직 아무도 쓰지 않습니다)

### DIFF
--- a/batch-runner/core/agentic_v2_tool_availability.py
+++ b/batch-runner/core/agentic_v2_tool_availability.py
@@ -1,0 +1,209 @@
+"""What each backend refuses, written beside each backend rather than once.
+
+The plan carries a hand-written paragraph telling the model which tools refuse.
+It names three, and it is wrong about both backends that exist -- in opposite
+directions, so no edit to it can be right. On the fixture, ``exec_run`` is named
+as refusing and one argv really works, while ``browser_run`` is not named at all
+and its network half refuses. On the microVM it is the other way round:
+``browser_run`` refuses every operation including ``open_local``, and
+``exec_run`` boots a machine and runs the command. A paragraph true of one is
+false of the other, and the run it would be false of is the real one.
+``tests/test_the_standing_instructions_fit_neither_backend.py`` holds both sides
+of that against the code.
+
+So the list is kept per backend and rendered at the point the prompt is built.
+
+**Declared here, checked against behaviour by a test.** The alternative was to
+find out by asking: call each tool once at the start of a run and see what comes
+back. That is more honest in principle and wrong in practice, because those
+calls are tool events like any other and would land in the trace, be counted,
+and change the workspace. A declaration that a test proves against the real
+methods buys the same guarantee without putting anything in the record --
+``tests/test_the_declared_refusals_match_what_the_backends_do.py`` calls the
+fixture's tools for real and asks the microVM's the way it can be asked without
+a machine.
+
+**Nothing reads this yet.** The instruction text is a pinned condition of
+trial_30, and changing it means a new plan file and a new run id rather than an
+edit in place. :func:`apply_tool_availability` is therefore a no-op on any
+instruction string that does not ask for it: a plan opts in by putting
+:data:`PLACEHOLDER` in its text, and every plan in the repository today does
+not, so every one of them passes through byte for byte.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+#: A plan asks for a derived list by putting this in its instruction text.
+#: Absent, the text is returned unchanged -- which is what keeps the pinned
+#: instructions of an already-run stage exactly as they were.
+PLACEHOLDER = "{{TOOL_AVAILABILITY}}"
+
+#: True of both backends, because it is not a property of either. Any result
+#: that is not ``ok: true`` raises ``_EndTheRun`` in ``agentic_v2_runner.py``,
+#: one layer above the backend. The paragraph the plan carries today says the
+#: opposite -- "the calls are counted against you" -- which describes a refusal
+#: as costing one turn of nine rather than as ending the task.
+A_REFUSAL_ENDS_THE_TASK = (
+    "A refused call ends your task. It is not a turn spent and recovered "
+    "from: there is no turn after it. Do not call a tool listed below as "
+    "refusing, and do not call one in a way this list says it will not serve."
+)
+
+
+@dataclass(frozen=True)
+class ToolAvailability:
+    """One tool, on one backend, in the terms the model needs.
+
+    ``verdict`` is one of ``works``, ``partly`` or ``refuses``. ``partly`` is
+    the one that matters and the one a yes/no list cannot hold: both backends
+    have a tool that serves some arguments and refuses others, and on both of
+    them it is the tool the current paragraph gets wrong.
+    """
+
+    tool: str
+    verdict: str
+    note: str
+
+    def __post_init__(self) -> None:
+        if self.verdict not in {"works", "partly", "refuses"}:
+            raise ValueError(f"{self.tool}: unknown verdict {self.verdict!r}")
+        if self.verdict != "works" and not self.note.strip():
+            raise ValueError(
+                f"{self.tool}: a tool that does not simply work needs a note "
+                "saying what it will and will not serve. A bare 'refuses' is "
+                "what the current paragraph already tells the model, and it "
+                "is not enough to act on"
+            )
+
+
+_FIXTURE: tuple[ToolAvailability, ...] = (
+    ToolAvailability("workspace_apply", "works", ""),
+    ToolAvailability("verify_public", "works", ""),
+    ToolAvailability("capabilities_query", "works", ""),
+    ToolAvailability("finalize", "works", ""),
+    ToolAvailability(
+        "exec_run",
+        "partly",
+        "serves exactly one command, `fixture-upper SOURCE DESTINATION`, "
+        "which writes SOURCE upper-cased to DESTINATION. Every other argv "
+        "refuses.",
+    ),
+    ToolAvailability(
+        "browser_run",
+        "partly",
+        "serves `open_local`, `snapshot` and `screenshot`, each of which "
+        "takes a path inside your workspace. `search` and `open_url` refuse: "
+        "there is no network here.",
+    ),
+    ToolAvailability(
+        "environment_resolve",
+        "refuses",
+        "there is no index to resolve against.",
+    ),
+    ToolAvailability(
+        "environment_activate",
+        "refuses",
+        "there is nothing to activate, because nothing can be resolved.",
+    ),
+)
+
+_MICROVM: tuple[ToolAvailability, ...] = (
+    ToolAvailability("workspace_apply", "works", ""),
+    ToolAvailability("verify_public", "works", ""),
+    ToolAvailability("capabilities_query", "works", ""),
+    ToolAvailability("finalize", "works", ""),
+    ToolAvailability(
+        "exec_run",
+        "works",
+        "runs your command in a machine of its own. One boot per call, so "
+        "prefer one command that does the work to several that build up to it.",
+    ),
+    ToolAvailability(
+        "browser_run",
+        "refuses",
+        "every operation, `open_local` included. The machine has no route out "
+        "for `search` and `open_url`, and nothing here drives a browser for "
+        "the three that need no network.",
+    ),
+    ToolAvailability(
+        "environment_resolve",
+        "refuses",
+        "the machine's only network interface is the loopback, so there is "
+        "nothing to resolve against.",
+    ),
+    ToolAvailability(
+        "environment_activate",
+        "refuses",
+        "there is no lock to activate, because none can be made.",
+    ),
+)
+
+#: Keyed by class name rather than by the class, so that reading this table
+#: does not import a backend. ``run_agentic_v2_stage.py`` already writes the
+#: same string into its run record as ``backend``.
+AVAILABILITY_BY_BACKEND: Mapping[str, tuple[ToolAvailability, ...]] = {
+    "AgenticV2FixtureBackend": _FIXTURE,
+    "AgenticV2MicroVMBackend": _MICROVM,
+}
+
+
+def backend_name(backend: Any) -> str:
+    """The class name, whether given the class, an instance, or the name."""
+    if isinstance(backend, str):
+        return backend
+    if isinstance(backend, type):
+        return backend.__name__
+    return type(backend).__name__
+
+
+def availability_for(backend: Any) -> tuple[ToolAvailability, ...]:
+    """What `backend` serves and refuses.
+
+    Raises rather than guessing. A backend nobody has written a list for is a
+    backend whose refusals nobody has checked, and telling the model a list
+    that was inferred from a similar-looking class is the failure this module
+    exists to stop.
+    """
+    name = backend_name(backend)
+    try:
+        return AVAILABILITY_BY_BACKEND[name]
+    except KeyError:
+        raise KeyError(
+            f"no refusal list has been written for {name}. Add one to "
+            "AVAILABILITY_BY_BACKEND and a case to "
+            "test_the_declared_refusals_match_what_the_backends_do.py, which "
+            "will hold it against what the backend really does"
+        ) from None
+
+
+def tool_availability_paragraph(backend: Any) -> str:
+    """The list as the model should read it, longest-lived facts first."""
+    entries = availability_for(backend)
+    lines = [A_REFUSAL_ENDS_THE_TASK, ""]
+
+    works = [entry.tool for entry in entries if entry.verdict == "works"]
+    if works:
+        lines.append(f"These serve any call the schema accepts: {', '.join(works)}.")
+
+    for entry in entries:
+        if entry.verdict == "partly":
+            lines.append(f"{entry.tool} is open in part — it {entry.note}")
+    for entry in entries:
+        if entry.verdict == "refuses":
+            lines.append(f"{entry.tool} refuses: {entry.note}")
+
+    return "\n".join(lines)
+
+
+def apply_tool_availability(instructions: str, backend: Any) -> str:
+    """Substitute the derived list into `instructions`, if it asks for one.
+
+    A string without :data:`PLACEHOLDER` comes back identical, which is the
+    property the pinned plans rely on: adding this call to the stage runner
+    must not change a single byte of what an already-run stage sent.
+    """
+    if PLACEHOLDER not in instructions:
+        return instructions
+    return instructions.replace(PLACEHOLDER, tool_availability_paragraph(backend))

--- a/batch-runner/scripts/run_agentic_v2_stage.py
+++ b/batch-runner/scripts/run_agentic_v2_stage.py
@@ -103,6 +103,9 @@ from core.agentic_v2_stage_one_budget import (  # noqa: E402
     price_one_stage,
     run_stage_one_preflight,
 )
+from core.agentic_v2_tool_availability import (  # noqa: E402
+    apply_tool_availability,
+)
 from core.cost_receipts import (  # noqa: E402
     BUCKET_PROBLEM_SOLVING,
     STATUS_UNAVAILABLE,
@@ -997,7 +1000,9 @@ def main() -> int:
                 deployment=deployment,
                 resource=resource,
                 budget=budget,
-                instructions=str(plan.get("instructions") or ""),
+                instructions=apply_tool_availability(
+                    str(plan.get("instructions") or ""), AgenticV2FixtureBackend
+                ),
                 max_output_tokens_per_turn=ceilings.max_written_tokens_per_turn,
                 request_timeout_seconds=ceilings.max_seconds,
                 prices=prices,

--- a/batch-runner/tests/test_the_declared_refusals_match_what_the_backends_do.py
+++ b/batch-runner/tests/test_the_declared_refusals_match_what_the_backends_do.py
@@ -1,0 +1,347 @@
+"""The declared refusal lists, held against what the backends really do.
+
+`core/agentic_v2_tool_availability.py` writes down what each backend serves and
+refuses, so that the model can be told something true of the backend it is
+actually on rather than one paragraph that is false of both. A written-down list
+drifts from the code unless something stops it, and this file is that something.
+
+Each list is checked the strongest way that costs nothing:
+
+* the **fixture**'s tools are called for real, in a temp directory -- the ones
+  declared as working, the exact call declared as served on each half-open tool,
+  and the exact call declared as refused;
+* the **microVM**'s four working tools are checked to be *the same function
+  objects* as the fixture's, which they are because it subclasses it -- so
+  calling the fixture's really did exercise the machine's;
+* the microVM's three refusing tools drop their arguments and return, so they
+  can be asked without a machine, a manifest or a host;
+* and its ``exec_run``, the one call that would boot something, is checked by
+  asking whether the class overrides it rather than by running it.
+
+Also pinned here: adding the substitution to the stage runner must not change a
+single byte of what an already-run stage sent. Every plan in the repository is
+put through :func:`apply_tool_availability` and asserted to come back identical,
+because none of them asks for a derived list.
+
+Offline. No model call, no network, no machine, no spend.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from core.agentic_v2_contract import TOOL_NAMES, AgenticV2Profile
+from core.agentic_v2_fixture_backend import AgenticV2FixtureBackend
+from core.agentic_v2_microvm_backend import AgenticV2MicroVMBackend
+from core.agentic_v2_tool_availability import (
+    AVAILABILITY_BY_BACKEND,
+    PLACEHOLDER,
+    ToolAvailability,
+    apply_tool_availability,
+    availability_for,
+    tool_availability_paragraph,
+)
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+
+#: The one argv the fixture's `exec_run` serves, per its declared note.
+THE_COMMAND_THAT_WORKS = ["fixture-upper", "a.txt", "b.txt"]
+
+#: Every operation `browser_run` accepts, from the contract's two schemas.
+BROWSER_OPERATIONS = ("open_local", "snapshot", "screenshot", "open_url", "search")
+
+
+@pytest.fixture
+def fixture_backend(tmp_path):
+    made = AgenticV2FixtureBackend(
+        root=tmp_path / "task",
+        profile=AgenticV2Profile(
+            tool_contract_version="2.0",
+            policy_profile_id="offline-full-v1",
+            foundation_only=True,
+        ),
+    )
+    (made.work / "inputs").mkdir()
+    (made.work / "inputs" / "notes.md").write_text("a local file\n", encoding="utf-8")
+    (made.work / "a.txt").write_text("hello\n", encoding="utf-8")
+    return made
+
+
+def _declared(backend, tool: str) -> ToolAvailability:
+    for entry in availability_for(backend):
+        if entry.tool == tool:
+            return entry
+    raise AssertionError(f"{tool} is not declared for {backend}")
+
+
+# ---------------------------------------------------------------------------
+# Every tool is accounted for, on every backend
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend_name", sorted(AVAILABILITY_BY_BACKEND))
+def test_no_tool_is_left_out_of_a_list(backend_name):
+    """Omission is the defect this module exists to stop, so check for it.
+
+    The paragraph in the plan is wrong about `browser_run` by *not mentioning
+    it*, and that silence ended twelve of trial_30's thirty tasks. A list that
+    is allowed to be short can make the same mistake quietly.
+    """
+    declared = availability_for(backend_name)
+    assert tuple(sorted(entry.tool for entry in declared)) == tuple(sorted(TOOL_NAMES))
+    assert len({entry.tool for entry in declared}) == len(declared), "a tool twice"
+
+
+@pytest.mark.parametrize("backend_name", sorted(AVAILABILITY_BY_BACKEND))
+def test_every_declared_tool_exists_on_the_backend(backend_name):
+    classes = {
+        "AgenticV2FixtureBackend": AgenticV2FixtureBackend,
+        "AgenticV2MicroVMBackend": AgenticV2MicroVMBackend,
+    }
+    backend = classes[backend_name]
+    for entry in availability_for(backend_name):
+        assert callable(getattr(backend, entry.tool, None)), (
+            f"{backend_name} has no {entry.tool} to be right or wrong about"
+        )
+
+
+def test_an_unknown_backend_raises_rather_than_guessing():
+    with pytest.raises(KeyError, match="no refusal list has been written"):
+        availability_for("AgenticV2SomethingElseBackend")
+
+
+# ---------------------------------------------------------------------------
+# The fixture, called for real
+# ---------------------------------------------------------------------------
+
+
+def test_the_fixture_serves_everything_declared_as_working(fixture_backend):
+    fixture_backend.work.joinpath("out").mkdir()
+    served = {
+        "capabilities_query": lambda: fixture_backend.capabilities_query(
+            {"kind": "commands"}
+        ),
+        "workspace_apply": lambda: fixture_backend.workspace_apply(
+            {"operation": "list", "path": "inputs"}
+        ),
+        "verify_public": lambda: fixture_backend.verify_public({"deliverables": []}),
+        "finalize": lambda: fixture_backend.finalize(
+            {"deliverables": [], "summary": "done"}
+        ),
+    }
+    for entry in availability_for(AgenticV2FixtureBackend):
+        if entry.verdict != "works":
+            continue
+        assert entry.tool in served, (
+            f"{entry.tool} is declared as working and this test does not call "
+            "it -- add a call rather than trusting the declaration"
+        )
+        assert served[entry.tool]()["ok"] is True, f"{entry.tool} did not serve"
+
+
+def test_the_fixture_exec_run_is_open_exactly_as_declared(fixture_backend):
+    """One argv works and another does not, which is what `partly` means."""
+    assert _declared(AgenticV2FixtureBackend, "exec_run").verdict == "partly"
+
+    served = fixture_backend.exec_run(
+        {"argv": list(THE_COMMAND_THAT_WORKS), "cwd": ".", "timeout_seconds": 30}
+    )
+    assert served["ok"] is True
+    assert (fixture_backend.work / "b.txt").read_text(encoding="utf-8") == "HELLO\n"
+
+    refused = fixture_backend.exec_run(
+        {"argv": ["python3", "-c", "print(1)"], "cwd": ".", "timeout_seconds": 30}
+    )
+    assert refused == {"ok": False, "error_type": "capability_unavailable"}
+
+
+@pytest.mark.parametrize("operation", ["open_local", "snapshot", "screenshot"])
+def test_the_fixture_browser_serves_the_three_local_operations(
+    fixture_backend, operation
+):
+    assert _declared(AgenticV2FixtureBackend, "browser_run").verdict == "partly"
+    answer = fixture_backend.browser_run(
+        {"operation": operation, "path": "inputs/notes.md"}
+    )
+    assert answer["ok"] is True
+
+
+@pytest.mark.parametrize("operation", ["search", "open_url"])
+def test_the_fixture_browser_refuses_the_two_network_operations(
+    fixture_backend, operation
+):
+    answer = fixture_backend.browser_run(
+        {"operation": operation, "query": "anything", "url": "https://example.com"}
+    )
+    assert answer == {"ok": False, "error_type": "capability_unavailable"}
+
+
+@pytest.mark.parametrize("tool", ["environment_resolve", "environment_activate"])
+def test_the_fixture_refuses_what_it_is_declared_to_refuse(fixture_backend, tool):
+    assert _declared(AgenticV2FixtureBackend, tool).verdict == "refuses"
+    answer = getattr(fixture_backend, tool)({"packages": ["numpy"]})
+    assert answer["ok"] is False
+    assert answer["error_type"] == "capability_unavailable"
+
+
+# ---------------------------------------------------------------------------
+# The microVM, without booting one
+# ---------------------------------------------------------------------------
+
+
+#: Tools the machine implements itself, so the fixture's run does not stand in
+#: for them. Each needs its own test, named here so that the claim is checkable
+#: rather than an exemption.
+COVERED_SEPARATELY = {
+    "exec_run": "test_the_machine_implements_exec_run_rather_than_refusing_it",
+}
+
+
+def test_the_machines_working_tools_are_the_fixtures_own_functions():
+    """It subclasses the fixture, so the calls above really did exercise these.
+
+    This is the whole reason the machine's half of the list can be checked at
+    all offline: the four inherited tools are not merely similar to the ones
+    called for real above, they are the same function objects.
+
+    ``exec_run`` is the exception and is listed as one. If another tool is ever
+    overridden, this fails -- and the fix is to write a test for the override
+    and name it in :data:`COVERED_SEPARATELY`, not to widen the exemption.
+    """
+    for entry in availability_for(AgenticV2MicroVMBackend):
+        if entry.verdict != "works":
+            continue
+        if entry.tool in COVERED_SEPARATELY:
+            covering = COVERED_SEPARATELY[entry.tool]
+            assert covering in globals(), (
+                f"{entry.tool} is exempted on the grounds that {covering} "
+                "covers it, and no such test exists in this file"
+            )
+            continue
+        assert getattr(AgenticV2MicroVMBackend, entry.tool) is getattr(
+            AgenticV2FixtureBackend, entry.tool
+        ), (
+            f"{entry.tool} is overridden on the machine, so calling the "
+            "fixture's no longer says anything about it. Write a test for the "
+            "override and add it to COVERED_SEPARATELY"
+        )
+
+
+@pytest.mark.parametrize("operation", BROWSER_OPERATIONS)
+def test_the_machine_browser_refuses_every_operation(operation):
+    assert _declared(AgenticV2MicroVMBackend, "browser_run").verdict == "refuses"
+    assert AgenticV2MicroVMBackend.browser_run(
+        None, {"operation": operation, "path": "page.html"}
+    ) == {"ok": False, "error_type": "capability_unavailable"}
+
+
+@pytest.mark.parametrize("tool", ["environment_resolve", "environment_activate"])
+def test_the_machine_refuses_the_environment_pair(tool):
+    assert _declared(AgenticV2MicroVMBackend, tool).verdict == "refuses"
+    assert getattr(AgenticV2MicroVMBackend, tool)(None, {"packages": ["numpy"]}) == {
+        "ok": False,
+        "error_type": "capability_unavailable",
+    }
+
+
+def test_the_machine_implements_exec_run_rather_than_refusing_it():
+    """Checked by asking whether the class overrides it, not by running it.
+
+    Running it boots a machine, which is exactly what this suite must not do.
+    """
+    assert _declared(AgenticV2MicroVMBackend, "exec_run").verdict == "works"
+    assert AgenticV2MicroVMBackend.exec_run is not AgenticV2FixtureBackend.exec_run
+    assert "boot" in (AgenticV2MicroVMBackend.exec_run.__doc__ or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# What the model would be shown, and what the pinned plans keep
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend_name", sorted(AVAILABILITY_BY_BACKEND))
+def test_the_paragraph_says_a_refusal_ends_the_task(backend_name):
+    """The correction that costs the most, and it is true of both backends."""
+    paragraph = tool_availability_paragraph(backend_name)
+    assert "A refused call ends your task" in paragraph
+    assert "counted against you" not in paragraph, (
+        "the sentence that told the model a refusal was survivable has come "
+        "back; the runner still ends the task on the first one"
+    )
+    for entry in availability_for(backend_name):
+        assert entry.tool in paragraph
+
+
+def test_the_two_paragraphs_disagree_about_the_two_tools_that_matter():
+    """Which is the fact that makes one hand-written paragraph impossible."""
+    on_the_fixture = tool_availability_paragraph(AgenticV2FixtureBackend)
+    on_the_machine = tool_availability_paragraph(AgenticV2MicroVMBackend)
+    assert on_the_fixture != on_the_machine
+    assert "exec_run is open in part" in on_the_fixture
+    assert "browser_run refuses" in on_the_machine
+    assert "browser_run refuses" not in on_the_fixture
+
+
+def test_the_stage_runner_derives_for_the_backend_it_actually_builds():
+    """Three places in the stage runner name a backend. They must agree.
+
+    The instructions are derived for one class, the factory constructs one, and
+    the run record writes one down. A run that told the model about the fixture
+    while building the machine would be the exact failure this module exists to
+    prevent, and it would look fine in every other check.
+
+    Read out of the source rather than by running the stage: constructing it
+    needs a staged dataset, an Azure client and an approved amount, none of
+    which belong in an offline suite.
+    """
+    source = (BATCH_RUNNER_ROOT / "scripts" / "run_agentic_v2_stage.py").read_text(
+        encoding="utf-8"
+    )
+    assert (
+        "apply_tool_availability(\n"
+        '                    str(plan.get("instructions") or ""), '
+        "AgenticV2FixtureBackend\n"
+        "                )" in source
+    ), "the instructions are no longer derived for AgenticV2FixtureBackend"
+    assert "return AgenticV2FixtureBackend(root=task_root" in source, (
+        "the factory builds something other than the backend the instructions "
+        "are derived for"
+    )
+    assert '"backend": "AgenticV2FixtureBackend"' in source, (
+        "the run record names a backend other than the one built"
+    )
+    assert "AgenticV2FixtureBackend" in AVAILABILITY_BY_BACKEND
+
+
+def test_text_without_the_placeholder_comes_back_identical():
+    untouched = "Three of them refuse in this run: exec_run, environment_resolve."
+    assert apply_tool_availability(untouched, AgenticV2FixtureBackend) is untouched
+
+
+def test_no_plan_in_the_repository_asks_for_a_derived_list_yet():
+    """So wiring the substitution in cannot alter any stage that has run.
+
+    The instruction text is a pinned condition. When a plan does opt in, it is
+    a new plan file with its own run id, and this test is what will say so --
+    it fails, and the fix is to name the new plan here rather than to delete
+    the assertion.
+    """
+    plans = sorted((BATCH_RUNNER_ROOT / "experiments").rglob("*.yaml"))
+    assert plans, "no experiment files found -- the glob is wrong, not the repo"
+
+    asking = []
+    for path in plans:
+        try:
+            loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError:
+            continue
+        if not isinstance(loaded, dict):
+            continue
+        text = str(loaded.get("instructions") or "")
+        if PLACEHOLDER in text:
+            asking.append(path.relative_to(BATCH_RUNNER_ROOT))
+        assert apply_tool_availability(text, AgenticV2FixtureBackend) == text or asking
+
+    assert asking == [], f"these plans now ask for a derived list: {asking}"


### PR DESCRIPTION
#568에서 확인한 것: **어떤 한 문단도 두 백엔드에 동시에 참일 수 없습니다.**
그러면 남는 교정은 목록을 백엔드별로 두고 프롬프트를 조립할 때 그리는
것입니다. 이 PR이 그 장치입니다.

**조건은 하나도 바꾸지 않습니다.** 안내 문구도, plan 파일도, 상한도
그대로입니다. 오늘 이 코드를 쓰는 곳은 없습니다.

## 무엇을 넣었나

### `core/agentic_v2_tool_availability.py`

백엔드별로 도구 8개 각각을 `works` / `partly` / `refuses`로 적습니다.

중요한 값은 **`partly`** 입니다. 양쪽 백엔드 모두 "일부 인자는 서빙하고
일부는 거부하는" 도구를 가지고 있고, 지금 문단이 틀리는 곳이 정확히
거기입니다.

| 도구 | 픽스처 | 마이크로VM |
|---|---|---|
| `exec_run` | `partly` — `fixture-upper SRC DST` 한 줄만 | `works` — 호출마다 기계 한 대 |
| `browser_run` | `partly` — 로컬 3개 서빙, 네트워크 2개 거부 | `refuses` — `open_local`까지 전부 |
| `environment_resolve` / `_activate` | `refuses` | `refuses` |
| 나머지 4개 | `works` | `works` |

`note`는 `works`가 아닌 항목에 **필수**입니다. 그냥 "거부함"은 지금 문단이
이미 하고 있는 말이고, 그것만으로는 모델이 행동을 바꿀 수 없습니다.

### 가장 비싼 교정은 목록이 아닙니다

그려지는 문단은 이렇게 시작합니다.

> A refused call ends your task. It is not a turn spent and recovered from:
> there is no turn after it.

지금 문구는 *"the calls are counted against you"* 라고 말합니다. 거부를
아홉 중 하나를 쓰는 일로 설명하는 문장인데, `agentic_v2_runner.py`는
`ok: true`가 아닌 **모든** 결과에서 `_EndTheRun`을 올립니다. 이 문장은
백엔드의 성질이 아니라 그 위 층의 성질이라 양쪽에 동일하게 참이고, 그래서
목록과 달리 고정 문장으로 둡니다.

## 왜 "선언 + 테스트"이고 "실행 중 조회"가 아닌가

실행 시작에 도구를 한 번씩 불러 알아내는 쪽이 원리적으로는 더 정직합니다.
실제로는 틀렸습니다. 그 호출들도 tool event라 **트레이스에 남고, 계산되고,
워크스페이스를 바꿉니다.** 선언해 두고 실제 메서드를 호출하는 테스트가
기록에 아무것도 남기지 않으면서 같은 보증을 줍니다.

## 검증 (28개 신규, 오프라인 0.7초)

- **픽스처는 진짜로 호출합니다.** `works` 4개는 실제로 서빙하고, `exec_run`은
  선언된 argv만 서빙하고 다른 argv는 거부하며, `browser_run`은 로컬 3개를
  서빙하고 네트워크 2개를 거부합니다.
- **마이크로VM의 `works` 4개는 픽스처의 같은 함수 객체입니다**(상속).
  그래서 위에서 픽스처를 부른 것이 기계 쪽도 실제로 검증한 것이 됩니다.
  재정의가 하나라도 생기면 테스트가 깨지고, 고치는 방법은 면제를 넓히는 것이
  아니라 그 재정의용 테스트를 쓰고 `COVERED_SEPARATELY`에 이름을 적는
  것입니다. — **이 규칙이 작성 중에 제 선언 하나를 실제로 잡았습니다.**
  `exec_run`을 `works`로 적어 놓고 기계 쪽은 다른 구현이라는 것을 놓쳤습니다.
- 마이크로VM의 거부 3종은 인자를 버리고 반환하므로 기계 없이 물어봅니다.
  `exec_run`은 **실행하지 않고** 재정의 여부만 확인합니다. 실행하면 기계가
  뜨고, 그것이 이 스위트가 절대 하지 말아야 할 일입니다.
- **도구 8개가 양쪽 목록에 빠짐없이** 들어 있는지 확인합니다. `browser_run`을
  *언급하지 않아서* 30문제 중 12개가 끝났으므로, 짧아도 되는 목록은 같은
  실수를 조용히 반복할 수 있습니다.
- **세 곳이 백엔드 이름을 말하는데 서로 어긋나지 않는지** 확인합니다. 픽스처
  안내를 주면서 기계를 띄우는 실행은 다른 어떤 검사도 통과합니다.

## 아무도 아직 쓰지 않습니다

`apply_tool_availability`는 플레이스홀더가 없는 문자열을 **그대로**
돌려줍니다. 저장소의 모든 plan 파일을 통과시켜 바이트가 같은지 확인하는
테스트가 있습니다.

안내 문구는 trial_30의 고정 조건입니다. 옵트인하려면 새 plan 파일(`--plan`)과
새 실행 ID가 필요하고, 그때 그 테스트가 실패하며 고치는 방법은 새 plan
이름을 적는 것입니다. `scripts/run_agentic_v2_stage.py`의 이음매 한 줄은
오늘 no-op이고, 지금 넣어두면 나중에 옵트인이 plan 파일 변경만으로 끝납니다.

## 결과

```
92 passed (신규 28 + 기존 stage runner 54 + 기존 안내문 9)
mypy 관문 명령 통과 (run_agentic_v2_stage.py + roll_up_agentic_v2_cost.py)
```

지출 없음. 모델 호출 없음. 네트워크 없음. 기계 없음.
